### PR TITLE
feat: initial implementation

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+node_modules

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,9 @@
+{
+  "extends": [
+    "plugin:bpmn-io/es6"
+  ],
+  "env": {
+    "node": true,
+    "es6": true
+  }
+}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,32 @@
+name: CI
+on: [ push, pull_request ]
+jobs:
+  Build:
+
+    strategy:
+      matrix:
+        os: [ ubuntu-latest ]
+        node-version: [ 14 ]
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Use Node.js
+      uses: actions/setup-node@v2
+      with:
+        node-version: ${{ matrix.node-version }}
+    - name: Cache Node.js modules
+      uses: actions/cache@v2
+      with:
+        # npm cache files are stored in `~/.npm` on Linux/macOS
+        path: ~/.npm
+        key: ${{ runner.OS }}-node-${{ hashFiles('**/package-lock.json') }}
+        restore-keys: |
+          ${{ runner.OS }}-node-
+          ${{ runner.OS }}-
+    - name: Install dependencies
+      run: npm ci
+    - name: Build
+      run: npm run all

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/README.md
+++ b/README.md
@@ -1,1 +1,27 @@
-# linting
+# @camunda/linting
+
+The BPMN linter used by the Camunda Desktop and Web Modeler. Batteries included. 🔋
+
+# Features
+
+* bundles [bpmnlint](https://github.com/bpmn-io/bpmnlint) and [bpmnlint-plugin-camunda-compat](https://github.com/camunda/bpmnlint-plugin-camunda-compat/)
+* configures linter based on `modeler:executionPlatform` and `modeler:executionPlatformVersion`
+* adjusts error messages to be shown in desktop and web modeler
+
+# Usage
+
+```javascript
+import { Linter } from '@camunda/linting';
+
+...
+
+// lint by passing definitions
+const reports = await Linter.lint(definitions);
+
+// or passing XML
+const reports = await Linter.lint(xml);
+```
+
+# License
+
+MIT

--- a/index.js
+++ b/index.js
@@ -1,0 +1,1 @@
+export { Linter } from './lib/Linter';

--- a/lib/Linter.js
+++ b/lib/Linter.js
@@ -1,0 +1,116 @@
+import BpmnModdle from 'bpmn-moddle/dist/index';
+
+import { Linter as BpmnLinter } from 'bpmnlint';
+
+import StaticResolver from 'bpmnlint/lib/resolver/static-resolver';
+
+import { configs } from 'bpmnlint-plugin-camunda-compat';
+
+import { isString } from 'min-dash';
+
+import modelerModdle from 'modeler-moddle/resources/modeler.json';
+import zeebeModdle from 'zeebe-bpmn-moddle/resources/zeebe.json';
+
+import { adjustErrorMessages } from './utils/error-messages';
+
+const moddle = new BpmnModdle({
+  modeler: modelerModdle,
+  zeebe: zeebeModdle
+});
+
+export class Linter {
+  static async lint(contents) {
+    let rootElement;
+
+    if (isString(contents)) {
+      ({ rootElement } = await moddle.fromXML(contents));
+    } else {
+      rootElement = contents;
+    }
+
+    const executionPlatform = rootElement.get('modeler:executionPlatform'),
+          executionPlatformVersion = rootElement.get('modeler:executionPlatformVersion');
+
+    if (!executionPlatform || !executionPlatformVersion) {
+      return [];
+    }
+
+    const configName = getConfigName(executionPlatform, executionPlatformVersion);
+
+    const config = configs[ configName ];
+
+    if (!config) {
+      return [];
+    }
+
+    const rules = await importRules(config);
+
+    const linter = new BpmnLinter({
+      config: prefixRules(config),
+      resolver: new StaticResolver(rules)
+    });
+
+    let reports = await linter.lint(rootElement);
+
+    reports = adjustErrorMessages(reports, getExecutionPlatformLabel(executionPlatform, toSemverMinor(executionPlatformVersion)));
+
+    return Object.values(reports).reduce((reports, report) => {
+      return [ ...reports, ...report ];
+    }, []);
+  }
+}
+
+function getConfigName(executionPlatform, executionPlatformVersion) {
+  return [
+    ...executionPlatform.split(' ').map(toLowerCase),
+    ...toSemverMinor(executionPlatformVersion).split('.')
+  ].join('-');
+}
+
+function prefixRules({ rules }) {
+  return {
+    rules: Object.entries(rules).reduce((rules, [ key, value ]) => {
+      return {
+        ...rules,
+        [ `bpmnlint-plugin-camunda-compat/${ key }` ]: value
+      };
+    }, {})
+  };
+}
+
+async function importRules({ rules }) {
+  let importedRules = {};
+
+  for (let key of Object.keys(rules)) {
+    const { default: importedRule } = await import(`bpmnlint-plugin-camunda-compat/rules/${ key }`);
+
+    importedRules = {
+      ...importedRules,
+      [ `rule:bpmnlint-plugin-camunda-compat/${ key }` ]: importedRule
+    };
+  }
+
+  return importedRules;
+}
+
+const executionPlatformLabels = {
+  'Camunda Cloud': {
+    '1.0': 'Camunda 8 (Zeebe 1.0)',
+    '1.1': 'Camunda 8 (Zeebe 1.1)',
+    '1.2': 'Camunda 8 (Zeebe 1.2)',
+    '1.3': 'Camunda 8 (Zeebe 1.3)',
+    '8.0': 'Camunda 8'
+  }
+};
+
+function getExecutionPlatformLabel(executionPlatform, executionPlatformVersion) {
+  return executionPlatformLabels[ executionPlatform ] && executionPlatformLabels[ executionPlatform ][ executionPlatformVersion ];
+}
+
+function toLowerCase(string) {
+  return string.toLowerCase();
+}
+
+function toSemverMinor(executionPlatformVersion) {
+  return executionPlatformVersion.split('.').slice(0, 2).join('.');
+}

--- a/lib/utils/error-messages.js
+++ b/lib/utils/error-messages.js
@@ -1,0 +1,247 @@
+import { ERROR_TYPES } from 'bpmnlint-plugin-camunda-compat/rules/utils/element';
+
+import { is } from 'bpmnlint-utils';
+
+import { isArray } from 'min-dash';
+
+import { getTypeString } from './types';
+
+export function adjustErrorMessage(report, executionPlatformLabel) {
+  const {
+    error,
+    message
+  } = report;
+
+  if (!error) {
+    return report;
+  }
+
+  const { type } = error;
+
+  if (type === ERROR_TYPES.ELEMENT_TYPE_NOT_ALLOWED) {
+    return getElementTypeNotAllowedErrorMessage(report, executionPlatformLabel);
+  }
+
+  if (type === ERROR_TYPES.EXTENSION_ELEMENT_NOT_ALLOWED) {
+    return getExtensionElementNotAllowedErrorMessage(report, executionPlatformLabel);
+  }
+
+  if (type === ERROR_TYPES.EXTENSION_ELEMENT_REQUIRED) {
+    return getExtensionElementRequiredErrorMessage(report);
+  }
+
+  if (type === ERROR_TYPES.PROPERTY_DEPENDEND_REQUIRED) {
+    return getPropertyDependendRequiredErrorMessage(report);
+  }
+
+  if (type === ERROR_TYPES.PROPERTY_REQUIRED) {
+    return getPropertyRequiredErrorMessage(report, executionPlatformLabel);
+  }
+
+  if (type === ERROR_TYPES.PROPERTY_TYPE_NOT_ALLOWED) {
+    return getPropertyTypeNotAllowedErrorMessage(report, executionPlatformLabel);
+  }
+
+  return message;
+}
+
+export function adjustErrorMessages(reports, executionPlatformLabel) {
+  Object.values(reports).forEach(reportsForRule => {
+    reportsForRule.forEach(report => {
+      report.message = adjustErrorMessage(report, executionPlatformLabel);
+    });
+  });
+
+  return reports;
+}
+
+function getIndefiniteArticle(type) {
+  if ([
+    'Error',
+    'Escalation',
+    'Event',
+    'Intermediate',
+    'Undefined'
+  ].includes(type.split(' ')[ 0 ])) {
+    return 'An';
+  }
+
+  return 'A';
+}
+
+function getElementTypeNotAllowedErrorMessage(report, executionPlatformLabel) {
+  const { error } = report;
+
+  const { node } = error;
+
+  const typeString = getTypeString(node);
+
+  return `${ getIndefiniteArticle(typeString) } <${ typeString }> is not supported by ${ executionPlatformLabel }`;
+}
+
+function getExtensionElementNotAllowedErrorMessage(report, executionPlatformLabel) {
+  const {
+    error,
+    message
+  } = report;
+
+  const {
+    node,
+    extensionElement
+  } = error;
+
+  if (is(node, 'bpmn:BusinessRuleTask') && is(extensionElement, 'zeebe:CalledDecision')) {
+    return `A <Business Rule Task> with <Implementation: DMN decision> is not supported by ${ executionPlatformLabel }`;
+  }
+
+  return message;
+}
+
+function getExtensionElementRequiredErrorMessage(report) {
+  const {
+    error,
+    message
+  } = report;
+
+  const {
+    node,
+    parentNode,
+    requiredExtensionElement
+  } = error;
+
+  const typeString = getTypeString(parentNode || node);
+
+  if (requiredExtensionElement === 'zeebe:CalledElement') {
+    return `${ getIndefiniteArticle(typeString) } <${ typeString }> must have a defined <Called element>`;
+  }
+
+  if (requiredExtensionElement === 'zeebe:LoopCharacteristics') {
+    return `${ getIndefiniteArticle(typeString) } <${ typeString }> with <Multi-instance marker> must have a defined <Input collection>`;
+  }
+
+  if (requiredExtensionElement === 'zeebe:Subscription') {
+    return `${ getIndefiniteArticle(typeString) } <${ typeString }> with <Message Reference> must have a defined <Subscription correlation key>`;
+  }
+
+  if (requiredExtensionElement === 'zeebe:TaskDefinition') {
+    return `${ getIndefiniteArticle(typeString) } <${ typeString }> must have a <Task definition type>`;
+  }
+
+  if (isArray(requiredExtensionElement) && requiredExtensionElement.includes('zeebe:CalledDecision')) {
+    return `${ getIndefiniteArticle(typeString) } <${ typeString }> must have a defined <Implementation>`;
+  }
+
+  return message;
+}
+
+function getPropertyDependendRequiredErrorMessage(report) {
+  const {
+    error,
+    message
+  } = report;
+
+  const {
+    node,
+    parentNode,
+    property,
+    dependendRequiredProperty
+  } = error;
+
+  const typeString = getTypeString(parentNode || node);
+
+  if (is(node, 'zeebe:LoopCharacteristics') && property === 'outputCollection' && dependendRequiredProperty === 'outputElement') {
+    return `${ getIndefiniteArticle(typeString) } <${ typeString }> with <Multi-instance marker> and defined <Output collection> must have a defined <Output element>`;
+  }
+
+  if (is(node, 'zeebe:LoopCharacteristics') && property === 'outputElement' && dependendRequiredProperty === 'outputCollection') {
+    return `${ getIndefiniteArticle(typeString) } <${ typeString }> with <Multi-instance marker> and defined <Output element> must have a defined <Output collection>`;
+  }
+
+  return message;
+}
+
+function getPropertyRequiredErrorMessage(report, executionPlatformLabel) {
+  const {
+    error,
+    message
+  } = report;
+
+  const {
+    node,
+    parentNode,
+    requiredProperty
+  } = error;
+
+  const typeString = getTypeString(parentNode || node);
+
+  if (parentNode && is(parentNode, 'bpmn:BusinessRuleTask') && is(node, 'zeebe:CalledDecision') && requiredProperty === 'decisionId') {
+    return 'A <Business Rule Task> with <Implementation: DMN decision> must have a defined <Called decision ID>';
+  }
+
+  if (parentNode && is(parentNode, 'bpmn:BusinessRuleTask') && is(node, 'zeebe:CalledDecision') && requiredProperty === 'resultVariable') {
+    return 'A <Business Rule Task> with <Implementation: DMN decision> must have a defined <Result variable>';
+  }
+
+  if (parentNode && is(parentNode, 'bpmn:BusinessRuleTask') && is(node, 'zeebe:TaskDefinition') && requiredProperty === 'type') {
+    return 'A <Business Rule Task> with <Implementation: Job worker> must have a defined <Task definition type>';
+  }
+
+  if (is(node, 'zeebe:CalledElement') && requiredProperty === 'processId') {
+    return `${ getIndefiniteArticle(typeString) } <${ typeString }> must have a defined <Called element>`;
+  }
+
+  if (is(node, 'bpmn:Error') && requiredProperty === 'errorCode') {
+    return `${ getIndefiniteArticle(typeString) } <${ typeString }> with <Error Reference> must have a defined <Error code>`;
+  }
+
+  if (is(node, 'bpmn:Event') && requiredProperty === 'eventDefinitions') {
+    return `${ getIndefiniteArticle(typeString) } <${ typeString }> is not supported by ${ executionPlatformLabel }`;
+  }
+
+  if (is(node, 'zeebe:LoopCharacteristics') && requiredProperty === 'inputCollection') {
+    return `${ getIndefiniteArticle(typeString) } <${ typeString }> with <Multi-instance marker> must have a defined <Input collection>`;
+  }
+
+  if (is(node, 'bpmn:Message') && requiredProperty === 'name') {
+    return `${ getIndefiniteArticle(typeString) } <${ typeString }> with <Message Reference> must have a defined <Name>`;
+  }
+
+  if (is(node, 'zeebe:Subscription') && requiredProperty === 'correlationKey') {
+    return `${ getIndefiniteArticle(typeString) } <${ typeString }> with <Message Reference> must have a defined <Subscription correlation key>`;
+  }
+
+  if (is(node, 'zeebe:TaskDefinition') && requiredProperty === 'type') {
+    return `${ getIndefiniteArticle(typeString) } <${ typeString }> with <Implementation: Job worker> must have a defined <Task definition type>`;
+  }
+
+  if (requiredProperty === 'errorRef') {
+    return `${ getIndefiniteArticle(typeString) } <${ typeString }> must have a defined <Error Reference>`;
+  }
+
+  if (requiredProperty === 'messageRef') {
+    return `${ getIndefiniteArticle(typeString) } <${ typeString }> must have a defined <Message Reference>`;
+  }
+
+  return message;
+}
+
+function getPropertyTypeNotAllowedErrorMessage(report, executionPlatformLabel) {
+  const {
+    error,
+    message
+  } = report;
+
+  const {
+    node,
+    parentNode,
+    property
+  } = error;
+
+  const typeString = getTypeString(parentNode || node);
+
+  if (is(node, 'bpmn:Event') && property === 'eventDefinitions') {
+    return `${ getIndefiniteArticle(typeString) } <${ typeString }> is not supported by ${ executionPlatformLabel }`;
+  }
+
+  return message;
+}

--- a/lib/utils/types.js
+++ b/lib/utils/types.js
@@ -1,0 +1,47 @@
+function getEventDefinition(node) {
+  const eventDefinitions = node.get('eventDefinitions');
+
+  return eventDefinitions && eventDefinitions[ 0 ];
+}
+
+function getEventDefinitionPrefix(eventDefinition) {
+  const localType = getLocalType(eventDefinition);
+
+  return localType.replace('EventDefinition', '');
+}
+
+function getLocalType(node) {
+  const { $descriptor } = node;
+
+  const { localName } = $descriptor.ns;
+
+  return localName;
+}
+
+function formatTypeString(string) {
+  return string.replace(/([a-z])([A-Z])/g, '$1 $2').trim();
+}
+
+export function getTypeString(node) {
+  let type = getLocalType(node);
+
+  const eventDefinition = getEventDefinition(node);
+
+  if (eventDefinition) {
+    type = `${ getEventDefinitionPrefix(eventDefinition) }${ type }`;
+  } else if ([
+    'BoundaryEvent',
+    'EndEvent',
+    'IntermediateCatchEvent',
+    'IntermediateThrowEvent',
+    'StartEvent'
+  ].includes(type)) {
+    type = `Undefined ${ type }`;
+  }
+
+  if (type === 'Task') {
+    type = 'Undefined Task';
+  }
+
+  return formatTypeString(type);
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,2108 @@
+{
+  "name": "@camunda/linting",
+  "version": "0.1.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@babel/code-frame": {
+      "version": "7.0.0-beta.44",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.44.tgz",
+      "integrity": "sha512-cuAuTTIQ9RqcFRJ/Y8PvTh+paepNcaGxwQwjIDRWPXmzzyAeCO4KqS9ikMvq0MCbRk6GlYKwfzStrcP3/jSL8g==",
+      "dev": true,
+      "requires": {
+        "@babel/highlight": "7.0.0-beta.44"
+      }
+    },
+    "@babel/generator": {
+      "version": "7.0.0-beta.44",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.44.tgz",
+      "integrity": "sha512-5xVb7hlhjGcdkKpMXgicAVgx8syK5VJz193k0i/0sLP6DzE6lRrU1K3B/rFefgdo9LPGMAOOOAWW4jycj07ShQ==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "7.0.0-beta.44",
+        "jsesc": "^2.5.1",
+        "lodash": "^4.2.0",
+        "source-map": "^0.5.0",
+        "trim-right": "^1.0.1"
+      }
+    },
+    "@babel/helper-function-name": {
+      "version": "7.0.0-beta.44",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.44.tgz",
+      "integrity": "sha512-MHRG2qZMKMFaBavX0LWpfZ2e+hLloT++N7rfM3DYOMUOGCD8cVjqZpwiL8a0bOX3IYcQev1ruciT0gdFFRTxzg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-get-function-arity": "7.0.0-beta.44",
+        "@babel/template": "7.0.0-beta.44",
+        "@babel/types": "7.0.0-beta.44"
+      }
+    },
+    "@babel/helper-get-function-arity": {
+      "version": "7.0.0-beta.44",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.44.tgz",
+      "integrity": "sha512-w0YjWVwrM2HwP6/H3sEgrSQdkCaxppqFeJtAnB23pRiJB5E/O9Yp7JAAeWBl+gGEgmBFinnTyOv2RN7rcSmMiw==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "7.0.0-beta.44"
+      }
+    },
+    "@babel/helper-split-export-declaration": {
+      "version": "7.0.0-beta.44",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.44.tgz",
+      "integrity": "sha512-aQ7QowtkgKKzPGf0j6u77kBMdUFVBKNHw2p/3HX/POt5/oz8ec5cs0GwlgM8Hz7ui5EwJnzyfRmkNF1Nx1N7aA==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "7.0.0-beta.44"
+      }
+    },
+    "@babel/highlight": {
+      "version": "7.0.0-beta.44",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.44.tgz",
+      "integrity": "sha512-Il19yJvy7vMFm8AVAh6OZzaFoAd0hbkeMZiX3P5HGD+z7dyI7RzndHB0dg6Urh/VAFfHtpOIzDUSxmY6coyZWQ==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.0.0",
+        "esutils": "^2.0.2",
+        "js-tokens": "^3.0.0"
+      }
+    },
+    "@babel/template": {
+      "version": "7.0.0-beta.44",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.44.tgz",
+      "integrity": "sha512-w750Sloq0UNifLx1rUqwfbnC6uSUk0mfwwgGRfdLiaUzfAOiH0tHJE6ILQIUi3KYkjiCDTskoIsnfqZvWLBDng==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "7.0.0-beta.44",
+        "@babel/types": "7.0.0-beta.44",
+        "babylon": "7.0.0-beta.44",
+        "lodash": "^4.2.0"
+      }
+    },
+    "@babel/traverse": {
+      "version": "7.0.0-beta.44",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.44.tgz",
+      "integrity": "sha512-UHuDz8ukQkJCDASKHf+oDt3FVUzFd+QYfuBIsiNu/4+/ix6pP/C+uQZJ6K1oEfbCMv/IKWbgDEh7fcsnIE5AtA==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "7.0.0-beta.44",
+        "@babel/generator": "7.0.0-beta.44",
+        "@babel/helper-function-name": "7.0.0-beta.44",
+        "@babel/helper-split-export-declaration": "7.0.0-beta.44",
+        "@babel/types": "7.0.0-beta.44",
+        "babylon": "7.0.0-beta.44",
+        "debug": "^3.1.0",
+        "globals": "^11.1.0",
+        "invariant": "^2.2.0",
+        "lodash": "^4.2.0"
+      }
+    },
+    "@babel/types": {
+      "version": "7.0.0-beta.44",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.44.tgz",
+      "integrity": "sha512-5eTV4WRmqbaFM3v9gHAIljEQJU4Ssc6fxL61JN+Oe2ga/BwyjzjamwkCVVAQjHGuAX8i0BWo42dshL8eO5KfLQ==",
+      "dev": true,
+      "requires": {
+        "esutils": "^2.0.2",
+        "lodash": "^4.2.0",
+        "to-fast-properties": "^2.0.0"
+      }
+    },
+    "@philippfromme/moddle-helpers": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@philippfromme/moddle-helpers/-/moddle-helpers-0.1.0.tgz",
+      "integrity": "sha512-eKnrt2mCtcYFhweNr20mOWSG0431BPPFnhYJEQd+D2/5ssWPaHVEEgD3YnUOmbg1gdRQdVe2rrxcdEvvPugB/A=="
+    },
+    "acorn": {
+      "version": "5.7.4",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.4.tgz",
+      "integrity": "sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg==",
+      "dev": true
+    },
+    "acorn-jsx": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
+      "integrity": "sha512-AU7pnZkguthwBjKgCg6998ByQNIMjbuDQZ8bb78QAFZwPfmKia8AIzgY/gWgqCjnht8JLdXmB4YxA0KaV60ncQ==",
+      "dev": true,
+      "requires": {
+        "acorn": "^3.0.4"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+          "integrity": "sha512-OLUyIIZ7mF5oaAUT1w0TFqQS81q3saT46x8t7ukpPjMNk+nbs4ZHhs7ToV8EWnLYLepjETXd4XaCE4uxkMeqUw==",
+          "dev": true
+        }
+      }
+    },
+    "ajv": {
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+      "integrity": "sha512-Ajr4IcMXq/2QmMkEmSvxqfLN5zGmJ92gHXAeOXq1OekoH2rfDNsgdDoL2f7QaRCy7G/E6TpxBVdRuNraMztGHw==",
+      "dev": true,
+      "requires": {
+        "co": "^4.6.0",
+        "fast-deep-equal": "^1.0.0",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.3.0"
+      }
+    },
+    "ajv-keywords": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
+      "integrity": "sha512-ZFztHzVRdGLAzJmpUT9LNFLe1YiVOEylcaNpEutM26PVTCtOD919IMfD01CgbRouB42Dd9atjx1HseC15DgOZA==",
+      "dev": true
+    },
+    "ansi-colors": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
+      "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA=="
+    },
+    "ansi-escapes": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+      "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
+      "dev": true
+    },
+    "ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
+      "dev": true
+    },
+    "ansi-styles": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "integrity": "sha512-kmCevFghRiWM7HB5zTPULl4r9bVFSWjz62MhqizDGUrq2NWuNMQyuv4tHHoKJHs69M/MF64lEcHdYIocrdWQYA==",
+      "dev": true
+    },
+    "argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "requires": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "array-includes": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.5.tgz",
+      "integrity": "sha512-iSDYZMMyTPkiFasVqfuAQnWAYcvO/SeBSCGKePoEthjp4LEMTe4uLc7b025o4jAZpHhihh8xPo99TNWUWWkGDQ==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.19.5",
+        "get-intrinsic": "^1.1.1",
+        "is-string": "^1.0.7"
+      }
+    },
+    "array.prototype.flatmap": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.0.tgz",
+      "integrity": "sha512-PZC9/8TKAIxcWKdyeb77EzULHPrIX/tIZebLJUQOMR1OwYosT8yggdfWScfTBCDj5utONvOuPQQumYsU2ULbkg==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.19.2",
+        "es-shim-unscopables": "^1.0.0"
+      }
+    },
+    "assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true
+    },
+    "babel-code-frame": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+      "integrity": "sha512-XqYMR2dfdGMW+hd0IUZ2PwK+fGeFkOxZJ0wY+JaQAHzt1Zx8LcvpiZD2NiGkEG8qx0CfkAOr5xt76d1e8vG90g==",
+      "dev": true,
+      "requires": {
+        "chalk": "^1.1.3",
+        "esutils": "^2.0.2",
+        "js-tokens": "^3.0.2"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
+        }
+      }
+    },
+    "babel-eslint": {
+      "version": "8.2.6",
+      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-8.2.6.tgz",
+      "integrity": "sha512-aCdHjhzcILdP8c9lej7hvXKvQieyRt20SF102SIGyY4cUIiw6UaAtK4j2o3dXX74jEmy0TJ0CEhv4fTIM3SzcA==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "7.0.0-beta.44",
+        "@babel/traverse": "7.0.0-beta.44",
+        "@babel/types": "7.0.0-beta.44",
+        "babylon": "7.0.0-beta.44",
+        "eslint-scope": "3.7.1",
+        "eslint-visitor-keys": "^1.0.0"
+      },
+      "dependencies": {
+        "eslint-scope": {
+          "version": "3.7.1",
+          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.1.tgz",
+          "integrity": "sha512-ivpbtpUgg9SJS4TLjK7KdcDhqc/E3CGItsvQbBNLkNGUeMhd5qnJcryba/brESS+dg3vrLqPuc/UcS7jRJdN5A==",
+          "dev": true,
+          "requires": {
+            "esrecurse": "^4.1.0",
+            "estraverse": "^4.1.1"
+          }
+        }
+      }
+    },
+    "babylon": {
+      "version": "7.0.0-beta.44",
+      "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.44.tgz",
+      "integrity": "sha512-5Hlm13BJVAioCHpImtFqNOF2H3ieTOHd0fmFGMxOJ9jgeFqeAwsv3u5P5cR7CSeFrkgHsT19DgFJkHV0/Mcd8g==",
+      "dev": true
+    },
+    "balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
+    },
+    "bpmn-moddle": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/bpmn-moddle/-/bpmn-moddle-7.1.2.tgz",
+      "integrity": "sha512-Sax4LokRCTqlg26njjULN3ZGtCmwH5gZVUZTRF0jwJk+YpMQhSfSoUECxjNv8OROoLxu8Z+MjdOHIxgvJf7KwA==",
+      "requires": {
+        "min-dash": "^3.5.2",
+        "moddle": "^5.0.2",
+        "moddle-xml": "^9.0.5"
+      }
+    },
+    "bpmnlint": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/bpmnlint/-/bpmnlint-7.8.0.tgz",
+      "integrity": "sha512-hzmDB/yMzv90bRYkey6lvJ5fyqSCBPdIMRLBzWSvqpH/XvSasaRo3Gibp1oX3dJg1JyHeZw4EnJZdhP55CzGWQ==",
+      "requires": {
+        "@philippfromme/moddle-helpers": "^0.1.0",
+        "ansi-colors": "^4.1.1",
+        "bpmn-moddle": "^7.1.2",
+        "bpmnlint-utils": "^1.0.2",
+        "cli-table": "^0.3.9",
+        "color-support": "^1.1.3",
+        "min-dash": "^3.8.0",
+        "mri": "^1.2.0",
+        "pluralize": "^7.0.0",
+        "tiny-glob": "^0.2.9"
+      }
+    },
+    "bpmnlint-plugin-camunda-compat": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/bpmnlint-plugin-camunda-compat/-/bpmnlint-plugin-camunda-compat-0.7.0.tgz",
+      "integrity": "sha512-EwCWF066+/yWkai/gO4Ho2JSlE0uZK6ICepcQn/Xf/kVVp9fuLsSA/r+bh7ykRF+lPPLDbTkuSoXt5EHc77pMQ==",
+      "requires": {
+        "@philippfromme/moddle-helpers": "^0.1.0",
+        "bpmnlint-utils": "^1.0.2",
+        "min-dash": "^3.8.0"
+      }
+    },
+    "bpmnlint-utils": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bpmnlint-utils/-/bpmnlint-utils-1.0.2.tgz",
+      "integrity": "sha512-+ti0VICOpgYpQgzpF0mwXqDX4NhrQCc2YKy28VjPu7v9sXpdpWEylP+iBw6WlheJFRcXoZh2q/QRLb5DMB3naQ=="
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "browser-stdout": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
+      "integrity": "sha512-7Rfk377tpSM9TWBEeHs0FlDZGoAIei2V/4MdZJoFMBFAK6BqLpxAIUepGRHGdPFgGsLb02PXovC4qddyHvQqTg==",
+      "dev": true
+    },
+    "buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true
+    },
+    "call-bind": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.0.2"
+      }
+    },
+    "caller-path": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
+      "integrity": "sha512-UJiE1otjXPF5/x+T3zTnSFiTOEmJoGTD9HmBoxnCUwho61a2eSNn/VwtwuIBDAo2SEOv1AJ7ARI5gCmohFLu/g==",
+      "dev": true,
+      "requires": {
+        "callsites": "^0.2.0"
+      }
+    },
+    "callsites": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
+      "integrity": "sha512-Zv4Dns9IbXXmPkgRRUjAaJQgfN4xX5p6+RQFhWUqscdvvK2xK/ZL8b3IXIJsj+4sD+f24NwnWy2BY8AJ82JB0A==",
+      "dev": true
+    },
+    "chai": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.6.tgz",
+      "integrity": "sha512-bbcp3YfHCUzMOvKqsztczerVgBKSsEijCySNlHHbX3VG1nskvqjz5Rfso1gGwD6w6oOV3eI60pKuMOV5MV7p3Q==",
+      "dev": true,
+      "requires": {
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.2",
+        "deep-eql": "^3.0.1",
+        "get-func-name": "^2.0.0",
+        "loupe": "^2.3.1",
+        "pathval": "^1.1.1",
+        "type-detect": "^4.0.5"
+      }
+    },
+    "chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "chardet": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
+      "integrity": "sha512-j/Toj7f1z98Hh2cYo2BVr85EpIRWqUi7rtRSGxh/cqUjqrnJe9l9UE7IUGd2vQ2p+kSHLkSzObQPZPLUC6TQwg==",
+      "dev": true
+    },
+    "check-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
+      "dev": true
+    },
+    "circular-json": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
+      "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
+      "dev": true
+    },
+    "cli-cursor": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+      "integrity": "sha512-8lgKz8LmCRYZZQDpRyT2m5rKJ08TnU4tR9FFFW2rxpxR1FzWi4PQ/NfyODchAatHaUgnSPVcx/R5w6NuTBzFiw==",
+      "dev": true,
+      "requires": {
+        "restore-cursor": "^2.0.0"
+      }
+    },
+    "cli-table": {
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.11.tgz",
+      "integrity": "sha512-IqLQi4lO0nIB4tcdTpN4LCB9FI3uqrJZK7RC515EnhZ6qBaglkIgICb1wjeAqpdoOabm1+SuQtkXIPdYC93jhQ==",
+      "requires": {
+        "colors": "1.0.3"
+      }
+    },
+    "cli-width": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.1.tgz",
+      "integrity": "sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw==",
+      "dev": true
+    },
+    "co": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==",
+      "dev": true
+    },
+    "color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+      "dev": true
+    },
+    "color-support": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
+      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg=="
+    },
+    "colors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+      "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs="
+    },
+    "commander": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+      "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+      "dev": true
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "concat-stream": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "dev": true,
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
+      }
+    },
+    "core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "dev": true
+    },
+    "cross-spawn": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+      "integrity": "sha512-pTgQJ5KC0d2hcY8eyL1IzlBPYjTkyH72XRZPnLyKus2mBfNjQs3klqbJU2VILqZryAZUt9JOb3h/mWMy23/f5A==",
+      "dev": true,
+      "requires": {
+        "lru-cache": "^4.0.1",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
+      }
+    },
+    "debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "requires": {
+        "ms": "^2.1.1"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+          "dev": true
+        }
+      }
+    },
+    "deep-eql": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
+      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+      "dev": true,
+      "requires": {
+        "type-detect": "^4.0.0"
+      }
+    },
+    "deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true
+    },
+    "define-properties": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
+      "integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
+      "dev": true,
+      "requires": {
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
+      }
+    },
+    "diff": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
+      "integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww==",
+      "dev": true
+    },
+    "doctrine": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+      "dev": true,
+      "requires": {
+        "esutils": "^2.0.2"
+      }
+    },
+    "es-abstract": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.1.tgz",
+      "integrity": "sha512-WEm2oBhfoI2sImeM4OF2zE2V3BYdSF+KnSi9Sidz51fQHd7+JuF8Xgcj9/0o+OWeIeIS/MiuNnlruQrJf16GQA==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "es-to-primitive": "^1.2.1",
+        "function-bind": "^1.1.1",
+        "function.prototype.name": "^1.1.5",
+        "get-intrinsic": "^1.1.1",
+        "get-symbol-description": "^1.0.0",
+        "has": "^1.0.3",
+        "has-property-descriptors": "^1.0.0",
+        "has-symbols": "^1.0.3",
+        "internal-slot": "^1.0.3",
+        "is-callable": "^1.2.4",
+        "is-negative-zero": "^2.0.2",
+        "is-regex": "^1.1.4",
+        "is-shared-array-buffer": "^1.0.2",
+        "is-string": "^1.0.7",
+        "is-weakref": "^1.0.2",
+        "object-inspect": "^1.12.0",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.2",
+        "regexp.prototype.flags": "^1.4.3",
+        "string.prototype.trimend": "^1.0.5",
+        "string.prototype.trimstart": "^1.0.5",
+        "unbox-primitive": "^1.0.2"
+      }
+    },
+    "es-shim-unscopables": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.0.0.tgz",
+      "integrity": "sha512-Jm6GPcCdC30eMLbZ2x8z2WuRwAws3zTBBKuusffYVUrNj/GVSUAZ+xKMaUpfNDR5IbyNA5LJbaecoUVbmUcB1w==",
+      "dev": true,
+      "requires": {
+        "has": "^1.0.3"
+      }
+    },
+    "es-to-primitive": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+      "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+      "dev": true,
+      "requires": {
+        "is-callable": "^1.1.4",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.2"
+      }
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true
+    },
+    "eslint": {
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.19.1.tgz",
+      "integrity": "sha512-bT3/1x1EbZB7phzYu7vCr1v3ONuzDtX8WjuM9c0iYxe+cq+pwcKEoQjl7zd3RpC6YOLgnSy3cTN58M2jcoPDIQ==",
+      "dev": true,
+      "requires": {
+        "ajv": "^5.3.0",
+        "babel-code-frame": "^6.22.0",
+        "chalk": "^2.1.0",
+        "concat-stream": "^1.6.0",
+        "cross-spawn": "^5.1.0",
+        "debug": "^3.1.0",
+        "doctrine": "^2.1.0",
+        "eslint-scope": "^3.7.1",
+        "eslint-visitor-keys": "^1.0.0",
+        "espree": "^3.5.4",
+        "esquery": "^1.0.0",
+        "esutils": "^2.0.2",
+        "file-entry-cache": "^2.0.0",
+        "functional-red-black-tree": "^1.0.1",
+        "glob": "^7.1.2",
+        "globals": "^11.0.1",
+        "ignore": "^3.3.3",
+        "imurmurhash": "^0.1.4",
+        "inquirer": "^3.0.6",
+        "is-resolvable": "^1.0.0",
+        "js-yaml": "^3.9.1",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.3.0",
+        "lodash": "^4.17.4",
+        "minimatch": "^3.0.2",
+        "mkdirp": "^0.5.1",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.8.2",
+        "path-is-inside": "^1.0.2",
+        "pluralize": "^7.0.0",
+        "progress": "^2.0.0",
+        "regexpp": "^1.0.1",
+        "require-uncached": "^1.0.3",
+        "semver": "^5.3.0",
+        "strip-ansi": "^4.0.0",
+        "strip-json-comments": "~2.0.1",
+        "table": "4.0.2",
+        "text-table": "~0.2.0"
+      },
+      "dependencies": {
+        "eslint-scope": {
+          "version": "3.7.3",
+          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.3.tgz",
+          "integrity": "sha512-W+B0SvF4gamyCTmUc+uITPY0989iXVfKvhwtmJocTaYoc/3khEHmEmvfY/Gn9HA9VV75jrQECsHizkNw1b68FA==",
+          "dev": true,
+          "requires": {
+            "esrecurse": "^4.1.0",
+            "estraverse": "^4.1.1"
+          }
+        }
+      }
+    },
+    "eslint-plugin-bpmn-io": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-bpmn-io/-/eslint-plugin-bpmn-io-0.4.1.tgz",
+      "integrity": "sha512-2Lh0CR8eRcCwlHubelnLmtA2VCm8fZVVvhuPomapZqnLVdXvMrxKq+LEq8hLviPy68/RiRCr1H6T6nOJR03dgA==",
+      "dev": true,
+      "requires": {
+        "babel-eslint": "^8.2.1",
+        "eslint-plugin-mocha": "^4.11.0",
+        "eslint-plugin-react": "^7.6.1"
+      }
+    },
+    "eslint-plugin-mocha": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-mocha/-/eslint-plugin-mocha-4.12.1.tgz",
+      "integrity": "sha512-hxWtYHvLA0p/PKymRfDYh9Mxt5dYkg2Goy1vZDarTEEYfELP9ksga7kKG1NUKSQy27C8Qjc7YrSWTLUhOEOksA==",
+      "dev": true,
+      "requires": {
+        "ramda": "^0.25.0"
+      }
+    },
+    "eslint-plugin-react": {
+      "version": "7.30.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.30.0.tgz",
+      "integrity": "sha512-RgwH7hjW48BleKsYyHK5vUAvxtE9SMPDKmcPRQgtRCYaZA0XQPt5FSkrU3nhz5ifzMZcA8opwmRJ2cmOO8tr5A==",
+      "dev": true,
+      "requires": {
+        "array-includes": "^3.1.5",
+        "array.prototype.flatmap": "^1.3.0",
+        "doctrine": "^2.1.0",
+        "estraverse": "^5.3.0",
+        "jsx-ast-utils": "^2.4.1 || ^3.0.0",
+        "minimatch": "^3.1.2",
+        "object.entries": "^1.1.5",
+        "object.fromentries": "^2.0.5",
+        "object.hasown": "^1.1.1",
+        "object.values": "^1.1.5",
+        "prop-types": "^15.8.1",
+        "resolve": "^2.0.0-next.3",
+        "semver": "^6.3.0",
+        "string.prototype.matchall": "^4.0.7"
+      },
+      "dependencies": {
+        "estraverse": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+          "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+          "dev": true
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
+      }
+    },
+    "eslint-visitor-keys": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+      "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+      "dev": true
+    },
+    "esm": {
+      "version": "3.2.25",
+      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
+      "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==",
+      "dev": true
+    },
+    "espree": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
+      "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
+      "dev": true,
+      "requires": {
+        "acorn": "^5.5.0",
+        "acorn-jsx": "^3.0.0"
+      }
+    },
+    "esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true
+    },
+    "esquery": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
+      "integrity": "sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==",
+      "dev": true,
+      "requires": {
+        "estraverse": "^5.1.0"
+      },
+      "dependencies": {
+        "estraverse": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+          "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+          "dev": true
+        }
+      }
+    },
+    "esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "requires": {
+        "estraverse": "^5.2.0"
+      },
+      "dependencies": {
+        "estraverse": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+          "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+          "dev": true
+        }
+      }
+    },
+    "estraverse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+      "dev": true
+    },
+    "esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true
+    },
+    "external-editor": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
+      "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
+      "dev": true,
+      "requires": {
+        "chardet": "^0.4.0",
+        "iconv-lite": "^0.4.17",
+        "tmp": "^0.0.33"
+      }
+    },
+    "fast-deep-equal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+      "integrity": "sha512-fueX787WZKCV0Is4/T2cyAdM4+x1S3MXXOAhavE1ys/W42SHAPacLTQhucja22QBYrfGw50M2sRiXPtTGv9Ymw==",
+      "dev": true
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true
+    },
+    "fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true
+    },
+    "figures": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+      "integrity": "sha512-Oa2M9atig69ZkfwiApY8F2Yy+tzMbazyvqv21R0NsSC8floSOC09BbT1ITWAdoMGQvJ/aZnR1KMwdx9tvHnTNA==",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "^1.0.5"
+      }
+    },
+    "file-entry-cache": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
+      "integrity": "sha512-uXP/zGzxxFvFfcZGgBIwotm+Tdc55ddPAzF7iHshP4YGaXMww7rSF9peD9D1sui5ebONg5UobsZv+FfgEpGv/w==",
+      "dev": true,
+      "requires": {
+        "flat-cache": "^1.2.1",
+        "object-assign": "^4.0.1"
+      }
+    },
+    "flat-cache": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.4.tgz",
+      "integrity": "sha512-VwyB3Lkgacfik2vhqR4uv2rvebqmDvFu4jlN/C1RzWoJEo8I7z4Q404oiqYCkq41mni8EzQnm95emU9seckwtg==",
+      "dev": true,
+      "requires": {
+        "circular-json": "^0.3.1",
+        "graceful-fs": "^4.1.2",
+        "rimraf": "~2.6.2",
+        "write": "^0.2.1"
+      }
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
+    },
+    "function.prototype.name": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.5.tgz",
+      "integrity": "sha512-uN7m/BzVKQnCUF/iW8jYea67v++2u7m5UgENbHRtdDVclOUP+FMPlCNdmk0h/ysGyo2tavMJEDqJAkJdRa1vMA==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.19.0",
+        "functions-have-names": "^1.2.2"
+      }
+    },
+    "functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
+      "dev": true
+    },
+    "functions-have-names": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+      "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
+      "dev": true
+    },
+    "get-func-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
+      "dev": true
+    },
+    "get-intrinsic": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+      "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.1"
+      }
+    },
+    "get-symbol-description": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.0.tgz",
+      "integrity": "sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.1"
+      }
+    },
+    "glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "globals": {
+      "version": "11.12.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+      "dev": true
+    },
+    "globalyzer": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/globalyzer/-/globalyzer-0.1.0.tgz",
+      "integrity": "sha512-40oNTM9UfG6aBmuKxk/giHn5nQ8RVz/SS4Ir6zgzOv9/qC3kKZ9v4etGTcJbEl/NyVQH7FGU7d+X1egr57Md2Q=="
+    },
+    "globrex": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
+      "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg=="
+    },
+    "graceful-fs": {
+      "version": "4.2.10",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
+      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
+      "dev": true
+    },
+    "growl": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
+      "integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q==",
+      "dev": true
+    },
+    "has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1"
+      }
+    },
+    "has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha512-C8vBJ8DwUCx19vhm7urhTuUsr4/IyP6l4VzNQDv+ryHQObW3TTTp9yB68WpYgRe2bbaGuZ/se74IqFeVnMnLZg==",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^2.0.0"
+      }
+    },
+    "has-bigints": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
+      "integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
+      "dev": true
+    },
+    "has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "dev": true
+    },
+    "has-property-descriptors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
+      "integrity": "sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==",
+      "dev": true,
+      "requires": {
+        "get-intrinsic": "^1.1.1"
+      }
+    },
+    "has-symbols": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+      "dev": true
+    },
+    "has-tostringtag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
+      "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
+      "dev": true,
+      "requires": {
+        "has-symbols": "^1.0.2"
+      }
+    },
+    "he": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+      "integrity": "sha512-z/GDPjlRMNOa2XJiB4em8wJpuuBfrFOlYKTZxtpkdr1uPdibHI8rYA3MY0KDObpVyaes0e/aunid/t88ZI2EKA==",
+      "dev": true
+    },
+    "iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dev": true,
+      "requires": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      }
+    },
+    "ignore": {
+      "version": "3.3.10",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
+      "integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==",
+      "dev": true
+    },
+    "imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
+    },
+    "inquirer": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
+      "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "^3.0.0",
+        "chalk": "^2.0.0",
+        "cli-cursor": "^2.1.0",
+        "cli-width": "^2.0.0",
+        "external-editor": "^2.0.4",
+        "figures": "^2.0.0",
+        "lodash": "^4.3.0",
+        "mute-stream": "0.0.7",
+        "run-async": "^2.2.0",
+        "rx-lite": "^4.0.8",
+        "rx-lite-aggregates": "^4.0.8",
+        "string-width": "^2.1.0",
+        "strip-ansi": "^4.0.0",
+        "through": "^2.3.6"
+      }
+    },
+    "internal-slot": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.3.tgz",
+      "integrity": "sha512-O0DB1JC/sPyZl7cIo78n5dR7eUSwwpYPiXRhTzNxZVAMUuB8vlnRFyLxdrVToks6XPLVnFfbzaVd5WLjhgg+vA==",
+      "dev": true,
+      "requires": {
+        "get-intrinsic": "^1.1.0",
+        "has": "^1.0.3",
+        "side-channel": "^1.0.4"
+      }
+    },
+    "invariant": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "dev": true,
+      "requires": {
+        "loose-envify": "^1.0.0"
+      }
+    },
+    "is-bigint": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
+      "integrity": "sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==",
+      "dev": true,
+      "requires": {
+        "has-bigints": "^1.0.1"
+      }
+    },
+    "is-boolean-object": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
+      "integrity": "sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "has-tostringtag": "^1.0.0"
+      }
+    },
+    "is-callable": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.4.tgz",
+      "integrity": "sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w==",
+      "dev": true
+    },
+    "is-core-module": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.9.0.tgz",
+      "integrity": "sha512-+5FPy5PnwmO3lvfMb0AsoPaBG+5KHUI0wYFXOtYPnVVVspTFUuMZNfNaNVRt3FZadstu2c8x23vykRW/NBoU6A==",
+      "dev": true,
+      "requires": {
+        "has": "^1.0.3"
+      }
+    },
+    "is-date-object": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.5.tgz",
+      "integrity": "sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==",
+      "dev": true,
+      "requires": {
+        "has-tostringtag": "^1.0.0"
+      }
+    },
+    "is-fullwidth-code-point": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w==",
+      "dev": true
+    },
+    "is-negative-zero": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.2.tgz",
+      "integrity": "sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA==",
+      "dev": true
+    },
+    "is-number-object": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.7.tgz",
+      "integrity": "sha512-k1U0IRzLMo7ZlYIfzRu23Oh6MiIFasgpb9X76eqfFZAqwH44UI4KTBvBYIZ1dSL9ZzChTB9ShHfLkR4pdW5krQ==",
+      "dev": true,
+      "requires": {
+        "has-tostringtag": "^1.0.0"
+      }
+    },
+    "is-regex": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
+      "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "has-tostringtag": "^1.0.0"
+      }
+    },
+    "is-resolvable": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
+      "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
+      "dev": true
+    },
+    "is-shared-array-buffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.2.tgz",
+      "integrity": "sha512-sqN2UDu1/0y6uvXyStCOzyhAjCSlHceFoMKJW8W9EU9cvic/QdsZ0kEU93HEy3IUEFZIiH/3w+AH/UQbPHNdhA==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2"
+      }
+    },
+    "is-string": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
+      "integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
+      "dev": true,
+      "requires": {
+        "has-tostringtag": "^1.0.0"
+      }
+    },
+    "is-symbol": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
+      "integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
+      "dev": true,
+      "requires": {
+        "has-symbols": "^1.0.2"
+      }
+    },
+    "is-weakref": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
+      "integrity": "sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2"
+      }
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "dev": true
+    },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true
+    },
+    "js-tokens": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+      "integrity": "sha512-RjTcuD4xjtthQkaWH7dFlH85L+QaVtSoOyGdZ3g6HFhS9dFNDfLyqgm2NFe2X6cQpeFmt0452FJjFG5UameExg==",
+      "dev": true
+    },
+    "js-yaml": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "dev": true,
+      "requires": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      }
+    },
+    "jsesc": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+      "dev": true
+    },
+    "json-schema-traverse": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+      "integrity": "sha512-4JD/Ivzg7PoW8NzdrBSr3UFwC9mHgvI7Z6z3QGBsSHgKaRTUDmyZAAKJo2UbG1kUVfS9WS8bi36N49U1xw43DA==",
+      "dev": true
+    },
+    "json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true
+    },
+    "jsx-ast-utils": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.0.tgz",
+      "integrity": "sha512-XzO9luP6L0xkxwhIJMTJQpZo/eeN60K08jHdexfD569AGxeNug6UketeHXEhROoM8aR7EcUoOQmIhcJQjcuq8Q==",
+      "dev": true,
+      "requires": {
+        "array-includes": "^3.1.4",
+        "object.assign": "^4.1.2"
+      }
+    },
+    "levn": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+      "integrity": "sha512-0OO4y2iOHix2W6ujICbKIaEQXvFQHue65vUG3pb5EUomzPI90z9hsA1VsO/dbIIpC53J8gxM9Q4Oho0jrCM/yA==",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
+      }
+    },
+    "lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
+    },
+    "loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
+      "requires": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      }
+    },
+    "loupe": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.4.tgz",
+      "integrity": "sha512-OvKfgCC2Ndby6aSTREl5aCCPTNIzlDfQZvZxNUrBrihDhL3xcrYegTblhmEiCrg2kKQz4XsFIaemE5BF4ybSaQ==",
+      "dev": true,
+      "requires": {
+        "get-func-name": "^2.0.0"
+      }
+    },
+    "lru-cache": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+      "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+      "dev": true,
+      "requires": {
+        "pseudomap": "^1.0.2",
+        "yallist": "^2.1.2"
+      }
+    },
+    "mimic-fn": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+      "dev": true
+    },
+    "min-dash": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/min-dash/-/min-dash-3.8.1.tgz",
+      "integrity": "sha512-evumdlmIlg9mbRVPbC4F5FuRhNmcMS5pvuBUbqb1G9v09Ro0ImPEgz5n3khir83lFok1inKqVDjnKEg3GpDxQg=="
+    },
+    "minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "minimist": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha512-miQKw5Hv4NS1Psg2517mV4e4dYNaO3++hjAvLOAzKqZ61rH8NS1SK+vbfBWZ5PY/Me/bEWhUwqMghEW5Fb9T7Q==",
+      "dev": true
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha512-SknJC52obPfGQPnjIkXbmA6+5H15E+fR+E4iR2oQ3zzCLbd7/ONua69R/Gw7AgkTLsRG+r5fzksYwWe1AgTyWA==",
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8"
+      }
+    },
+    "mocha": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-4.1.0.tgz",
+      "integrity": "sha512-0RVnjg1HJsXY2YFDoTNzcc1NKhYuXKRrBAG2gDygmJJA136Cs2QlRliZG1mA0ap7cuaT30mw16luAeln+4RiNA==",
+      "dev": true,
+      "requires": {
+        "browser-stdout": "1.3.0",
+        "commander": "2.11.0",
+        "debug": "3.1.0",
+        "diff": "3.3.1",
+        "escape-string-regexp": "1.0.5",
+        "glob": "7.1.2",
+        "growl": "1.10.3",
+        "he": "1.1.1",
+        "mkdirp": "0.5.1",
+        "supports-color": "4.4.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+          "dev": true
+        },
+        "glob": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        }
+      }
+    },
+    "moddle": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/moddle/-/moddle-5.0.3.tgz",
+      "integrity": "sha512-EjnQkSaZClHMsM3H/guBy9h7AmHUICH0Pf8H1VnnYGUXy2hkZQU4gqEAyHywJzMRAhYX87pXjH2NtyigF7evkA==",
+      "requires": {
+        "min-dash": "^3.0.0"
+      }
+    },
+    "moddle-xml": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/moddle-xml/-/moddle-xml-9.0.5.tgz",
+      "integrity": "sha512-1t9N35ZMQZTYZmRDoh1mBVd0XwLB34BkBywNJ0+YlLLYxaDBjFR/I+fqwsY746ayYPBz6yNRg8JpLyFgNF+eHg==",
+      "requires": {
+        "min-dash": "^3.5.2",
+        "moddle": "^5.0.2",
+        "saxen": "^8.1.2"
+      }
+    },
+    "modeler-moddle": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/modeler-moddle/-/modeler-moddle-0.2.0.tgz",
+      "integrity": "sha512-l8OUpvX94m3spe+RBwWFQ0bGvPBZ3FBCiSY3yNtDk52j0YRj+cnVOxTMQvVM+i6k1T326IfqYM3F9HJfPZtXRw==",
+      "dev": true
+    },
+    "mri": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
+      "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA=="
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "dev": true
+    },
+    "mute-stream": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+      "integrity": "sha512-r65nCZhrbXXb6dXOACihYApHw2Q6pV0M3V0PSxd74N0+D8nzAdEAITq2oAjA1jVnKI+tGvEBUpqiMh0+rW6zDQ==",
+      "dev": true
+    },
+    "natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true
+    },
+    "object-inspect": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.2.tgz",
+      "integrity": "sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==",
+      "dev": true
+    },
+    "object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true
+    },
+    "object.assign": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+      "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3",
+        "has-symbols": "^1.0.1",
+        "object-keys": "^1.1.1"
+      }
+    },
+    "object.entries": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.5.tgz",
+      "integrity": "sha512-TyxmjUoZggd4OrrU1W66FMDG6CuqJxsFvymeyXI51+vQLN67zYfZseptRge703kKQdo4uccgAKebXFcRCzk4+g==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.19.1"
+      }
+    },
+    "object.fromentries": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.5.tgz",
+      "integrity": "sha512-CAyG5mWQRRiBU57Re4FKoTBjXfDoNwdFVH2Y1tS9PqCsfUTymAohOkEMSG3aRNKmv4lV3O7p1et7c187q6bynw==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.19.1"
+      }
+    },
+    "object.hasown": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object.hasown/-/object.hasown-1.1.1.tgz",
+      "integrity": "sha512-LYLe4tivNQzq4JdaWW6WO3HMZZJWzkkH8fnI6EebWl0VZth2wL2Lovm74ep2/gZzlaTdV62JZHEqHQ2yVn8Q/A==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.19.5"
+      }
+    },
+    "object.values": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.5.tgz",
+      "integrity": "sha512-QUZRW0ilQ3PnPpbNtgdNV1PDbEqLIiSFB3l+EnGtBQ/8SUTLj1PZwtQHABZtLgwpJZTSZhuGLOGk57Drx2IvYg==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.19.1"
+      }
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "onetime": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+      "integrity": "sha512-oyyPpiMaKARvvcgip+JV+7zci5L8D1W9RZIz2l1o08AM3pfspitVWnPt3mzHcBPp12oYMTy0pqrFs/C+m3EwsQ==",
+      "dev": true,
+      "requires": {
+        "mimic-fn": "^1.0.0"
+      }
+    },
+    "optionator": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
+      "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
+      "dev": true,
+      "requires": {
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.6",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "word-wrap": "~1.2.3"
+      }
+    },
+    "os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
+      "dev": true
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "path-is-inside": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+      "integrity": "sha512-DUWJr3+ULp4zXmol/SZkFf3JGsS9/SIv+Y3Rt93/UjPpDpklB5f1er4O3POIbUuUJ3FXgqte2Q7SrU6zAqwk8w==",
+      "dev": true
+    },
+    "path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true
+    },
+    "pathval": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
+      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
+      "dev": true
+    },
+    "pluralize": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
+      "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow=="
+    },
+    "prelude-ls": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "integrity": "sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==",
+      "dev": true
+    },
+    "process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true
+    },
+    "progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true
+    },
+    "prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "dev": true,
+      "requires": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "pseudomap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ==",
+      "dev": true
+    },
+    "ramda": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.25.0.tgz",
+      "integrity": "sha512-GXpfrYVPwx3K7RQ6aYT8KPS8XViSXUVJT1ONhoKPE9VAleW42YE+U+8VEyGWt41EnEQW7gwecYJriTI0pKoecQ==",
+      "dev": true
+    },
+    "react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "dev": true
+    },
+    "readable-stream": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "dev": true,
+      "requires": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "regexp.prototype.flags": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz",
+      "integrity": "sha512-fjggEOO3slI6Wvgjwflkc4NFRCTZAu5CnNfBd5qOMYhWdn67nJBBu34/TkD++eeFmd8C9r9jfXJ27+nSiRkSUA==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "functions-have-names": "^1.2.2"
+      }
+    },
+    "regexpp": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-1.1.0.tgz",
+      "integrity": "sha512-LOPw8FpgdQF9etWMaAfG/WRthIdXJGYp4mJ2Jgn/2lpkbod9jPn0t9UqN7AxBOKNfzRbYyVfgc7Vk4t/MpnXgw==",
+      "dev": true
+    },
+    "require-uncached": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
+      "integrity": "sha512-Xct+41K3twrbBHdxAgMoOS+cNcoqIjfM2/VxBF4LL2hVph7YsF8VSKyQ3BDFZwEVbok9yeDl2le/qo0S77WG2w==",
+      "dev": true,
+      "requires": {
+        "caller-path": "^0.1.0",
+        "resolve-from": "^1.0.0"
+      }
+    },
+    "resolve": {
+      "version": "2.0.0-next.3",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.3.tgz",
+      "integrity": "sha512-W8LucSynKUIDu9ylraa7ueVZ7hc0uAgJBxVsQSKOXOyle8a93qXhcz+XAXZ8bIq2d6i4Ehddn6Evt+0/UwKk6Q==",
+      "dev": true,
+      "requires": {
+        "is-core-module": "^2.2.0",
+        "path-parse": "^1.0.6"
+      }
+    },
+    "resolve-from": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
+      "integrity": "sha512-kT10v4dhrlLNcnO084hEjvXCI1wUG9qZLoz2RogxqDQQYy7IxjI/iMUkOtQTNEh6rzHxvdQWHsJyel1pKOVCxg==",
+      "dev": true
+    },
+    "restore-cursor": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+      "integrity": "sha512-6IzJLuGi4+R14vwagDHX+JrXmPVtPpn4mffDJ1UdR7/Edm87fl6yi8mMBIVvFtJaNTUvjughmW4hwLhRG7gC1Q==",
+      "dev": true,
+      "requires": {
+        "onetime": "^2.0.0",
+        "signal-exit": "^3.0.2"
+      }
+    },
+    "rimraf": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.1.3"
+      }
+    },
+    "run-async": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
+      "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==",
+      "dev": true
+    },
+    "rx-lite": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
+      "integrity": "sha512-Cun9QucwK6MIrp3mry/Y7hqD1oFqTYLQ4pGxaHTjIdaFDWRGGLikqp6u8LcWJnzpoALg9hap+JGk8sFIUuEGNA==",
+      "dev": true
+    },
+    "rx-lite-aggregates": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
+      "integrity": "sha512-3xPNZGW93oCjiO7PtKxRK6iOVYBWBvtf9QHDfU23Oc+dLIQmAV//UnyXV/yihv81VS/UqoQPk4NegS8EFi55Hg==",
+      "dev": true,
+      "requires": {
+        "rx-lite": "*"
+      }
+    },
+    "safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
+    },
+    "saxen": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/saxen/-/saxen-8.1.2.tgz",
+      "integrity": "sha512-xUOiiFbc3Ow7p8KMxwsGICPx46ZQvy3+qfNVhrkwfz3Vvq45eGt98Ft5IQaA1R/7Tb5B5MKh9fUR9x3c3nDTxw=="
+    },
+    "semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "dev": true
+    },
+    "shebang-command": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+      "dev": true,
+      "requires": {
+        "shebang-regex": "^1.0.0"
+      }
+    },
+    "shebang-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+      "dev": true
+    },
+    "side-channel": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
+      "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.0",
+        "get-intrinsic": "^1.0.2",
+        "object-inspect": "^1.9.0"
+      }
+    },
+    "signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true
+    },
+    "slice-ansi": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
+      "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
+      "dev": true,
+      "requires": {
+        "is-fullwidth-code-point": "^2.0.0"
+      }
+    },
+    "source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+      "dev": true
+    },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
+    },
+    "string-width": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+      "dev": true,
+      "requires": {
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^4.0.0"
+      }
+    },
+    "string.prototype.matchall": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.7.tgz",
+      "integrity": "sha512-f48okCX7JiwVi1NXCVWcFnZgADDC/n2vePlQ/KUCNqCikLLilQvwjMO8+BHVKvgzH0JB0J9LEPgxOGT02RoETg==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.19.1",
+        "get-intrinsic": "^1.1.1",
+        "has-symbols": "^1.0.3",
+        "internal-slot": "^1.0.3",
+        "regexp.prototype.flags": "^1.4.1",
+        "side-channel": "^1.0.4"
+      }
+    },
+    "string.prototype.trimend": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.5.tgz",
+      "integrity": "sha512-I7RGvmjV4pJ7O3kdf+LXFpVfdNOxtCW/2C8f6jNiW4+PQchwxkCDzlk1/7p+Wl4bqFIZeF47qAHXLuHHWKAxog==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.19.5"
+      }
+    },
+    "string.prototype.trimstart": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.5.tgz",
+      "integrity": "sha512-THx16TJCGlsN0o6dl2o6ncWUsdgnLRSA23rRE5pyGBw/mLr3Ej/R2LaqCtgP8VNMGZsvMWnf9ooZPyY2bHvUFg==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.19.5"
+      }
+    },
+    "string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "strip-ansi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+      "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^3.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.1.tgz",
+          "integrity": "sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw==",
+          "dev": true
+        }
+      }
+    },
+    "strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+      "dev": true
+    },
+    "supports-color": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
+      "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+      "dev": true,
+      "requires": {
+        "has-flag": "^2.0.0"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha512-P+1n3MnwjR/Epg9BBo1KT8qbye2g2Ou4sFumihwt6I4tsUX7jnLcX4BTOSKg/B1ZrIYMN9FcEnG4x5a7NB8Eng==",
+          "dev": true
+        }
+      }
+    },
+    "table": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/table/-/table-4.0.2.tgz",
+      "integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
+      "dev": true,
+      "requires": {
+        "ajv": "^5.2.3",
+        "ajv-keywords": "^2.1.0",
+        "chalk": "^2.1.0",
+        "lodash": "^4.17.4",
+        "slice-ansi": "1.0.0",
+        "string-width": "^2.1.1"
+      }
+    },
+    "text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+      "dev": true
+    },
+    "through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "dev": true
+    },
+    "tiny-glob": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/tiny-glob/-/tiny-glob-0.2.9.tgz",
+      "integrity": "sha512-g/55ssRPUjShh+xkfx9UPDXqhckHEsHr4Vd9zX55oSdGZc/MD0m3sferOkwWtp98bv+kcVfEHtRJgBVJzelrzg==",
+      "requires": {
+        "globalyzer": "0.1.0",
+        "globrex": "^0.1.2"
+      }
+    },
+    "tmp": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "dev": true,
+      "requires": {
+        "os-tmpdir": "~1.0.2"
+      }
+    },
+    "to-fast-properties": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+      "dev": true
+    },
+    "trim-right": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+      "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
+      "dev": true
+    },
+    "type-check": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "~1.1.2"
+      }
+    },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true
+    },
+    "typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+      "dev": true
+    },
+    "unbox-primitive": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
+      "integrity": "sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "has-bigints": "^1.0.2",
+        "has-symbols": "^1.0.3",
+        "which-boxed-primitive": "^1.0.2"
+      }
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
+    },
+    "which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dev": true,
+      "requires": {
+        "isexe": "^2.0.0"
+      }
+    },
+    "which-boxed-primitive": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
+      "integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
+      "dev": true,
+      "requires": {
+        "is-bigint": "^1.0.1",
+        "is-boolean-object": "^1.1.0",
+        "is-number-object": "^1.0.4",
+        "is-string": "^1.0.5",
+        "is-symbol": "^1.0.3"
+      }
+    },
+    "word-wrap": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
+      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "dev": true
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    },
+    "write": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
+      "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
+      "dev": true,
+      "requires": {
+        "mkdirp": "^0.5.1"
+      }
+    },
+    "yallist": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+      "dev": true
+    },
+    "zeebe-bpmn-moddle": {
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/zeebe-bpmn-moddle/-/zeebe-bpmn-moddle-0.12.1.tgz",
+      "integrity": "sha512-rnUoK+A/gzinOGUlmJKeXmnjorgEm4yf7qgeaowXGZOFtFqtM2lvJ7XYTJNsKClaNfFG245JtKHH3G/caJxE6g==",
+      "dev": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "@camunda/linting",
+  "version": "0.1.0",
+  "description": "Linting for Camunda Platform",
+  "main": "index.js",
+  "scripts": {
+    "all": "npm run lint && npm test",
+    "lint": "eslint .",
+    "test": "mocha -r esm --reporter=spec --recursive test/spec",
+    "test:watch": "npm run test -- --watch"
+  },
+  "keywords": [
+    "bpmnlint",
+    "camunda"
+  ],
+  "author": {
+    "name": "Philipp Fromme",
+    "url": "https://github.com/philippfromme"
+  },
+  "license": "MIT",
+  "dependencies": {
+    "bpmnlint": "^7.8.0",
+    "bpmnlint-plugin-camunda-compat": "^0.7.0",
+    "bpmnlint-utils": "^1.0.2"
+  },
+  "devDependencies": {
+    "bpmn-moddle": "^7.1.2",
+    "chai": "^4.3.6",
+    "eslint": "^4.11.0",
+    "eslint-plugin-bpmn-io": "^0.4.1",
+    "esm": "^3.2.25",
+    "min-dash": "^3.8.1",
+    "mocha": "^4.0.1",
+    "modeler-moddle": "^0.2.0",
+    "zeebe-bpmn-moddle": "^0.12.1"
+  },
+  "files": [
+    "lib"
+  ]
+}

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -1,0 +1,5 @@
+{
+  "extends": [
+    "plugin:bpmn-io/mocha"
+  ]
+}

--- a/test/helper.js
+++ b/test/helper.js
@@ -1,0 +1,84 @@
+import BpmnModdle from 'bpmn-moddle';
+
+import { isArray } from 'min-dash';
+
+import modelerModdleSchema from 'modeler-moddle/resources/modeler.json';
+import zeebeModdleSchema from 'zeebe-bpmn-moddle/resources/zeebe.json';
+
+import { readFileSync } from 'fs';
+
+export function readModdle(filePath) {
+  const contents = readFileSync(filePath, 'utf8');
+
+  return createModdle(contents);
+}
+
+export async function createModdle(xml) {
+  const moddle = new BpmnModdle({
+    modeler: modelerModdleSchema,
+    zeebe: zeebeModdleSchema
+  });
+
+  let root, warnings;
+
+  try {
+    ({
+      rootElement: root,
+      warnings = []
+    } = await moddle.fromXML(xml, 'bpmn:Definitions', { lax: true }));
+  } catch (err) {
+    console.log(err);
+  }
+
+  return {
+    root,
+    moddle,
+    context: {
+      warnings
+    },
+    warnings
+  };
+}
+
+export function createElement(type, properties) {
+  const moddle = new BpmnModdle({
+    modeler: modelerModdleSchema,
+    zeebe: zeebeModdleSchema
+  });
+
+  const moddleElement = moddle.create(type, properties);
+
+  const isReference = (propertyName, moddleElement) => {
+    const { $descriptor } = moddleElement;
+
+    const { propertiesByName } = $descriptor;
+
+    const property = propertiesByName[ propertyName ];
+
+    return property.isReference;
+  };
+
+  const setParent = (property) => {
+    if (property.$type) {
+      const childModdleElement = property;
+
+      childModdleElement.$parent = moddleElement;
+    }
+  };
+
+  if (properties) {
+    Object.entries(properties).forEach(([ propertyName, property ]) => {
+      if (isReference(propertyName, moddleElement)) {
+        return;
+      }
+
+      setParent(property);
+
+      if (isArray(property)) {
+        property.forEach(setParent);
+      }
+    });
+  }
+
+  return moddleElement;
+}

--- a/test/spec/Linter.spec.js
+++ b/test/spec/Linter.spec.js
@@ -1,0 +1,171 @@
+import { expect } from 'chai';
+
+import { readModdle } from '../helper';
+
+import { Linter } from '../..';
+
+describe('Linter', function() {
+
+  it('should not lint (no execution platform)', async function() {
+
+    // given
+    const { root } = await readModdle('test/spec/no-execution-platform.bpmn');
+
+    // when
+    const reports = await Linter.lint(root);
+
+    // then
+    expect(reports).to.be.empty;
+  });
+
+
+  describe('camunda-cloud', function() {
+
+    it('should lint without errors (Camunda Cloud 1.0.0)', async function() {
+
+      // given
+      const { root } = await readModdle('test/spec/camunda-cloud-1-0-valid.bpmn');
+
+      // when
+      const reports = await Linter.lint(root);
+
+      // then
+      expect(reports).to.be.empty;
+    });
+
+
+    it('should lint with errors (Camunda Cloud 1.0.0)', async function() {
+
+      // given
+      const { root } = await readModdle('test/spec/camunda-cloud-1-0-invalid.bpmn');
+
+      // when
+      const reports = await Linter.lint(root);
+
+      // then
+      expect(reports).not.to.be.empty;
+    });
+
+
+    it('should lint without errors (Camunda Cloud 1.1.0)', async function() {
+
+      // given
+      const { root } = await readModdle('test/spec/camunda-cloud-1-1-valid.bpmn');
+
+      // when
+      const reports = await Linter.lint(root);
+
+      // then
+      expect(reports).to.be.empty;
+    });
+
+
+    it('should lint with errors (Camunda Cloud 1.1.0)', async function() {
+
+      // given
+      const { root } = await readModdle('test/spec/camunda-cloud-1-1-invalid.bpmn');
+
+      // when
+      const reports = await Linter.lint(root);
+
+      // then
+      expect(reports).not.to.be.empty;
+    });
+
+
+    it('should lint without errors (Camunda Cloud 1.2.0)', async function() {
+
+      // given
+      const { root } = await readModdle('test/spec/camunda-cloud-1-2-valid.bpmn');
+
+      // when
+      const reports = await Linter.lint(root);
+
+      // then
+      expect(reports).to.be.empty;
+    });
+
+
+    it('should lint with errors (Camunda Cloud 1.2.0)', async function() {
+
+      // given
+      const { root } = await readModdle('test/spec/camunda-cloud-1-2-invalid.bpmn');
+
+      // when
+      const reports = await Linter.lint(root);
+
+      // then
+      expect(reports).not.to.be.empty;
+    });
+
+
+    it('should lint without errors (Camunda Cloud 1.3.0)', async function() {
+
+      // given
+      const { root } = await readModdle('test/spec/camunda-cloud-1-3-valid.bpmn');
+
+      // when
+      const reports = await Linter.lint(root);
+
+      // then
+      expect(reports).to.be.empty;
+    });
+
+
+    it('should lint with errors (Camunda Cloud 1.3.0)', async function() {
+
+      // given
+      const { root } = await readModdle('test/spec/camunda-cloud-1-3-invalid.bpmn');
+
+      // when
+      const reports = await Linter.lint(root);
+
+      // then
+      expect(reports).not.to.be.empty;
+    });
+
+
+    it('should lint without errors (Camunda Cloud 8.0.0)', async function() {
+
+      // given
+      const { root } = await readModdle('test/spec/camunda-cloud-8-0-valid.bpmn');
+
+      // when
+      const reports = await Linter.lint(root);
+
+      // then
+      expect(reports).to.be.empty;
+    });
+
+
+    it('should lint with errors (Camunda Cloud 8.0.0)', async function() {
+
+      // given
+      const { root } = await readModdle('test/spec/camunda-cloud-8-0-invalid.bpmn');
+
+      // when
+      const reports = await Linter.lint(root);
+
+      // then
+      expect(reports).not.to.be.empty;
+    });
+
+  });
+
+  describe('camunda-platform', function() {
+
+    it('should not lint Camunda Platform 7.17', async function() {
+
+      // given
+      const { root } = await readModdle('test/spec/camunda-platform-7-17.bpmn');
+
+      // when
+      const reports = await Linter.lint(root);
+
+      // then
+      expect(reports).to.be.empty;
+    });
+
+  });
+
+});

--- a/test/spec/camunda-cloud-1-0-invalid.bpmn
+++ b/test/spec/camunda-cloud-1-0-invalid.bpmn
@@ -1,0 +1,239 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1vc92ax" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.0.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="1.0.0">
+  <bpmn:collaboration id="Collaboration_013oh0t">
+    <bpmn:participant id="Participant_1lhpzkq" processRef="Process_07pko08" />
+  </bpmn:collaboration>
+  <bpmn:process id="Process_07pko08" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1c9prry</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:serviceTask id="Activity_0tmvr8k" name="foo">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1c9prry</bpmn:incoming>
+      <bpmn:outgoing>Flow_04jud3f</bpmn:outgoing>
+      <bpmn:multiInstanceLoopCharacteristics>
+        <bpmn:extensionElements>
+          <zeebe:loopCharacteristics />
+        </bpmn:extensionElements>
+      </bpmn:multiInstanceLoopCharacteristics>
+    </bpmn:serviceTask>
+    <bpmn:endEvent id="Event_1vne73h">
+      <bpmn:incoming>Flow_0av9in9</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:callActivity id="Activity_19dosz4">
+      <bpmn:extensionElements>
+        <zeebe:calledElement propagateAllChildVariables="false" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_04jud3f</bpmn:incoming>
+      <bpmn:outgoing>Flow_1bj4q1g</bpmn:outgoing>
+    </bpmn:callActivity>
+    <bpmn:exclusiveGateway id="Gateway_03oxb21">
+      <bpmn:incoming>Flow_1bj4q1g</bpmn:incoming>
+      <bpmn:outgoing>Flow_0aq3rml</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0wkb4hq</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:parallelGateway id="Gateway_1ee6i9s">
+      <bpmn:incoming>Flow_0aq3rml</bpmn:incoming>
+      <bpmn:outgoing>Flow_13iwl91</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:eventBasedGateway id="Gateway_0v1y6l3">
+      <bpmn:incoming>Flow_13iwl91</bpmn:incoming>
+      <bpmn:outgoing>Flow_0ozoxv7</bpmn:outgoing>
+      <bpmn:outgoing>Flow_1dj62p6</bpmn:outgoing>
+    </bpmn:eventBasedGateway>
+    <bpmn:intermediateCatchEvent id="Event_1xosfgb">
+      <bpmn:incoming>Flow_0ozoxv7</bpmn:incoming>
+      <bpmn:outgoing>Flow_1hk0gog</bpmn:outgoing>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_1gucz9d" messageRef="Message_0inbjmp" />
+    </bpmn:intermediateCatchEvent>
+    <bpmn:intermediateCatchEvent id="Event_0cyp3nd">
+      <bpmn:incoming>Flow_1dj62p6</bpmn:incoming>
+      <bpmn:outgoing>Flow_0uqdyxp</bpmn:outgoing>
+      <bpmn:timerEventDefinition id="TimerEventDefinition_1vu1hns" />
+    </bpmn:intermediateCatchEvent>
+    <bpmn:receiveTask id="Activity_0v05780" name="bar">
+      <bpmn:incoming>Flow_1hk0gog</bpmn:incoming>
+      <bpmn:outgoing>Flow_0k2v5e1</bpmn:outgoing>
+    </bpmn:receiveTask>
+    <bpmn:userTask id="Activity_18h7yic">
+      <bpmn:incoming>Flow_0uqdyxp</bpmn:incoming>
+      <bpmn:outgoing>Flow_1a5127t</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:endEvent id="Event_195u06h">
+      <bpmn:incoming>Flow_1a5127t</bpmn:incoming>
+      <bpmn:errorEventDefinition id="ErrorEventDefinition_075l6v5" errorRef="Error_035q7ey" />
+    </bpmn:endEvent>
+    <bpmn:subProcess id="Activity_09495yf">
+      <bpmn:incoming>Flow_0k2v5e1</bpmn:incoming>
+      <bpmn:startEvent id="Event_0ijiazl" />
+    </bpmn:subProcess>
+    <bpmn:boundaryEvent id="Event_1j12ud3" attachedToRef="Activity_0tmvr8k">
+      <bpmn:outgoing>Flow_0av9in9</bpmn:outgoing>
+      <bpmn:outgoing>Flow_11x8rdy</bpmn:outgoing>
+      <bpmn:errorEventDefinition id="ErrorEventDefinition_0cy2jeo" errorRef="Error_035q7ey" />
+    </bpmn:boundaryEvent>
+    <bpmn:sequenceFlow id="Flow_1c9prry" sourceRef="StartEvent_1" targetRef="Activity_0tmvr8k" />
+    <bpmn:sequenceFlow id="Flow_0av9in9" sourceRef="Event_1j12ud3" targetRef="Event_1vne73h" />
+    <bpmn:sequenceFlow id="Flow_04jud3f" sourceRef="Activity_0tmvr8k" targetRef="Activity_19dosz4" />
+    <bpmn:sequenceFlow id="Flow_1bj4q1g" sourceRef="Activity_19dosz4" targetRef="Gateway_03oxb21" />
+    <bpmn:sequenceFlow id="Flow_0aq3rml" sourceRef="Gateway_03oxb21" targetRef="Gateway_1ee6i9s" />
+    <bpmn:sequenceFlow id="Flow_13iwl91" sourceRef="Gateway_1ee6i9s" targetRef="Gateway_0v1y6l3" />
+    <bpmn:sequenceFlow id="Flow_0ozoxv7" sourceRef="Gateway_0v1y6l3" targetRef="Event_1xosfgb" />
+    <bpmn:sequenceFlow id="Flow_1dj62p6" sourceRef="Gateway_0v1y6l3" targetRef="Event_0cyp3nd" />
+    <bpmn:sequenceFlow id="Flow_1hk0gog" sourceRef="Event_1xosfgb" targetRef="Activity_0v05780" />
+    <bpmn:sequenceFlow id="Flow_0k2v5e1" sourceRef="Activity_0v05780" targetRef="Activity_09495yf" />
+    <bpmn:sequenceFlow id="Flow_0uqdyxp" sourceRef="Event_0cyp3nd" targetRef="Activity_18h7yic" />
+    <bpmn:sequenceFlow id="Flow_1a5127t" sourceRef="Activity_18h7yic" targetRef="Event_195u06h" />
+    <bpmn:complexGateway id="Gateway_1adft3c">
+      <bpmn:incoming>Flow_0wkb4hq</bpmn:incoming>
+    </bpmn:complexGateway>
+    <bpmn:sequenceFlow id="Flow_0wkb4hq" sourceRef="Gateway_03oxb21" targetRef="Gateway_1adft3c" />
+    <bpmn:sequenceFlow id="Flow_11x8rdy" sourceRef="Event_1j12ud3" targetRef="Event_0el3zk8" />
+    <bpmn:endEvent id="Event_0el3zk8">
+      <bpmn:incoming>Flow_11x8rdy</bpmn:incoming>
+      <bpmn:errorEventDefinition id="ErrorEventDefinition_16vp8au" />
+    </bpmn:endEvent>
+    <bpmn:textAnnotation id="TextAnnotation_092byka">
+      <bpmn:text>foo</bpmn:text>
+    </bpmn:textAnnotation>
+    <bpmn:association id="Association_07pskij" sourceRef="Activity_0tmvr8k" targetRef="TextAnnotation_092byka" />
+  </bpmn:process>
+  <bpmn:message id="Message_0inbjmp" name="Message_0inbjmp">
+    <bpmn:extensionElements>
+      <zeebe:subscription />
+    </bpmn:extensionElements>
+  </bpmn:message>
+  <bpmn:error id="Error_035q7ey" name="Error_07ueecl" errorCode="foo" />
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Collaboration_013oh0t">
+      <bpmndi:BPMNShape id="Participant_1lhpzkq_di" bpmnElement="Participant_1lhpzkq" isHorizontal="true">
+        <dc:Bounds x="129" y="80" width="1601" height="488" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_11x8rdy_di" bpmnElement="Flow_11x8rdy">
+        <di:waypoint x="370" y="325" />
+        <di:waypoint x="370" y="500" />
+        <di:waypoint x="442" y="500" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0wkb4hq_di" bpmnElement="Flow_0wkb4hq">
+        <di:waypoint x="620" y="292" />
+        <di:waypoint x="620" y="380" />
+        <di:waypoint x="715" y="380" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1a5127t_di" bpmnElement="Flow_1a5127t">
+        <di:waypoint x="1180" y="380" />
+        <di:waypoint x="1220" y="380" />
+        <di:waypoint x="1220" y="490" />
+        <di:waypoint x="1262" y="490" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0uqdyxp_di" bpmnElement="Flow_0uqdyxp">
+        <di:waypoint x="998" y="380" />
+        <di:waypoint x="1080" y="380" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0k2v5e1_di" bpmnElement="Flow_0k2v5e1">
+        <di:waypoint x="1180" y="267" />
+        <di:waypoint x="1280" y="267" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1hk0gog_di" bpmnElement="Flow_1hk0gog">
+        <di:waypoint x="998" y="267" />
+        <di:waypoint x="1080" y="267" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1dj62p6_di" bpmnElement="Flow_1dj62p6">
+        <di:waypoint x="860" y="292" />
+        <di:waypoint x="860" y="380" />
+        <di:waypoint x="962" y="380" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0ozoxv7_di" bpmnElement="Flow_0ozoxv7">
+        <di:waypoint x="885" y="267" />
+        <di:waypoint x="962" y="267" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_13iwl91_di" bpmnElement="Flow_13iwl91">
+        <di:waypoint x="765" y="267" />
+        <di:waypoint x="835" y="267" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0aq3rml_di" bpmnElement="Flow_0aq3rml">
+        <di:waypoint x="645" y="267" />
+        <di:waypoint x="715" y="267" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1bj4q1g_di" bpmnElement="Flow_1bj4q1g">
+        <di:waypoint x="530" y="267" />
+        <di:waypoint x="595" y="267" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_04jud3f_di" bpmnElement="Flow_04jud3f">
+        <di:waypoint x="370" y="267" />
+        <di:waypoint x="430" y="267" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0av9in9_di" bpmnElement="Flow_0av9in9">
+        <di:waypoint x="370" y="325" />
+        <di:waypoint x="370" y="390" />
+        <di:waypoint x="442" y="390" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1c9prry_di" bpmnElement="Flow_1c9prry">
+        <di:waypoint x="215" y="267" />
+        <di:waypoint x="270" y="267" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="249" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_18wmzbb_di" bpmnElement="Activity_0tmvr8k">
+        <dc:Bounds x="270" y="227" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1vne73h_di" bpmnElement="Event_1vne73h">
+        <dc:Bounds x="442" y="372" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1wish8i_di" bpmnElement="Activity_19dosz4">
+        <dc:Bounds x="430" y="227" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_03oxb21_di" bpmnElement="Gateway_03oxb21" isMarkerVisible="true">
+        <dc:Bounds x="595" y="242" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0zdq4bc_di" bpmnElement="Gateway_1ee6i9s">
+        <dc:Bounds x="715" y="242" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0ov1azh_di" bpmnElement="Gateway_0v1y6l3">
+        <dc:Bounds x="835" y="242" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1xosfgb_di" bpmnElement="Event_1xosfgb">
+        <dc:Bounds x="962" y="249" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0cyp3nd_di" bpmnElement="Event_0cyp3nd">
+        <dc:Bounds x="962" y="362" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1sak8hk_di" bpmnElement="Activity_0v05780">
+        <dc:Bounds x="1080" y="227" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1fdzcmp_di" bpmnElement="Activity_18h7yic">
+        <dc:Bounds x="1080" y="340" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0gcrrhl_di" bpmnElement="Event_195u06h">
+        <dc:Bounds x="1262" y="472" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_09495yf_di" bpmnElement="Activity_09495yf" isExpanded="true">
+        <dc:Bounds x="1280" y="167" width="350" height="200" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0ijiazl_di" bpmnElement="Event_0ijiazl">
+        <dc:Bounds x="1320" y="249" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1adft3c_di" bpmnElement="Gateway_1adft3c" isMarkerVisible="true">
+        <dc:Bounds x="715" y="355" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_16u5s1h_di" bpmnElement="Event_0el3zk8">
+        <dc:Bounds x="442" y="482" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="TextAnnotation_092byka_di" bpmnElement="TextAnnotation_092byka">
+        <dc:Bounds x="370" y="140" width="100" height="30" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0yhfoa2_di" bpmnElement="Event_1j12ud3">
+        <dc:Bounds x="352" y="289" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Association_07pskij_di" bpmnElement="Association_07pskij">
+        <di:waypoint x="356" y="227" />
+        <di:waypoint x="407" y="170" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/spec/camunda-cloud-1-0-valid.bpmn
+++ b/test/spec/camunda-cloud-1-0-valid.bpmn
@@ -1,0 +1,244 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1vc92ax" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.0.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="1.0.0">
+  <bpmn:collaboration id="Collaboration_013oh0t">
+    <bpmn:participant id="Participant_1lhpzkq" processRef="Process_07pko08" />
+  </bpmn:collaboration>
+  <bpmn:process id="Process_07pko08" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1c9prry</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:serviceTask id="Activity_0tmvr8k" name="foo">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="foo" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1c9prry</bpmn:incoming>
+      <bpmn:outgoing>Flow_04jud3f</bpmn:outgoing>
+      <bpmn:multiInstanceLoopCharacteristics>
+        <bpmn:extensionElements>
+          <zeebe:loopCharacteristics inputCollection="foo" />
+        </bpmn:extensionElements>
+      </bpmn:multiInstanceLoopCharacteristics>
+    </bpmn:serviceTask>
+    <bpmn:endEvent id="Event_1vne73h">
+      <bpmn:incoming>Flow_0av9in9</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:callActivity id="Activity_19dosz4">
+      <bpmn:extensionElements>
+        <zeebe:calledElement processId="foo" propagateAllChildVariables="false" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_04jud3f</bpmn:incoming>
+      <bpmn:outgoing>Flow_1bj4q1g</bpmn:outgoing>
+      <bpmn:multiInstanceLoopCharacteristics>
+        <bpmn:extensionElements>
+          <zeebe:loopCharacteristics inputCollection="foo" />
+        </bpmn:extensionElements>
+      </bpmn:multiInstanceLoopCharacteristics>
+    </bpmn:callActivity>
+    <bpmn:exclusiveGateway id="Gateway_03oxb21">
+      <bpmn:incoming>Flow_1bj4q1g</bpmn:incoming>
+      <bpmn:outgoing>Flow_0aq3rml</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0wkb4hq</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:parallelGateway id="Gateway_1ee6i9s">
+      <bpmn:incoming>Flow_0aq3rml</bpmn:incoming>
+      <bpmn:outgoing>Flow_13iwl91</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:eventBasedGateway id="Gateway_0v1y6l3">
+      <bpmn:incoming>Flow_13iwl91</bpmn:incoming>
+      <bpmn:outgoing>Flow_0ozoxv7</bpmn:outgoing>
+      <bpmn:outgoing>Flow_1dj62p6</bpmn:outgoing>
+    </bpmn:eventBasedGateway>
+    <bpmn:intermediateCatchEvent id="Event_1xosfgb">
+      <bpmn:incoming>Flow_0ozoxv7</bpmn:incoming>
+      <bpmn:outgoing>Flow_1hk0gog</bpmn:outgoing>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_1gucz9d" messageRef="Message_0inbjmp" />
+    </bpmn:intermediateCatchEvent>
+    <bpmn:intermediateCatchEvent id="Event_0cyp3nd">
+      <bpmn:incoming>Flow_1dj62p6</bpmn:incoming>
+      <bpmn:outgoing>Flow_0uqdyxp</bpmn:outgoing>
+      <bpmn:timerEventDefinition id="TimerEventDefinition_1vu1hns" />
+    </bpmn:intermediateCatchEvent>
+    <bpmn:receiveTask id="Activity_0v05780" name="bar" messageRef="Message_0inbjmp">
+      <bpmn:incoming>Flow_1hk0gog</bpmn:incoming>
+      <bpmn:outgoing>Flow_0k2v5e1</bpmn:outgoing>
+    </bpmn:receiveTask>
+    <bpmn:userTask id="Activity_18h7yic">
+      <bpmn:incoming>Flow_0uqdyxp</bpmn:incoming>
+      <bpmn:outgoing>Flow_1a5127t</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:endEvent id="Event_195u06h">
+      <bpmn:incoming>Flow_1a5127t</bpmn:incoming>
+      <bpmn:errorEventDefinition id="ErrorEventDefinition_075l6v5" errorRef="Error_035q7ey" />
+    </bpmn:endEvent>
+    <bpmn:subProcess id="Activity_09495yf">
+      <bpmn:incoming>Flow_0k2v5e1</bpmn:incoming>
+      <bpmn:startEvent id="Event_0ijiazl" />
+    </bpmn:subProcess>
+    <bpmn:boundaryEvent id="Event_1j12ud3" attachedToRef="Activity_0tmvr8k">
+      <bpmn:outgoing>Flow_0av9in9</bpmn:outgoing>
+      <bpmn:outgoing>Flow_11x8rdy</bpmn:outgoing>
+      <bpmn:errorEventDefinition id="ErrorEventDefinition_0cy2jeo" errorRef="Error_035q7ey" />
+    </bpmn:boundaryEvent>
+    <bpmn:sequenceFlow id="Flow_1c9prry" sourceRef="StartEvent_1" targetRef="Activity_0tmvr8k" />
+    <bpmn:sequenceFlow id="Flow_0av9in9" sourceRef="Event_1j12ud3" targetRef="Event_1vne73h" />
+    <bpmn:sequenceFlow id="Flow_04jud3f" sourceRef="Activity_0tmvr8k" targetRef="Activity_19dosz4" />
+    <bpmn:sequenceFlow id="Flow_1bj4q1g" sourceRef="Activity_19dosz4" targetRef="Gateway_03oxb21" />
+    <bpmn:sequenceFlow id="Flow_0aq3rml" sourceRef="Gateway_03oxb21" targetRef="Gateway_1ee6i9s" />
+    <bpmn:sequenceFlow id="Flow_13iwl91" sourceRef="Gateway_1ee6i9s" targetRef="Gateway_0v1y6l3" />
+    <bpmn:sequenceFlow id="Flow_0ozoxv7" sourceRef="Gateway_0v1y6l3" targetRef="Event_1xosfgb" />
+    <bpmn:sequenceFlow id="Flow_1dj62p6" sourceRef="Gateway_0v1y6l3" targetRef="Event_0cyp3nd" />
+    <bpmn:sequenceFlow id="Flow_1hk0gog" sourceRef="Event_1xosfgb" targetRef="Activity_0v05780" />
+    <bpmn:sequenceFlow id="Flow_0k2v5e1" sourceRef="Activity_0v05780" targetRef="Activity_09495yf" />
+    <bpmn:sequenceFlow id="Flow_0uqdyxp" sourceRef="Event_0cyp3nd" targetRef="Activity_18h7yic" />
+    <bpmn:sequenceFlow id="Flow_1a5127t" sourceRef="Activity_18h7yic" targetRef="Event_195u06h" />
+    <bpmn:sequenceFlow id="Flow_0wkb4hq" sourceRef="Gateway_03oxb21" targetRef="Gateway_1adft3c" />
+    <bpmn:sequenceFlow id="Flow_11x8rdy" sourceRef="Event_1j12ud3" targetRef="Event_0el3zk8" />
+    <bpmn:endEvent id="Event_0el3zk8">
+      <bpmn:incoming>Flow_11x8rdy</bpmn:incoming>
+      <bpmn:errorEventDefinition id="ErrorEventDefinition_16vp8au" errorRef="Error_035q7ey" />
+    </bpmn:endEvent>
+    <bpmn:exclusiveGateway id="Gateway_1adft3c">
+      <bpmn:incoming>Flow_0wkb4hq</bpmn:incoming>
+    </bpmn:exclusiveGateway>
+    <bpmn:textAnnotation id="TextAnnotation_092byka">
+      <bpmn:text>foo</bpmn:text>
+    </bpmn:textAnnotation>
+    <bpmn:association id="Association_07pskij" sourceRef="Activity_0tmvr8k" targetRef="TextAnnotation_092byka" />
+  </bpmn:process>
+  <bpmn:message id="Message_0inbjmp" name="Message_0inbjmp">
+    <bpmn:extensionElements>
+      <zeebe:subscription correlationKey="foo" />
+    </bpmn:extensionElements>
+  </bpmn:message>
+  <bpmn:error id="Error_035q7ey" name="Error_07ueecl" errorCode="foo" />
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Collaboration_013oh0t">
+      <bpmndi:BPMNShape id="Participant_1lhpzkq_di" bpmnElement="Participant_1lhpzkq" isHorizontal="true">
+        <dc:Bounds x="129" y="80" width="1601" height="488" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_11x8rdy_di" bpmnElement="Flow_11x8rdy">
+        <di:waypoint x="370" y="325" />
+        <di:waypoint x="370" y="500" />
+        <di:waypoint x="442" y="500" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0wkb4hq_di" bpmnElement="Flow_0wkb4hq">
+        <di:waypoint x="620" y="292" />
+        <di:waypoint x="620" y="380" />
+        <di:waypoint x="715" y="380" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1a5127t_di" bpmnElement="Flow_1a5127t">
+        <di:waypoint x="1180" y="380" />
+        <di:waypoint x="1220" y="380" />
+        <di:waypoint x="1220" y="490" />
+        <di:waypoint x="1262" y="490" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0uqdyxp_di" bpmnElement="Flow_0uqdyxp">
+        <di:waypoint x="998" y="380" />
+        <di:waypoint x="1080" y="380" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0k2v5e1_di" bpmnElement="Flow_0k2v5e1">
+        <di:waypoint x="1180" y="267" />
+        <di:waypoint x="1280" y="267" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1hk0gog_di" bpmnElement="Flow_1hk0gog">
+        <di:waypoint x="998" y="267" />
+        <di:waypoint x="1080" y="267" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1dj62p6_di" bpmnElement="Flow_1dj62p6">
+        <di:waypoint x="860" y="292" />
+        <di:waypoint x="860" y="380" />
+        <di:waypoint x="962" y="380" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0ozoxv7_di" bpmnElement="Flow_0ozoxv7">
+        <di:waypoint x="885" y="267" />
+        <di:waypoint x="962" y="267" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_13iwl91_di" bpmnElement="Flow_13iwl91">
+        <di:waypoint x="765" y="267" />
+        <di:waypoint x="835" y="267" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0aq3rml_di" bpmnElement="Flow_0aq3rml">
+        <di:waypoint x="645" y="267" />
+        <di:waypoint x="715" y="267" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1bj4q1g_di" bpmnElement="Flow_1bj4q1g">
+        <di:waypoint x="530" y="267" />
+        <di:waypoint x="595" y="267" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_04jud3f_di" bpmnElement="Flow_04jud3f">
+        <di:waypoint x="370" y="267" />
+        <di:waypoint x="430" y="267" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0av9in9_di" bpmnElement="Flow_0av9in9">
+        <di:waypoint x="370" y="325" />
+        <di:waypoint x="370" y="390" />
+        <di:waypoint x="442" y="390" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1c9prry_di" bpmnElement="Flow_1c9prry">
+        <di:waypoint x="215" y="267" />
+        <di:waypoint x="270" y="267" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="249" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_18wmzbb_di" bpmnElement="Activity_0tmvr8k">
+        <dc:Bounds x="270" y="227" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1vne73h_di" bpmnElement="Event_1vne73h">
+        <dc:Bounds x="442" y="372" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1wish8i_di" bpmnElement="Activity_19dosz4">
+        <dc:Bounds x="430" y="227" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_03oxb21_di" bpmnElement="Gateway_03oxb21" isMarkerVisible="true">
+        <dc:Bounds x="595" y="242" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0zdq4bc_di" bpmnElement="Gateway_1ee6i9s">
+        <dc:Bounds x="715" y="242" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0ov1azh_di" bpmnElement="Gateway_0v1y6l3">
+        <dc:Bounds x="835" y="242" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1xosfgb_di" bpmnElement="Event_1xosfgb">
+        <dc:Bounds x="962" y="249" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0cyp3nd_di" bpmnElement="Event_0cyp3nd">
+        <dc:Bounds x="962" y="362" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1sak8hk_di" bpmnElement="Activity_0v05780">
+        <dc:Bounds x="1080" y="227" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1fdzcmp_di" bpmnElement="Activity_18h7yic">
+        <dc:Bounds x="1080" y="340" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0gcrrhl_di" bpmnElement="Event_195u06h">
+        <dc:Bounds x="1262" y="472" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0wspz7j_di" bpmnElement="Gateway_1adft3c" isMarkerVisible="true">
+        <dc:Bounds x="715" y="355" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_09495yf_di" bpmnElement="Activity_09495yf" isExpanded="true">
+        <dc:Bounds x="1280" y="167" width="350" height="200" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0ijiazl_di" bpmnElement="Event_0ijiazl">
+        <dc:Bounds x="1320" y="249" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_16u5s1h_di" bpmnElement="Event_0el3zk8">
+        <dc:Bounds x="442" y="482" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="TextAnnotation_092byka_di" bpmnElement="TextAnnotation_092byka">
+        <dc:Bounds x="370" y="140" width="100" height="30" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0yhfoa2_di" bpmnElement="Event_1j12ud3">
+        <dc:Bounds x="352" y="289" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Association_07pskij_di" bpmnElement="Association_07pskij">
+        <di:waypoint x="356" y="227" />
+        <di:waypoint x="407" y="170" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/spec/camunda-cloud-1-1-invalid.bpmn
+++ b/test/spec/camunda-cloud-1-1-invalid.bpmn
@@ -1,0 +1,325 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1vc92ax" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.0.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="1.1.0">
+  <bpmn:collaboration id="Collaboration_013oh0t">
+    <bpmn:participant id="Participant_1lhpzkq" processRef="Process_07pko08" />
+  </bpmn:collaboration>
+  <bpmn:process id="Process_07pko08" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1c9prry</bpmn:outgoing>
+      <bpmn:outgoing>Flow_00dv1kp</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:serviceTask id="Activity_0tmvr8k" name="foo">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1c9prry</bpmn:incoming>
+      <bpmn:outgoing>Flow_04jud3f</bpmn:outgoing>
+      <bpmn:multiInstanceLoopCharacteristics>
+        <bpmn:extensionElements>
+          <zeebe:loopCharacteristics />
+        </bpmn:extensionElements>
+      </bpmn:multiInstanceLoopCharacteristics>
+    </bpmn:serviceTask>
+    <bpmn:endEvent id="Event_1vne73h">
+      <bpmn:incoming>Flow_0av9in9</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:callActivity id="Activity_19dosz4">
+      <bpmn:extensionElements>
+        <zeebe:calledElement propagateAllChildVariables="false" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_04jud3f</bpmn:incoming>
+      <bpmn:outgoing>Flow_1bj4q1g</bpmn:outgoing>
+    </bpmn:callActivity>
+    <bpmn:exclusiveGateway id="Gateway_03oxb21">
+      <bpmn:incoming>Flow_1bj4q1g</bpmn:incoming>
+      <bpmn:outgoing>Flow_0aq3rml</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0wkb4hq</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:parallelGateway id="Gateway_1ee6i9s">
+      <bpmn:incoming>Flow_0aq3rml</bpmn:incoming>
+      <bpmn:outgoing>Flow_13iwl91</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:eventBasedGateway id="Gateway_0v1y6l3">
+      <bpmn:incoming>Flow_13iwl91</bpmn:incoming>
+      <bpmn:outgoing>Flow_0ozoxv7</bpmn:outgoing>
+      <bpmn:outgoing>Flow_1dj62p6</bpmn:outgoing>
+    </bpmn:eventBasedGateway>
+    <bpmn:intermediateCatchEvent id="Event_1xosfgb">
+      <bpmn:incoming>Flow_0ozoxv7</bpmn:incoming>
+      <bpmn:outgoing>Flow_1hk0gog</bpmn:outgoing>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_1gucz9d" messageRef="Message_0inbjmp" />
+    </bpmn:intermediateCatchEvent>
+    <bpmn:intermediateCatchEvent id="Event_0cyp3nd">
+      <bpmn:incoming>Flow_1dj62p6</bpmn:incoming>
+      <bpmn:outgoing>Flow_0uqdyxp</bpmn:outgoing>
+      <bpmn:timerEventDefinition id="TimerEventDefinition_1vu1hns" />
+    </bpmn:intermediateCatchEvent>
+    <bpmn:receiveTask id="Activity_0v05780" name="bar">
+      <bpmn:incoming>Flow_1hk0gog</bpmn:incoming>
+      <bpmn:outgoing>Flow_0k2v5e1</bpmn:outgoing>
+    </bpmn:receiveTask>
+    <bpmn:userTask id="Activity_18h7yic">
+      <bpmn:incoming>Flow_0uqdyxp</bpmn:incoming>
+      <bpmn:outgoing>Flow_1a5127t</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:endEvent id="Event_195u06h">
+      <bpmn:incoming>Flow_1a5127t</bpmn:incoming>
+      <bpmn:errorEventDefinition id="ErrorEventDefinition_075l6v5" errorRef="Error_035q7ey" />
+    </bpmn:endEvent>
+    <bpmn:subProcess id="Activity_09495yf">
+      <bpmn:incoming>Flow_0k2v5e1</bpmn:incoming>
+      <bpmn:startEvent id="Event_0ijiazl">
+        <bpmn:outgoing>Flow_0ydr2ya</bpmn:outgoing>
+      </bpmn:startEvent>
+      <bpmn:sequenceFlow id="Flow_0ydr2ya" sourceRef="Event_0ijiazl" targetRef="Activity_15d1o2q" />
+      <bpmn:businessRuleTask id="Activity_15d1o2q">
+        <bpmn:extensionElements>
+          <zeebe:taskDefinition type="foo" />
+        </bpmn:extensionElements>
+        <bpmn:incoming>Flow_0ydr2ya</bpmn:incoming>
+      </bpmn:businessRuleTask>
+    </bpmn:subProcess>
+    <bpmn:boundaryEvent id="Event_1j12ud3" attachedToRef="Activity_0tmvr8k">
+      <bpmn:outgoing>Flow_0av9in9</bpmn:outgoing>
+      <bpmn:outgoing>Flow_11x8rdy</bpmn:outgoing>
+      <bpmn:errorEventDefinition id="ErrorEventDefinition_0cy2jeo" errorRef="Error_035q7ey" />
+    </bpmn:boundaryEvent>
+    <bpmn:sequenceFlow id="Flow_1c9prry" sourceRef="StartEvent_1" targetRef="Activity_0tmvr8k" />
+    <bpmn:sequenceFlow id="Flow_0av9in9" sourceRef="Event_1j12ud3" targetRef="Event_1vne73h" />
+    <bpmn:sequenceFlow id="Flow_04jud3f" sourceRef="Activity_0tmvr8k" targetRef="Activity_19dosz4" />
+    <bpmn:sequenceFlow id="Flow_1bj4q1g" sourceRef="Activity_19dosz4" targetRef="Gateway_03oxb21" />
+    <bpmn:sequenceFlow id="Flow_0aq3rml" sourceRef="Gateway_03oxb21" targetRef="Gateway_1ee6i9s" />
+    <bpmn:sequenceFlow id="Flow_13iwl91" sourceRef="Gateway_1ee6i9s" targetRef="Gateway_0v1y6l3" />
+    <bpmn:sequenceFlow id="Flow_0ozoxv7" sourceRef="Gateway_0v1y6l3" targetRef="Event_1xosfgb" />
+    <bpmn:sequenceFlow id="Flow_1dj62p6" sourceRef="Gateway_0v1y6l3" targetRef="Event_0cyp3nd" />
+    <bpmn:sequenceFlow id="Flow_1hk0gog" sourceRef="Event_1xosfgb" targetRef="Activity_0v05780" />
+    <bpmn:sequenceFlow id="Flow_0k2v5e1" sourceRef="Activity_0v05780" targetRef="Activity_09495yf" />
+    <bpmn:sequenceFlow id="Flow_0uqdyxp" sourceRef="Event_0cyp3nd" targetRef="Activity_18h7yic" />
+    <bpmn:sequenceFlow id="Flow_1a5127t" sourceRef="Activity_18h7yic" targetRef="Event_195u06h" />
+    <bpmn:complexGateway id="Gateway_1adft3c">
+      <bpmn:incoming>Flow_0wkb4hq</bpmn:incoming>
+      <bpmn:outgoing>Flow_1gvflfp</bpmn:outgoing>
+      <bpmn:outgoing>Flow_08k7vbr</bpmn:outgoing>
+    </bpmn:complexGateway>
+    <bpmn:sequenceFlow id="Flow_0wkb4hq" sourceRef="Gateway_03oxb21" targetRef="Gateway_1adft3c" />
+    <bpmn:sequenceFlow id="Flow_11x8rdy" sourceRef="Event_1j12ud3" targetRef="Event_0el3zk8" />
+    <bpmn:endEvent id="Event_0el3zk8">
+      <bpmn:incoming>Flow_11x8rdy</bpmn:incoming>
+      <bpmn:errorEventDefinition id="ErrorEventDefinition_16vp8au" />
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1gvflfp" sourceRef="Gateway_1adft3c" targetRef="Event_0ghtmm6" />
+    <bpmn:intermediateThrowEvent id="Event_0ghtmm6">
+      <bpmn:incoming>Flow_1gvflfp</bpmn:incoming>
+    </bpmn:intermediateThrowEvent>
+    <bpmn:sequenceFlow id="Flow_08k7vbr" sourceRef="Gateway_1adft3c" targetRef="Event_1fzuab7" />
+    <bpmn:intermediateCatchEvent id="Event_1fzuab7">
+      <bpmn:incoming>Flow_08k7vbr</bpmn:incoming>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_01kef5q" />
+    </bpmn:intermediateCatchEvent>
+    <bpmn:sequenceFlow id="Flow_00dv1kp" sourceRef="StartEvent_1" targetRef="Activity_1knqz62" />
+    <bpmn:manualTask id="Activity_1knqz62">
+      <bpmn:incoming>Flow_00dv1kp</bpmn:incoming>
+      <bpmn:outgoing>Flow_16pvdna</bpmn:outgoing>
+    </bpmn:manualTask>
+    <bpmn:sequenceFlow id="Flow_16pvdna" sourceRef="Activity_1knqz62" targetRef="Activity_1mxteew" />
+    <bpmn:scriptTask id="Activity_1mxteew">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="foo" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_16pvdna</bpmn:incoming>
+      <bpmn:outgoing>Flow_1c7yptg</bpmn:outgoing>
+    </bpmn:scriptTask>
+    <bpmn:sequenceFlow id="Flow_1c7yptg" sourceRef="Activity_1mxteew" targetRef="Activity_1d00s75" />
+    <bpmn:sendTask id="Activity_1d00s75">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="foo" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1c7yptg</bpmn:incoming>
+    </bpmn:sendTask>
+    <bpmn:textAnnotation id="TextAnnotation_092byka">
+      <bpmn:text>foo</bpmn:text>
+    </bpmn:textAnnotation>
+    <bpmn:association id="Association_07pskij" sourceRef="Activity_0tmvr8k" targetRef="TextAnnotation_092byka" />
+  </bpmn:process>
+  <bpmn:message id="Message_0inbjmp" name="Message_0inbjmp">
+    <bpmn:extensionElements>
+      <zeebe:subscription />
+    </bpmn:extensionElements>
+  </bpmn:message>
+  <bpmn:error id="Error_035q7ey" name="Error_07ueecl" errorCode="foo" />
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Collaboration_013oh0t">
+      <bpmndi:BPMNShape id="Participant_1lhpzkq_di" bpmnElement="Participant_1lhpzkq" isHorizontal="true">
+        <dc:Bounds x="129" y="80" width="1601" height="650" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1c7yptg_di" bpmnElement="Flow_1c7yptg">
+        <di:waypoint x="510" y="630" />
+        <di:waypoint x="560" y="630" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_16pvdna_di" bpmnElement="Flow_16pvdna">
+        <di:waypoint x="360" y="630" />
+        <di:waypoint x="410" y="630" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_00dv1kp_di" bpmnElement="Flow_00dv1kp">
+        <di:waypoint x="215" y="267" />
+        <di:waypoint x="240" y="267" />
+        <di:waypoint x="240" y="630" />
+        <di:waypoint x="260" y="630" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_08k7vbr_di" bpmnElement="Flow_08k7vbr">
+        <di:waypoint x="765" y="380" />
+        <di:waypoint x="860" y="380" />
+        <di:waypoint x="860" y="482" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1gvflfp_di" bpmnElement="Flow_1gvflfp">
+        <di:waypoint x="740" y="405" />
+        <di:waypoint x="740" y="482" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_11x8rdy_di" bpmnElement="Flow_11x8rdy">
+        <di:waypoint x="370" y="325" />
+        <di:waypoint x="370" y="500" />
+        <di:waypoint x="442" y="500" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0wkb4hq_di" bpmnElement="Flow_0wkb4hq">
+        <di:waypoint x="620" y="292" />
+        <di:waypoint x="620" y="380" />
+        <di:waypoint x="715" y="380" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1a5127t_di" bpmnElement="Flow_1a5127t">
+        <di:waypoint x="1180" y="380" />
+        <di:waypoint x="1220" y="380" />
+        <di:waypoint x="1220" y="490" />
+        <di:waypoint x="1262" y="490" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0uqdyxp_di" bpmnElement="Flow_0uqdyxp">
+        <di:waypoint x="998" y="380" />
+        <di:waypoint x="1080" y="380" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0k2v5e1_di" bpmnElement="Flow_0k2v5e1">
+        <di:waypoint x="1180" y="267" />
+        <di:waypoint x="1280" y="267" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1hk0gog_di" bpmnElement="Flow_1hk0gog">
+        <di:waypoint x="998" y="267" />
+        <di:waypoint x="1080" y="267" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1dj62p6_di" bpmnElement="Flow_1dj62p6">
+        <di:waypoint x="860" y="292" />
+        <di:waypoint x="860" y="380" />
+        <di:waypoint x="962" y="380" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0ozoxv7_di" bpmnElement="Flow_0ozoxv7">
+        <di:waypoint x="885" y="267" />
+        <di:waypoint x="962" y="267" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_13iwl91_di" bpmnElement="Flow_13iwl91">
+        <di:waypoint x="765" y="267" />
+        <di:waypoint x="835" y="267" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0aq3rml_di" bpmnElement="Flow_0aq3rml">
+        <di:waypoint x="645" y="267" />
+        <di:waypoint x="715" y="267" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1bj4q1g_di" bpmnElement="Flow_1bj4q1g">
+        <di:waypoint x="530" y="267" />
+        <di:waypoint x="595" y="267" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_04jud3f_di" bpmnElement="Flow_04jud3f">
+        <di:waypoint x="370" y="267" />
+        <di:waypoint x="430" y="267" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0av9in9_di" bpmnElement="Flow_0av9in9">
+        <di:waypoint x="370" y="325" />
+        <di:waypoint x="370" y="390" />
+        <di:waypoint x="442" y="390" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1c9prry_di" bpmnElement="Flow_1c9prry">
+        <di:waypoint x="215" y="267" />
+        <di:waypoint x="270" y="267" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="249" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_18wmzbb_di" bpmnElement="Activity_0tmvr8k">
+        <dc:Bounds x="270" y="227" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1vne73h_di" bpmnElement="Event_1vne73h">
+        <dc:Bounds x="442" y="372" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1wish8i_di" bpmnElement="Activity_19dosz4">
+        <dc:Bounds x="430" y="227" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_03oxb21_di" bpmnElement="Gateway_03oxb21" isMarkerVisible="true">
+        <dc:Bounds x="595" y="242" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0zdq4bc_di" bpmnElement="Gateway_1ee6i9s">
+        <dc:Bounds x="715" y="242" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0ov1azh_di" bpmnElement="Gateway_0v1y6l3">
+        <dc:Bounds x="835" y="242" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1xosfgb_di" bpmnElement="Event_1xosfgb">
+        <dc:Bounds x="962" y="249" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0cyp3nd_di" bpmnElement="Event_0cyp3nd">
+        <dc:Bounds x="962" y="362" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1sak8hk_di" bpmnElement="Activity_0v05780">
+        <dc:Bounds x="1080" y="227" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1fdzcmp_di" bpmnElement="Activity_18h7yic">
+        <dc:Bounds x="1080" y="340" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0gcrrhl_di" bpmnElement="Event_195u06h">
+        <dc:Bounds x="1262" y="472" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_09495yf_di" bpmnElement="Activity_09495yf" isExpanded="true">
+        <dc:Bounds x="1280" y="167" width="350" height="200" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0ydr2ya_di" bpmnElement="Flow_0ydr2ya">
+        <di:waypoint x="1356" y="267" />
+        <di:waypoint x="1410" y="267" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Event_0ijiazl_di" bpmnElement="Event_0ijiazl">
+        <dc:Bounds x="1320" y="249" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_08nc9km_di" bpmnElement="Activity_15d1o2q">
+        <dc:Bounds x="1410" y="227" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1adft3c_di" bpmnElement="Gateway_1adft3c" isMarkerVisible="true">
+        <dc:Bounds x="715" y="355" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_16u5s1h_di" bpmnElement="Event_0el3zk8">
+        <dc:Bounds x="442" y="482" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0hvr4ge_di" bpmnElement="Event_0ghtmm6">
+        <dc:Bounds x="722" y="482" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0200ml6_di" bpmnElement="Event_1fzuab7">
+        <dc:Bounds x="842" y="482" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0g9s8t2_di" bpmnElement="Activity_1knqz62">
+        <dc:Bounds x="260" y="590" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1sh1e8o_di" bpmnElement="Activity_1mxteew">
+        <dc:Bounds x="410" y="590" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0iuc6yg_di" bpmnElement="Activity_1d00s75">
+        <dc:Bounds x="560" y="590" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="TextAnnotation_092byka_di" bpmnElement="TextAnnotation_092byka">
+        <dc:Bounds x="370" y="140" width="100" height="30" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0yhfoa2_di" bpmnElement="Event_1j12ud3">
+        <dc:Bounds x="352" y="289" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Association_07pskij_di" bpmnElement="Association_07pskij">
+        <di:waypoint x="356" y="227" />
+        <di:waypoint x="407" y="170" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/spec/camunda-cloud-1-1-valid.bpmn
+++ b/test/spec/camunda-cloud-1-1-valid.bpmn
@@ -1,0 +1,330 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1vc92ax" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.0.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="1.1.0">
+  <bpmn:collaboration id="Collaboration_013oh0t">
+    <bpmn:participant id="Participant_1lhpzkq" processRef="Process_07pko08" />
+  </bpmn:collaboration>
+  <bpmn:process id="Process_07pko08" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1c9prry</bpmn:outgoing>
+      <bpmn:outgoing>Flow_00dv1kp</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:serviceTask id="Activity_0tmvr8k" name="foo">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="foo" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1c9prry</bpmn:incoming>
+      <bpmn:outgoing>Flow_04jud3f</bpmn:outgoing>
+      <bpmn:multiInstanceLoopCharacteristics>
+        <bpmn:extensionElements>
+          <zeebe:loopCharacteristics inputCollection="foo" />
+        </bpmn:extensionElements>
+      </bpmn:multiInstanceLoopCharacteristics>
+    </bpmn:serviceTask>
+    <bpmn:endEvent id="Event_1vne73h">
+      <bpmn:incoming>Flow_0av9in9</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:callActivity id="Activity_19dosz4">
+      <bpmn:extensionElements>
+        <zeebe:calledElement processId="foo" propagateAllChildVariables="false" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_04jud3f</bpmn:incoming>
+      <bpmn:outgoing>Flow_1bj4q1g</bpmn:outgoing>
+      <bpmn:multiInstanceLoopCharacteristics>
+        <bpmn:extensionElements>
+          <zeebe:loopCharacteristics inputCollection="foo" />
+        </bpmn:extensionElements>
+      </bpmn:multiInstanceLoopCharacteristics>
+    </bpmn:callActivity>
+    <bpmn:exclusiveGateway id="Gateway_03oxb21">
+      <bpmn:incoming>Flow_1bj4q1g</bpmn:incoming>
+      <bpmn:outgoing>Flow_0aq3rml</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0wkb4hq</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:parallelGateway id="Gateway_1ee6i9s">
+      <bpmn:incoming>Flow_0aq3rml</bpmn:incoming>
+      <bpmn:outgoing>Flow_13iwl91</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:eventBasedGateway id="Gateway_0v1y6l3">
+      <bpmn:incoming>Flow_13iwl91</bpmn:incoming>
+      <bpmn:outgoing>Flow_0ozoxv7</bpmn:outgoing>
+      <bpmn:outgoing>Flow_1dj62p6</bpmn:outgoing>
+    </bpmn:eventBasedGateway>
+    <bpmn:intermediateCatchEvent id="Event_1xosfgb">
+      <bpmn:incoming>Flow_0ozoxv7</bpmn:incoming>
+      <bpmn:outgoing>Flow_1hk0gog</bpmn:outgoing>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_1gucz9d" messageRef="Message_0inbjmp" />
+    </bpmn:intermediateCatchEvent>
+    <bpmn:intermediateCatchEvent id="Event_0cyp3nd">
+      <bpmn:incoming>Flow_1dj62p6</bpmn:incoming>
+      <bpmn:outgoing>Flow_0uqdyxp</bpmn:outgoing>
+      <bpmn:timerEventDefinition id="TimerEventDefinition_1vu1hns" />
+    </bpmn:intermediateCatchEvent>
+    <bpmn:receiveTask id="Activity_0v05780" name="bar" messageRef="Message_0inbjmp">
+      <bpmn:incoming>Flow_1hk0gog</bpmn:incoming>
+      <bpmn:outgoing>Flow_0k2v5e1</bpmn:outgoing>
+    </bpmn:receiveTask>
+    <bpmn:userTask id="Activity_18h7yic">
+      <bpmn:incoming>Flow_0uqdyxp</bpmn:incoming>
+      <bpmn:outgoing>Flow_1a5127t</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:endEvent id="Event_195u06h">
+      <bpmn:incoming>Flow_1a5127t</bpmn:incoming>
+      <bpmn:errorEventDefinition id="ErrorEventDefinition_075l6v5" errorRef="Error_035q7ey" />
+    </bpmn:endEvent>
+    <bpmn:subProcess id="Activity_09495yf">
+      <bpmn:incoming>Flow_0k2v5e1</bpmn:incoming>
+      <bpmn:startEvent id="Event_0ijiazl">
+        <bpmn:outgoing>Flow_0ydr2ya</bpmn:outgoing>
+      </bpmn:startEvent>
+      <bpmn:sequenceFlow id="Flow_0ydr2ya" sourceRef="Event_0ijiazl" targetRef="Activity_15d1o2q" />
+      <bpmn:businessRuleTask id="Activity_15d1o2q">
+        <bpmn:extensionElements>
+          <zeebe:taskDefinition type="foo" />
+        </bpmn:extensionElements>
+        <bpmn:incoming>Flow_0ydr2ya</bpmn:incoming>
+      </bpmn:businessRuleTask>
+    </bpmn:subProcess>
+    <bpmn:boundaryEvent id="Event_1j12ud3" attachedToRef="Activity_0tmvr8k">
+      <bpmn:outgoing>Flow_0av9in9</bpmn:outgoing>
+      <bpmn:outgoing>Flow_11x8rdy</bpmn:outgoing>
+      <bpmn:errorEventDefinition id="ErrorEventDefinition_0cy2jeo" errorRef="Error_035q7ey" />
+    </bpmn:boundaryEvent>
+    <bpmn:sequenceFlow id="Flow_1c9prry" sourceRef="StartEvent_1" targetRef="Activity_0tmvr8k" />
+    <bpmn:sequenceFlow id="Flow_0av9in9" sourceRef="Event_1j12ud3" targetRef="Event_1vne73h" />
+    <bpmn:sequenceFlow id="Flow_04jud3f" sourceRef="Activity_0tmvr8k" targetRef="Activity_19dosz4" />
+    <bpmn:sequenceFlow id="Flow_1bj4q1g" sourceRef="Activity_19dosz4" targetRef="Gateway_03oxb21" />
+    <bpmn:sequenceFlow id="Flow_0aq3rml" sourceRef="Gateway_03oxb21" targetRef="Gateway_1ee6i9s" />
+    <bpmn:sequenceFlow id="Flow_13iwl91" sourceRef="Gateway_1ee6i9s" targetRef="Gateway_0v1y6l3" />
+    <bpmn:sequenceFlow id="Flow_0ozoxv7" sourceRef="Gateway_0v1y6l3" targetRef="Event_1xosfgb" />
+    <bpmn:sequenceFlow id="Flow_1dj62p6" sourceRef="Gateway_0v1y6l3" targetRef="Event_0cyp3nd" />
+    <bpmn:sequenceFlow id="Flow_1hk0gog" sourceRef="Event_1xosfgb" targetRef="Activity_0v05780" />
+    <bpmn:sequenceFlow id="Flow_0k2v5e1" sourceRef="Activity_0v05780" targetRef="Activity_09495yf" />
+    <bpmn:sequenceFlow id="Flow_0uqdyxp" sourceRef="Event_0cyp3nd" targetRef="Activity_18h7yic" />
+    <bpmn:sequenceFlow id="Flow_1a5127t" sourceRef="Activity_18h7yic" targetRef="Event_195u06h" />
+    <bpmn:sequenceFlow id="Flow_0wkb4hq" sourceRef="Gateway_03oxb21" targetRef="Gateway_1adft3c" />
+    <bpmn:sequenceFlow id="Flow_11x8rdy" sourceRef="Event_1j12ud3" targetRef="Event_0el3zk8" />
+    <bpmn:endEvent id="Event_0el3zk8">
+      <bpmn:incoming>Flow_11x8rdy</bpmn:incoming>
+      <bpmn:errorEventDefinition id="ErrorEventDefinition_16vp8au" errorRef="Error_035q7ey" />
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1gvflfp" sourceRef="Gateway_1adft3c" targetRef="Event_0ghtmm6" />
+    <bpmn:intermediateThrowEvent id="Event_0ghtmm6">
+      <bpmn:incoming>Flow_1gvflfp</bpmn:incoming>
+    </bpmn:intermediateThrowEvent>
+    <bpmn:sequenceFlow id="Flow_08k7vbr" sourceRef="Gateway_1adft3c" targetRef="Event_1fzuab7" />
+    <bpmn:intermediateCatchEvent id="Event_1fzuab7">
+      <bpmn:incoming>Flow_08k7vbr</bpmn:incoming>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_01kef5q" messageRef="Message_0inbjmp" />
+    </bpmn:intermediateCatchEvent>
+    <bpmn:sequenceFlow id="Flow_00dv1kp" sourceRef="StartEvent_1" targetRef="Activity_1knqz62" />
+    <bpmn:manualTask id="Activity_1knqz62">
+      <bpmn:incoming>Flow_00dv1kp</bpmn:incoming>
+      <bpmn:outgoing>Flow_16pvdna</bpmn:outgoing>
+    </bpmn:manualTask>
+    <bpmn:sequenceFlow id="Flow_16pvdna" sourceRef="Activity_1knqz62" targetRef="Activity_1mxteew" />
+    <bpmn:scriptTask id="Activity_1mxteew">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="foo" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_16pvdna</bpmn:incoming>
+      <bpmn:outgoing>Flow_1c7yptg</bpmn:outgoing>
+    </bpmn:scriptTask>
+    <bpmn:sequenceFlow id="Flow_1c7yptg" sourceRef="Activity_1mxteew" targetRef="Activity_1d00s75" />
+    <bpmn:sendTask id="Activity_1d00s75">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="foo" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1c7yptg</bpmn:incoming>
+    </bpmn:sendTask>
+    <bpmn:exclusiveGateway id="Gateway_1adft3c">
+      <bpmn:incoming>Flow_0wkb4hq</bpmn:incoming>
+      <bpmn:outgoing>Flow_1gvflfp</bpmn:outgoing>
+      <bpmn:outgoing>Flow_08k7vbr</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:textAnnotation id="TextAnnotation_092byka">
+      <bpmn:text>foo</bpmn:text>
+    </bpmn:textAnnotation>
+    <bpmn:association id="Association_07pskij" sourceRef="Activity_0tmvr8k" targetRef="TextAnnotation_092byka" />
+  </bpmn:process>
+  <bpmn:message id="Message_0inbjmp" name="Message_0inbjmp">
+    <bpmn:extensionElements>
+      <zeebe:subscription correlationKey="foo" />
+    </bpmn:extensionElements>
+  </bpmn:message>
+  <bpmn:error id="Error_035q7ey" name="Error_07ueecl" errorCode="foo" />
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Collaboration_013oh0t">
+      <bpmndi:BPMNShape id="Participant_1lhpzkq_di" bpmnElement="Participant_1lhpzkq" isHorizontal="true">
+        <dc:Bounds x="129" y="80" width="1601" height="650" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_11x8rdy_di" bpmnElement="Flow_11x8rdy">
+        <di:waypoint x="370" y="325" />
+        <di:waypoint x="370" y="500" />
+        <di:waypoint x="442" y="500" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0wkb4hq_di" bpmnElement="Flow_0wkb4hq">
+        <di:waypoint x="620" y="292" />
+        <di:waypoint x="620" y="380" />
+        <di:waypoint x="715" y="380" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1a5127t_di" bpmnElement="Flow_1a5127t">
+        <di:waypoint x="1180" y="380" />
+        <di:waypoint x="1220" y="380" />
+        <di:waypoint x="1220" y="490" />
+        <di:waypoint x="1262" y="490" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0uqdyxp_di" bpmnElement="Flow_0uqdyxp">
+        <di:waypoint x="998" y="380" />
+        <di:waypoint x="1080" y="380" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0k2v5e1_di" bpmnElement="Flow_0k2v5e1">
+        <di:waypoint x="1180" y="267" />
+        <di:waypoint x="1280" y="267" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1hk0gog_di" bpmnElement="Flow_1hk0gog">
+        <di:waypoint x="998" y="267" />
+        <di:waypoint x="1080" y="267" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1dj62p6_di" bpmnElement="Flow_1dj62p6">
+        <di:waypoint x="860" y="292" />
+        <di:waypoint x="860" y="380" />
+        <di:waypoint x="962" y="380" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0ozoxv7_di" bpmnElement="Flow_0ozoxv7">
+        <di:waypoint x="885" y="267" />
+        <di:waypoint x="962" y="267" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_13iwl91_di" bpmnElement="Flow_13iwl91">
+        <di:waypoint x="765" y="267" />
+        <di:waypoint x="835" y="267" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0aq3rml_di" bpmnElement="Flow_0aq3rml">
+        <di:waypoint x="645" y="267" />
+        <di:waypoint x="715" y="267" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1bj4q1g_di" bpmnElement="Flow_1bj4q1g">
+        <di:waypoint x="530" y="267" />
+        <di:waypoint x="595" y="267" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_04jud3f_di" bpmnElement="Flow_04jud3f">
+        <di:waypoint x="370" y="267" />
+        <di:waypoint x="430" y="267" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0av9in9_di" bpmnElement="Flow_0av9in9">
+        <di:waypoint x="370" y="325" />
+        <di:waypoint x="370" y="390" />
+        <di:waypoint x="442" y="390" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1c9prry_di" bpmnElement="Flow_1c9prry">
+        <di:waypoint x="215" y="267" />
+        <di:waypoint x="270" y="267" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1gvflfp_di" bpmnElement="Flow_1gvflfp">
+        <di:waypoint x="740" y="405" />
+        <di:waypoint x="740" y="482" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_08k7vbr_di" bpmnElement="Flow_08k7vbr">
+        <di:waypoint x="765" y="380" />
+        <di:waypoint x="860" y="380" />
+        <di:waypoint x="860" y="482" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_00dv1kp_di" bpmnElement="Flow_00dv1kp">
+        <di:waypoint x="215" y="267" />
+        <di:waypoint x="240" y="267" />
+        <di:waypoint x="240" y="630" />
+        <di:waypoint x="260" y="630" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_16pvdna_di" bpmnElement="Flow_16pvdna">
+        <di:waypoint x="360" y="630" />
+        <di:waypoint x="410" y="630" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1c7yptg_di" bpmnElement="Flow_1c7yptg">
+        <di:waypoint x="510" y="630" />
+        <di:waypoint x="560" y="630" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="249" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_18wmzbb_di" bpmnElement="Activity_0tmvr8k">
+        <dc:Bounds x="270" y="227" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1vne73h_di" bpmnElement="Event_1vne73h">
+        <dc:Bounds x="442" y="372" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1wish8i_di" bpmnElement="Activity_19dosz4">
+        <dc:Bounds x="430" y="227" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_03oxb21_di" bpmnElement="Gateway_03oxb21" isMarkerVisible="true">
+        <dc:Bounds x="595" y="242" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0zdq4bc_di" bpmnElement="Gateway_1ee6i9s">
+        <dc:Bounds x="715" y="242" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0ov1azh_di" bpmnElement="Gateway_0v1y6l3">
+        <dc:Bounds x="835" y="242" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1xosfgb_di" bpmnElement="Event_1xosfgb">
+        <dc:Bounds x="962" y="249" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0cyp3nd_di" bpmnElement="Event_0cyp3nd">
+        <dc:Bounds x="962" y="362" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1sak8hk_di" bpmnElement="Activity_0v05780">
+        <dc:Bounds x="1080" y="227" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1fdzcmp_di" bpmnElement="Activity_18h7yic">
+        <dc:Bounds x="1080" y="340" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0gcrrhl_di" bpmnElement="Event_195u06h">
+        <dc:Bounds x="1262" y="472" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0hvr4ge_di" bpmnElement="Event_0ghtmm6">
+        <dc:Bounds x="722" y="482" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0200ml6_di" bpmnElement="Event_1fzuab7">
+        <dc:Bounds x="842" y="482" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0g9s8t2_di" bpmnElement="Activity_1knqz62">
+        <dc:Bounds x="260" y="590" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1sh1e8o_di" bpmnElement="Activity_1mxteew">
+        <dc:Bounds x="410" y="590" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0iuc6yg_di" bpmnElement="Activity_1d00s75">
+        <dc:Bounds x="560" y="590" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0ip8bt6_di" bpmnElement="Gateway_1adft3c" isMarkerVisible="true">
+        <dc:Bounds x="715" y="355" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_09495yf_di" bpmnElement="Activity_09495yf" isExpanded="true">
+        <dc:Bounds x="1280" y="167" width="350" height="200" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0ydr2ya_di" bpmnElement="Flow_0ydr2ya">
+        <di:waypoint x="1356" y="267" />
+        <di:waypoint x="1410" y="267" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Event_0ijiazl_di" bpmnElement="Event_0ijiazl">
+        <dc:Bounds x="1320" y="249" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_08nc9km_di" bpmnElement="Activity_15d1o2q">
+        <dc:Bounds x="1410" y="227" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_16u5s1h_di" bpmnElement="Event_0el3zk8">
+        <dc:Bounds x="442" y="482" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="TextAnnotation_092byka_di" bpmnElement="TextAnnotation_092byka">
+        <dc:Bounds x="370" y="140" width="100" height="30" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0yhfoa2_di" bpmnElement="Event_1j12ud3">
+        <dc:Bounds x="352" y="289" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Association_07pskij_di" bpmnElement="Association_07pskij">
+        <di:waypoint x="356" y="227" />
+        <di:waypoint x="407" y="170" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/spec/camunda-cloud-1-2-invalid.bpmn
+++ b/test/spec/camunda-cloud-1-2-invalid.bpmn
@@ -1,0 +1,352 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1vc92ax" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.0.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="1.2.0">
+  <bpmn:collaboration id="Collaboration_013oh0t">
+    <bpmn:participant id="Participant_1lhpzkq" processRef="Process_07pko08" />
+  </bpmn:collaboration>
+  <bpmn:process id="Process_07pko08" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1c9prry</bpmn:outgoing>
+      <bpmn:outgoing>Flow_00dv1kp</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:serviceTask id="Activity_0tmvr8k" name="foo">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1c9prry</bpmn:incoming>
+      <bpmn:outgoing>Flow_04jud3f</bpmn:outgoing>
+      <bpmn:multiInstanceLoopCharacteristics>
+        <bpmn:extensionElements>
+          <zeebe:loopCharacteristics />
+        </bpmn:extensionElements>
+      </bpmn:multiInstanceLoopCharacteristics>
+    </bpmn:serviceTask>
+    <bpmn:endEvent id="Event_1vne73h">
+      <bpmn:incoming>Flow_0av9in9</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:callActivity id="Activity_19dosz4">
+      <bpmn:extensionElements>
+        <zeebe:calledElement propagateAllChildVariables="false" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_04jud3f</bpmn:incoming>
+      <bpmn:outgoing>Flow_1bj4q1g</bpmn:outgoing>
+    </bpmn:callActivity>
+    <bpmn:exclusiveGateway id="Gateway_03oxb21">
+      <bpmn:incoming>Flow_1bj4q1g</bpmn:incoming>
+      <bpmn:outgoing>Flow_0aq3rml</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0wkb4hq</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:parallelGateway id="Gateway_1ee6i9s">
+      <bpmn:incoming>Flow_0aq3rml</bpmn:incoming>
+      <bpmn:outgoing>Flow_13iwl91</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:eventBasedGateway id="Gateway_0v1y6l3">
+      <bpmn:incoming>Flow_13iwl91</bpmn:incoming>
+      <bpmn:outgoing>Flow_0ozoxv7</bpmn:outgoing>
+      <bpmn:outgoing>Flow_1dj62p6</bpmn:outgoing>
+    </bpmn:eventBasedGateway>
+    <bpmn:intermediateCatchEvent id="Event_1xosfgb">
+      <bpmn:incoming>Flow_0ozoxv7</bpmn:incoming>
+      <bpmn:outgoing>Flow_1hk0gog</bpmn:outgoing>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_1gucz9d" messageRef="Message_0inbjmp" />
+    </bpmn:intermediateCatchEvent>
+    <bpmn:intermediateCatchEvent id="Event_0cyp3nd">
+      <bpmn:incoming>Flow_1dj62p6</bpmn:incoming>
+      <bpmn:outgoing>Flow_0uqdyxp</bpmn:outgoing>
+      <bpmn:timerEventDefinition id="TimerEventDefinition_1vu1hns" />
+    </bpmn:intermediateCatchEvent>
+    <bpmn:receiveTask id="Activity_0v05780" name="bar">
+      <bpmn:incoming>Flow_1hk0gog</bpmn:incoming>
+      <bpmn:outgoing>Flow_0k2v5e1</bpmn:outgoing>
+    </bpmn:receiveTask>
+    <bpmn:userTask id="Activity_18h7yic">
+      <bpmn:incoming>Flow_0uqdyxp</bpmn:incoming>
+      <bpmn:outgoing>Flow_1a5127t</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:endEvent id="Event_195u06h">
+      <bpmn:incoming>Flow_1a5127t</bpmn:incoming>
+      <bpmn:errorEventDefinition id="ErrorEventDefinition_075l6v5" errorRef="Error_035q7ey" />
+    </bpmn:endEvent>
+    <bpmn:subProcess id="Activity_09495yf">
+      <bpmn:incoming>Flow_0k2v5e1</bpmn:incoming>
+      <bpmn:startEvent id="Event_0ijiazl">
+        <bpmn:outgoing>Flow_0ydr2ya</bpmn:outgoing>
+      </bpmn:startEvent>
+      <bpmn:sequenceFlow id="Flow_0ydr2ya" sourceRef="Event_0ijiazl" targetRef="Activity_15d1o2q" />
+      <bpmn:businessRuleTask id="Activity_15d1o2q">
+        <bpmn:extensionElements>
+          <zeebe:taskDefinition type="foo" />
+        </bpmn:extensionElements>
+        <bpmn:incoming>Flow_0ydr2ya</bpmn:incoming>
+      </bpmn:businessRuleTask>
+    </bpmn:subProcess>
+    <bpmn:boundaryEvent id="Event_1j12ud3" attachedToRef="Activity_0tmvr8k">
+      <bpmn:outgoing>Flow_0av9in9</bpmn:outgoing>
+      <bpmn:outgoing>Flow_11x8rdy</bpmn:outgoing>
+      <bpmn:errorEventDefinition id="ErrorEventDefinition_0cy2jeo" errorRef="Error_035q7ey" />
+    </bpmn:boundaryEvent>
+    <bpmn:sequenceFlow id="Flow_1c9prry" sourceRef="StartEvent_1" targetRef="Activity_0tmvr8k" />
+    <bpmn:sequenceFlow id="Flow_0av9in9" sourceRef="Event_1j12ud3" targetRef="Event_1vne73h" />
+    <bpmn:sequenceFlow id="Flow_04jud3f" sourceRef="Activity_0tmvr8k" targetRef="Activity_19dosz4" />
+    <bpmn:sequenceFlow id="Flow_1bj4q1g" sourceRef="Activity_19dosz4" targetRef="Gateway_03oxb21" />
+    <bpmn:sequenceFlow id="Flow_0aq3rml" sourceRef="Gateway_03oxb21" targetRef="Gateway_1ee6i9s" />
+    <bpmn:sequenceFlow id="Flow_13iwl91" sourceRef="Gateway_1ee6i9s" targetRef="Gateway_0v1y6l3" />
+    <bpmn:sequenceFlow id="Flow_0ozoxv7" sourceRef="Gateway_0v1y6l3" targetRef="Event_1xosfgb" />
+    <bpmn:sequenceFlow id="Flow_1dj62p6" sourceRef="Gateway_0v1y6l3" targetRef="Event_0cyp3nd" />
+    <bpmn:sequenceFlow id="Flow_1hk0gog" sourceRef="Event_1xosfgb" targetRef="Activity_0v05780" />
+    <bpmn:sequenceFlow id="Flow_0k2v5e1" sourceRef="Activity_0v05780" targetRef="Activity_09495yf" />
+    <bpmn:sequenceFlow id="Flow_0uqdyxp" sourceRef="Event_0cyp3nd" targetRef="Activity_18h7yic" />
+    <bpmn:sequenceFlow id="Flow_1a5127t" sourceRef="Activity_18h7yic" targetRef="Event_195u06h" />
+    <bpmn:complexGateway id="Gateway_1adft3c">
+      <bpmn:incoming>Flow_0wkb4hq</bpmn:incoming>
+      <bpmn:outgoing>Flow_1gvflfp</bpmn:outgoing>
+      <bpmn:outgoing>Flow_08k7vbr</bpmn:outgoing>
+      <bpmn:outgoing>Flow_19rqft2</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0n84ml1</bpmn:outgoing>
+    </bpmn:complexGateway>
+    <bpmn:sequenceFlow id="Flow_0wkb4hq" sourceRef="Gateway_03oxb21" targetRef="Gateway_1adft3c" />
+    <bpmn:sequenceFlow id="Flow_11x8rdy" sourceRef="Event_1j12ud3" targetRef="Event_0el3zk8" />
+    <bpmn:endEvent id="Event_0el3zk8">
+      <bpmn:incoming>Flow_11x8rdy</bpmn:incoming>
+      <bpmn:errorEventDefinition id="ErrorEventDefinition_16vp8au" />
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1gvflfp" sourceRef="Gateway_1adft3c" targetRef="Event_0ghtmm6" />
+    <bpmn:intermediateThrowEvent id="Event_0ghtmm6">
+      <bpmn:incoming>Flow_1gvflfp</bpmn:incoming>
+    </bpmn:intermediateThrowEvent>
+    <bpmn:sequenceFlow id="Flow_08k7vbr" sourceRef="Gateway_1adft3c" targetRef="Event_1fzuab7" />
+    <bpmn:intermediateCatchEvent id="Event_1fzuab7">
+      <bpmn:incoming>Flow_08k7vbr</bpmn:incoming>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_01kef5q" />
+    </bpmn:intermediateCatchEvent>
+    <bpmn:sequenceFlow id="Flow_00dv1kp" sourceRef="StartEvent_1" targetRef="Activity_1knqz62" />
+    <bpmn:manualTask id="Activity_1knqz62">
+      <bpmn:incoming>Flow_00dv1kp</bpmn:incoming>
+      <bpmn:outgoing>Flow_16pvdna</bpmn:outgoing>
+    </bpmn:manualTask>
+    <bpmn:sequenceFlow id="Flow_16pvdna" sourceRef="Activity_1knqz62" targetRef="Activity_1mxteew" />
+    <bpmn:scriptTask id="Activity_1mxteew">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="foo" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_16pvdna</bpmn:incoming>
+      <bpmn:outgoing>Flow_1c7yptg</bpmn:outgoing>
+    </bpmn:scriptTask>
+    <bpmn:sequenceFlow id="Flow_1c7yptg" sourceRef="Activity_1mxteew" targetRef="Activity_1d00s75" />
+    <bpmn:sendTask id="Activity_1d00s75">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="foo" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1c7yptg</bpmn:incoming>
+    </bpmn:sendTask>
+    <bpmn:sequenceFlow id="Flow_19rqft2" sourceRef="Gateway_1adft3c" targetRef="Event_0s4ygc1" />
+    <bpmn:intermediateThrowEvent id="Event_0s4ygc1">
+      <bpmn:incoming>Flow_19rqft2</bpmn:incoming>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_1odggmr" />
+    </bpmn:intermediateThrowEvent>
+    <bpmn:sequenceFlow id="Flow_0n84ml1" sourceRef="Gateway_1adft3c" targetRef="Event_1yqxsot" />
+    <bpmn:endEvent id="Event_1yqxsot">
+      <bpmn:incoming>Flow_0n84ml1</bpmn:incoming>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_04t0675" />
+    </bpmn:endEvent>
+    <bpmn:textAnnotation id="TextAnnotation_092byka">
+      <bpmn:text>foo</bpmn:text>
+    </bpmn:textAnnotation>
+    <bpmn:association id="Association_07pskij" sourceRef="Activity_0tmvr8k" targetRef="TextAnnotation_092byka" />
+  </bpmn:process>
+  <bpmn:message id="Message_0inbjmp" name="Message_0inbjmp">
+    <bpmn:extensionElements>
+      <zeebe:subscription />
+    </bpmn:extensionElements>
+  </bpmn:message>
+  <bpmn:error id="Error_035q7ey" name="Error_07ueecl" errorCode="foo" />
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Collaboration_013oh0t">
+      <bpmndi:BPMNShape id="Participant_1lhpzkq_di" bpmnElement="Participant_1lhpzkq" isHorizontal="true">
+        <dc:Bounds x="129" y="80" width="1601" height="650" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0n84ml1_di" bpmnElement="Flow_0n84ml1">
+        <di:waypoint x="740" y="405" />
+        <di:waypoint x="740" y="630" />
+        <di:waypoint x="842" y="630" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_19rqft2_di" bpmnElement="Flow_19rqft2">
+        <di:waypoint x="740" y="405" />
+        <di:waypoint x="740" y="612" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1c7yptg_di" bpmnElement="Flow_1c7yptg">
+        <di:waypoint x="510" y="630" />
+        <di:waypoint x="560" y="630" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_16pvdna_di" bpmnElement="Flow_16pvdna">
+        <di:waypoint x="360" y="630" />
+        <di:waypoint x="410" y="630" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_00dv1kp_di" bpmnElement="Flow_00dv1kp">
+        <di:waypoint x="215" y="267" />
+        <di:waypoint x="240" y="267" />
+        <di:waypoint x="240" y="630" />
+        <di:waypoint x="260" y="630" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_08k7vbr_di" bpmnElement="Flow_08k7vbr">
+        <di:waypoint x="765" y="380" />
+        <di:waypoint x="860" y="380" />
+        <di:waypoint x="860" y="482" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1gvflfp_di" bpmnElement="Flow_1gvflfp">
+        <di:waypoint x="740" y="405" />
+        <di:waypoint x="740" y="482" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_11x8rdy_di" bpmnElement="Flow_11x8rdy">
+        <di:waypoint x="370" y="325" />
+        <di:waypoint x="370" y="500" />
+        <di:waypoint x="442" y="500" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0wkb4hq_di" bpmnElement="Flow_0wkb4hq">
+        <di:waypoint x="620" y="292" />
+        <di:waypoint x="620" y="380" />
+        <di:waypoint x="715" y="380" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1a5127t_di" bpmnElement="Flow_1a5127t">
+        <di:waypoint x="1180" y="380" />
+        <di:waypoint x="1220" y="380" />
+        <di:waypoint x="1220" y="490" />
+        <di:waypoint x="1262" y="490" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0uqdyxp_di" bpmnElement="Flow_0uqdyxp">
+        <di:waypoint x="998" y="380" />
+        <di:waypoint x="1080" y="380" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0k2v5e1_di" bpmnElement="Flow_0k2v5e1">
+        <di:waypoint x="1180" y="267" />
+        <di:waypoint x="1280" y="267" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1hk0gog_di" bpmnElement="Flow_1hk0gog">
+        <di:waypoint x="998" y="267" />
+        <di:waypoint x="1080" y="267" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1dj62p6_di" bpmnElement="Flow_1dj62p6">
+        <di:waypoint x="860" y="292" />
+        <di:waypoint x="860" y="380" />
+        <di:waypoint x="962" y="380" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0ozoxv7_di" bpmnElement="Flow_0ozoxv7">
+        <di:waypoint x="885" y="267" />
+        <di:waypoint x="962" y="267" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_13iwl91_di" bpmnElement="Flow_13iwl91">
+        <di:waypoint x="765" y="267" />
+        <di:waypoint x="835" y="267" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0aq3rml_di" bpmnElement="Flow_0aq3rml">
+        <di:waypoint x="645" y="267" />
+        <di:waypoint x="715" y="267" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1bj4q1g_di" bpmnElement="Flow_1bj4q1g">
+        <di:waypoint x="530" y="267" />
+        <di:waypoint x="595" y="267" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_04jud3f_di" bpmnElement="Flow_04jud3f">
+        <di:waypoint x="370" y="267" />
+        <di:waypoint x="430" y="267" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0av9in9_di" bpmnElement="Flow_0av9in9">
+        <di:waypoint x="370" y="325" />
+        <di:waypoint x="370" y="390" />
+        <di:waypoint x="442" y="390" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1c9prry_di" bpmnElement="Flow_1c9prry">
+        <di:waypoint x="215" y="267" />
+        <di:waypoint x="270" y="267" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="249" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_18wmzbb_di" bpmnElement="Activity_0tmvr8k">
+        <dc:Bounds x="270" y="227" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1vne73h_di" bpmnElement="Event_1vne73h">
+        <dc:Bounds x="442" y="372" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1wish8i_di" bpmnElement="Activity_19dosz4">
+        <dc:Bounds x="430" y="227" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_03oxb21_di" bpmnElement="Gateway_03oxb21" isMarkerVisible="true">
+        <dc:Bounds x="595" y="242" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0zdq4bc_di" bpmnElement="Gateway_1ee6i9s">
+        <dc:Bounds x="715" y="242" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0ov1azh_di" bpmnElement="Gateway_0v1y6l3">
+        <dc:Bounds x="835" y="242" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1xosfgb_di" bpmnElement="Event_1xosfgb">
+        <dc:Bounds x="962" y="249" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0cyp3nd_di" bpmnElement="Event_0cyp3nd">
+        <dc:Bounds x="962" y="362" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1sak8hk_di" bpmnElement="Activity_0v05780">
+        <dc:Bounds x="1080" y="227" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1fdzcmp_di" bpmnElement="Activity_18h7yic">
+        <dc:Bounds x="1080" y="340" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0gcrrhl_di" bpmnElement="Event_195u06h">
+        <dc:Bounds x="1262" y="472" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_09495yf_di" bpmnElement="Activity_09495yf" isExpanded="true">
+        <dc:Bounds x="1280" y="167" width="350" height="200" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0ydr2ya_di" bpmnElement="Flow_0ydr2ya">
+        <di:waypoint x="1356" y="267" />
+        <di:waypoint x="1410" y="267" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Event_0ijiazl_di" bpmnElement="Event_0ijiazl">
+        <dc:Bounds x="1320" y="249" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_08nc9km_di" bpmnElement="Activity_15d1o2q">
+        <dc:Bounds x="1410" y="227" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1adft3c_di" bpmnElement="Gateway_1adft3c" isMarkerVisible="true">
+        <dc:Bounds x="715" y="355" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_16u5s1h_di" bpmnElement="Event_0el3zk8">
+        <dc:Bounds x="442" y="482" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0hvr4ge_di" bpmnElement="Event_0ghtmm6">
+        <dc:Bounds x="722" y="482" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0200ml6_di" bpmnElement="Event_1fzuab7">
+        <dc:Bounds x="842" y="482" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0g9s8t2_di" bpmnElement="Activity_1knqz62">
+        <dc:Bounds x="260" y="590" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1sh1e8o_di" bpmnElement="Activity_1mxteew">
+        <dc:Bounds x="410" y="590" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0iuc6yg_di" bpmnElement="Activity_1d00s75">
+        <dc:Bounds x="560" y="590" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_13yl25e_di" bpmnElement="Event_0s4ygc1">
+        <dc:Bounds x="722" y="612" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1deoy07_di" bpmnElement="Event_1yqxsot">
+        <dc:Bounds x="842" y="612" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="TextAnnotation_092byka_di" bpmnElement="TextAnnotation_092byka">
+        <dc:Bounds x="370" y="140" width="100" height="30" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0yhfoa2_di" bpmnElement="Event_1j12ud3">
+        <dc:Bounds x="352" y="289" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Association_07pskij_di" bpmnElement="Association_07pskij">
+        <di:waypoint x="356" y="227" />
+        <di:waypoint x="407" y="170" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/spec/camunda-cloud-1-2-valid.bpmn
+++ b/test/spec/camunda-cloud-1-2-valid.bpmn
@@ -1,0 +1,360 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1vc92ax" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.0.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="1.2.0">
+  <bpmn:collaboration id="Collaboration_013oh0t">
+    <bpmn:participant id="Participant_1lhpzkq" processRef="Process_07pko08" />
+  </bpmn:collaboration>
+  <bpmn:process id="Process_07pko08" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1c9prry</bpmn:outgoing>
+      <bpmn:outgoing>Flow_00dv1kp</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:serviceTask id="Activity_0tmvr8k" name="foo">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="foo" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1c9prry</bpmn:incoming>
+      <bpmn:outgoing>Flow_04jud3f</bpmn:outgoing>
+      <bpmn:multiInstanceLoopCharacteristics>
+        <bpmn:extensionElements>
+          <zeebe:loopCharacteristics inputCollection="foo" />
+        </bpmn:extensionElements>
+      </bpmn:multiInstanceLoopCharacteristics>
+    </bpmn:serviceTask>
+    <bpmn:endEvent id="Event_1vne73h">
+      <bpmn:incoming>Flow_0av9in9</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:callActivity id="Activity_19dosz4">
+      <bpmn:extensionElements>
+        <zeebe:calledElement processId="foo" propagateAllChildVariables="false" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_04jud3f</bpmn:incoming>
+      <bpmn:outgoing>Flow_1bj4q1g</bpmn:outgoing>
+      <bpmn:multiInstanceLoopCharacteristics>
+        <bpmn:extensionElements>
+          <zeebe:loopCharacteristics inputCollection="foo" />
+        </bpmn:extensionElements>
+      </bpmn:multiInstanceLoopCharacteristics>
+    </bpmn:callActivity>
+    <bpmn:exclusiveGateway id="Gateway_03oxb21">
+      <bpmn:incoming>Flow_1bj4q1g</bpmn:incoming>
+      <bpmn:outgoing>Flow_0aq3rml</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0wkb4hq</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:parallelGateway id="Gateway_1ee6i9s">
+      <bpmn:incoming>Flow_0aq3rml</bpmn:incoming>
+      <bpmn:outgoing>Flow_13iwl91</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:eventBasedGateway id="Gateway_0v1y6l3">
+      <bpmn:incoming>Flow_13iwl91</bpmn:incoming>
+      <bpmn:outgoing>Flow_0ozoxv7</bpmn:outgoing>
+      <bpmn:outgoing>Flow_1dj62p6</bpmn:outgoing>
+    </bpmn:eventBasedGateway>
+    <bpmn:intermediateCatchEvent id="Event_1xosfgb">
+      <bpmn:incoming>Flow_0ozoxv7</bpmn:incoming>
+      <bpmn:outgoing>Flow_1hk0gog</bpmn:outgoing>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_1gucz9d" messageRef="Message_0inbjmp" />
+    </bpmn:intermediateCatchEvent>
+    <bpmn:intermediateCatchEvent id="Event_0cyp3nd">
+      <bpmn:incoming>Flow_1dj62p6</bpmn:incoming>
+      <bpmn:outgoing>Flow_0uqdyxp</bpmn:outgoing>
+      <bpmn:timerEventDefinition id="TimerEventDefinition_1vu1hns" />
+    </bpmn:intermediateCatchEvent>
+    <bpmn:receiveTask id="Activity_0v05780" name="bar" messageRef="Message_0inbjmp">
+      <bpmn:incoming>Flow_1hk0gog</bpmn:incoming>
+      <bpmn:outgoing>Flow_0k2v5e1</bpmn:outgoing>
+    </bpmn:receiveTask>
+    <bpmn:userTask id="Activity_18h7yic">
+      <bpmn:incoming>Flow_0uqdyxp</bpmn:incoming>
+      <bpmn:outgoing>Flow_1a5127t</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:endEvent id="Event_195u06h">
+      <bpmn:incoming>Flow_1a5127t</bpmn:incoming>
+      <bpmn:errorEventDefinition id="ErrorEventDefinition_075l6v5" errorRef="Error_035q7ey" />
+    </bpmn:endEvent>
+    <bpmn:subProcess id="Activity_09495yf">
+      <bpmn:incoming>Flow_0k2v5e1</bpmn:incoming>
+      <bpmn:startEvent id="Event_0ijiazl">
+        <bpmn:outgoing>Flow_0ydr2ya</bpmn:outgoing>
+      </bpmn:startEvent>
+      <bpmn:sequenceFlow id="Flow_0ydr2ya" sourceRef="Event_0ijiazl" targetRef="Activity_15d1o2q" />
+      <bpmn:businessRuleTask id="Activity_15d1o2q">
+        <bpmn:extensionElements>
+          <zeebe:taskDefinition type="foo" />
+        </bpmn:extensionElements>
+        <bpmn:incoming>Flow_0ydr2ya</bpmn:incoming>
+      </bpmn:businessRuleTask>
+    </bpmn:subProcess>
+    <bpmn:boundaryEvent id="Event_1j12ud3" attachedToRef="Activity_0tmvr8k">
+      <bpmn:outgoing>Flow_0av9in9</bpmn:outgoing>
+      <bpmn:outgoing>Flow_11x8rdy</bpmn:outgoing>
+      <bpmn:errorEventDefinition id="ErrorEventDefinition_0cy2jeo" errorRef="Error_035q7ey" />
+    </bpmn:boundaryEvent>
+    <bpmn:sequenceFlow id="Flow_1c9prry" sourceRef="StartEvent_1" targetRef="Activity_0tmvr8k" />
+    <bpmn:sequenceFlow id="Flow_0av9in9" sourceRef="Event_1j12ud3" targetRef="Event_1vne73h" />
+    <bpmn:sequenceFlow id="Flow_04jud3f" sourceRef="Activity_0tmvr8k" targetRef="Activity_19dosz4" />
+    <bpmn:sequenceFlow id="Flow_1bj4q1g" sourceRef="Activity_19dosz4" targetRef="Gateway_03oxb21" />
+    <bpmn:sequenceFlow id="Flow_0aq3rml" sourceRef="Gateway_03oxb21" targetRef="Gateway_1ee6i9s" />
+    <bpmn:sequenceFlow id="Flow_13iwl91" sourceRef="Gateway_1ee6i9s" targetRef="Gateway_0v1y6l3" />
+    <bpmn:sequenceFlow id="Flow_0ozoxv7" sourceRef="Gateway_0v1y6l3" targetRef="Event_1xosfgb" />
+    <bpmn:sequenceFlow id="Flow_1dj62p6" sourceRef="Gateway_0v1y6l3" targetRef="Event_0cyp3nd" />
+    <bpmn:sequenceFlow id="Flow_1hk0gog" sourceRef="Event_1xosfgb" targetRef="Activity_0v05780" />
+    <bpmn:sequenceFlow id="Flow_0k2v5e1" sourceRef="Activity_0v05780" targetRef="Activity_09495yf" />
+    <bpmn:sequenceFlow id="Flow_0uqdyxp" sourceRef="Event_0cyp3nd" targetRef="Activity_18h7yic" />
+    <bpmn:sequenceFlow id="Flow_1a5127t" sourceRef="Activity_18h7yic" targetRef="Event_195u06h" />
+    <bpmn:sequenceFlow id="Flow_0wkb4hq" sourceRef="Gateway_03oxb21" targetRef="Gateway_1adft3c" />
+    <bpmn:sequenceFlow id="Flow_11x8rdy" sourceRef="Event_1j12ud3" targetRef="Event_0el3zk8" />
+    <bpmn:endEvent id="Event_0el3zk8">
+      <bpmn:incoming>Flow_11x8rdy</bpmn:incoming>
+      <bpmn:errorEventDefinition id="ErrorEventDefinition_16vp8au" errorRef="Error_035q7ey" />
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1gvflfp" sourceRef="Gateway_1adft3c" targetRef="Event_0ghtmm6" />
+    <bpmn:intermediateThrowEvent id="Event_0ghtmm6">
+      <bpmn:incoming>Flow_1gvflfp</bpmn:incoming>
+    </bpmn:intermediateThrowEvent>
+    <bpmn:sequenceFlow id="Flow_08k7vbr" sourceRef="Gateway_1adft3c" targetRef="Event_1fzuab7" />
+    <bpmn:intermediateCatchEvent id="Event_1fzuab7">
+      <bpmn:incoming>Flow_08k7vbr</bpmn:incoming>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_01kef5q" messageRef="Message_0inbjmp" />
+    </bpmn:intermediateCatchEvent>
+    <bpmn:sequenceFlow id="Flow_00dv1kp" sourceRef="StartEvent_1" targetRef="Activity_1knqz62" />
+    <bpmn:manualTask id="Activity_1knqz62">
+      <bpmn:incoming>Flow_00dv1kp</bpmn:incoming>
+      <bpmn:outgoing>Flow_16pvdna</bpmn:outgoing>
+    </bpmn:manualTask>
+    <bpmn:sequenceFlow id="Flow_16pvdna" sourceRef="Activity_1knqz62" targetRef="Activity_1mxteew" />
+    <bpmn:scriptTask id="Activity_1mxteew">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="foo" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_16pvdna</bpmn:incoming>
+      <bpmn:outgoing>Flow_1c7yptg</bpmn:outgoing>
+    </bpmn:scriptTask>
+    <bpmn:sequenceFlow id="Flow_1c7yptg" sourceRef="Activity_1mxteew" targetRef="Activity_1d00s75" />
+    <bpmn:sendTask id="Activity_1d00s75">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="foo" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1c7yptg</bpmn:incoming>
+    </bpmn:sendTask>
+    <bpmn:sequenceFlow id="Flow_19rqft2" sourceRef="Gateway_1adft3c" targetRef="Event_0s4ygc1" />
+    <bpmn:intermediateThrowEvent id="Event_0s4ygc1">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="foo" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_19rqft2</bpmn:incoming>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_1odggmr" />
+    </bpmn:intermediateThrowEvent>
+    <bpmn:sequenceFlow id="Flow_0n84ml1" sourceRef="Gateway_1adft3c" targetRef="Event_1yqxsot" />
+    <bpmn:endEvent id="Event_1yqxsot">
+      <bpmn:incoming>Flow_0n84ml1</bpmn:incoming>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_04t0675" />
+    </bpmn:endEvent>
+    <bpmn:exclusiveGateway id="Gateway_1adft3c">
+      <bpmn:incoming>Flow_0wkb4hq</bpmn:incoming>
+      <bpmn:outgoing>Flow_1gvflfp</bpmn:outgoing>
+      <bpmn:outgoing>Flow_08k7vbr</bpmn:outgoing>
+      <bpmn:outgoing>Flow_19rqft2</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0n84ml1</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:textAnnotation id="TextAnnotation_092byka">
+      <bpmn:text>foo</bpmn:text>
+    </bpmn:textAnnotation>
+    <bpmn:association id="Association_07pskij" sourceRef="Activity_0tmvr8k" targetRef="TextAnnotation_092byka" />
+  </bpmn:process>
+  <bpmn:message id="Message_0inbjmp" name="Message_0inbjmp">
+    <bpmn:extensionElements>
+      <zeebe:subscription correlationKey="foo" />
+    </bpmn:extensionElements>
+  </bpmn:message>
+  <bpmn:error id="Error_035q7ey" name="Error_07ueecl" errorCode="foo" />
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Collaboration_013oh0t">
+      <bpmndi:BPMNShape id="Participant_1lhpzkq_di" bpmnElement="Participant_1lhpzkq" isHorizontal="true">
+        <dc:Bounds x="129" y="80" width="1601" height="650" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0n84ml1_di" bpmnElement="Flow_0n84ml1">
+        <di:waypoint x="740" y="405" />
+        <di:waypoint x="740" y="630" />
+        <di:waypoint x="842" y="630" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_19rqft2_di" bpmnElement="Flow_19rqft2">
+        <di:waypoint x="740" y="405" />
+        <di:waypoint x="740" y="612" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1c7yptg_di" bpmnElement="Flow_1c7yptg">
+        <di:waypoint x="510" y="630" />
+        <di:waypoint x="560" y="630" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_16pvdna_di" bpmnElement="Flow_16pvdna">
+        <di:waypoint x="360" y="630" />
+        <di:waypoint x="410" y="630" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_00dv1kp_di" bpmnElement="Flow_00dv1kp">
+        <di:waypoint x="215" y="267" />
+        <di:waypoint x="240" y="267" />
+        <di:waypoint x="240" y="630" />
+        <di:waypoint x="260" y="630" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_08k7vbr_di" bpmnElement="Flow_08k7vbr">
+        <di:waypoint x="765" y="380" />
+        <di:waypoint x="860" y="380" />
+        <di:waypoint x="860" y="482" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1gvflfp_di" bpmnElement="Flow_1gvflfp">
+        <di:waypoint x="740" y="405" />
+        <di:waypoint x="740" y="482" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_11x8rdy_di" bpmnElement="Flow_11x8rdy">
+        <di:waypoint x="370" y="325" />
+        <di:waypoint x="370" y="500" />
+        <di:waypoint x="442" y="500" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0wkb4hq_di" bpmnElement="Flow_0wkb4hq">
+        <di:waypoint x="620" y="292" />
+        <di:waypoint x="620" y="380" />
+        <di:waypoint x="715" y="380" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1a5127t_di" bpmnElement="Flow_1a5127t">
+        <di:waypoint x="1180" y="380" />
+        <di:waypoint x="1220" y="380" />
+        <di:waypoint x="1220" y="490" />
+        <di:waypoint x="1262" y="490" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0uqdyxp_di" bpmnElement="Flow_0uqdyxp">
+        <di:waypoint x="998" y="380" />
+        <di:waypoint x="1080" y="380" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0k2v5e1_di" bpmnElement="Flow_0k2v5e1">
+        <di:waypoint x="1180" y="267" />
+        <di:waypoint x="1280" y="267" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1hk0gog_di" bpmnElement="Flow_1hk0gog">
+        <di:waypoint x="998" y="267" />
+        <di:waypoint x="1080" y="267" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1dj62p6_di" bpmnElement="Flow_1dj62p6">
+        <di:waypoint x="860" y="292" />
+        <di:waypoint x="860" y="380" />
+        <di:waypoint x="962" y="380" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0ozoxv7_di" bpmnElement="Flow_0ozoxv7">
+        <di:waypoint x="885" y="267" />
+        <di:waypoint x="962" y="267" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_13iwl91_di" bpmnElement="Flow_13iwl91">
+        <di:waypoint x="765" y="267" />
+        <di:waypoint x="835" y="267" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0aq3rml_di" bpmnElement="Flow_0aq3rml">
+        <di:waypoint x="645" y="267" />
+        <di:waypoint x="715" y="267" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1bj4q1g_di" bpmnElement="Flow_1bj4q1g">
+        <di:waypoint x="530" y="267" />
+        <di:waypoint x="595" y="267" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_04jud3f_di" bpmnElement="Flow_04jud3f">
+        <di:waypoint x="370" y="267" />
+        <di:waypoint x="430" y="267" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0av9in9_di" bpmnElement="Flow_0av9in9">
+        <di:waypoint x="370" y="325" />
+        <di:waypoint x="370" y="390" />
+        <di:waypoint x="442" y="390" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1c9prry_di" bpmnElement="Flow_1c9prry">
+        <di:waypoint x="215" y="267" />
+        <di:waypoint x="270" y="267" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="249" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_18wmzbb_di" bpmnElement="Activity_0tmvr8k">
+        <dc:Bounds x="270" y="227" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1vne73h_di" bpmnElement="Event_1vne73h">
+        <dc:Bounds x="442" y="372" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1wish8i_di" bpmnElement="Activity_19dosz4">
+        <dc:Bounds x="430" y="227" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_03oxb21_di" bpmnElement="Gateway_03oxb21" isMarkerVisible="true">
+        <dc:Bounds x="595" y="242" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0zdq4bc_di" bpmnElement="Gateway_1ee6i9s">
+        <dc:Bounds x="715" y="242" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0ov1azh_di" bpmnElement="Gateway_0v1y6l3">
+        <dc:Bounds x="835" y="242" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1xosfgb_di" bpmnElement="Event_1xosfgb">
+        <dc:Bounds x="962" y="249" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0cyp3nd_di" bpmnElement="Event_0cyp3nd">
+        <dc:Bounds x="962" y="362" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1sak8hk_di" bpmnElement="Activity_0v05780">
+        <dc:Bounds x="1080" y="227" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1fdzcmp_di" bpmnElement="Activity_18h7yic">
+        <dc:Bounds x="1080" y="340" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0gcrrhl_di" bpmnElement="Event_195u06h">
+        <dc:Bounds x="1262" y="472" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0la55ct_di" bpmnElement="Gateway_1adft3c" isMarkerVisible="true">
+        <dc:Bounds x="715" y="355" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_09495yf_di" bpmnElement="Activity_09495yf" isExpanded="true">
+        <dc:Bounds x="1280" y="167" width="350" height="200" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0ydr2ya_di" bpmnElement="Flow_0ydr2ya">
+        <di:waypoint x="1356" y="267" />
+        <di:waypoint x="1410" y="267" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Event_0ijiazl_di" bpmnElement="Event_0ijiazl">
+        <dc:Bounds x="1320" y="249" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_08nc9km_di" bpmnElement="Activity_15d1o2q">
+        <dc:Bounds x="1410" y="227" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_16u5s1h_di" bpmnElement="Event_0el3zk8">
+        <dc:Bounds x="442" y="482" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0hvr4ge_di" bpmnElement="Event_0ghtmm6">
+        <dc:Bounds x="722" y="482" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0200ml6_di" bpmnElement="Event_1fzuab7">
+        <dc:Bounds x="842" y="482" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0g9s8t2_di" bpmnElement="Activity_1knqz62">
+        <dc:Bounds x="260" y="590" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1sh1e8o_di" bpmnElement="Activity_1mxteew">
+        <dc:Bounds x="410" y="590" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0iuc6yg_di" bpmnElement="Activity_1d00s75">
+        <dc:Bounds x="560" y="590" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_13yl25e_di" bpmnElement="Event_0s4ygc1">
+        <dc:Bounds x="722" y="612" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1deoy07_di" bpmnElement="Event_1yqxsot">
+        <dc:Bounds x="842" y="612" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="TextAnnotation_092byka_di" bpmnElement="TextAnnotation_092byka">
+        <dc:Bounds x="370" y="140" width="100" height="30" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0yhfoa2_di" bpmnElement="Event_1j12ud3">
+        <dc:Bounds x="352" y="289" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Association_07pskij_di" bpmnElement="Association_07pskij">
+        <di:waypoint x="356" y="227" />
+        <di:waypoint x="407" y="170" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/spec/camunda-cloud-1-3-invalid.bpmn
+++ b/test/spec/camunda-cloud-1-3-invalid.bpmn
@@ -1,0 +1,350 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1vc92ax" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.0.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="1.3.0">
+  <bpmn:collaboration id="Collaboration_013oh0t">
+    <bpmn:participant id="Participant_1lhpzkq" processRef="Process_07pko08" />
+  </bpmn:collaboration>
+  <bpmn:process id="Process_07pko08" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1c9prry</bpmn:outgoing>
+      <bpmn:outgoing>Flow_00dv1kp</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:serviceTask id="Activity_0tmvr8k" name="foo">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1c9prry</bpmn:incoming>
+      <bpmn:outgoing>Flow_04jud3f</bpmn:outgoing>
+      <bpmn:multiInstanceLoopCharacteristics>
+        <bpmn:extensionElements>
+          <zeebe:loopCharacteristics />
+        </bpmn:extensionElements>
+      </bpmn:multiInstanceLoopCharacteristics>
+    </bpmn:serviceTask>
+    <bpmn:endEvent id="Event_1vne73h">
+      <bpmn:incoming>Flow_0av9in9</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:callActivity id="Activity_19dosz4">
+      <bpmn:extensionElements>
+        <zeebe:calledElement propagateAllChildVariables="false" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_04jud3f</bpmn:incoming>
+      <bpmn:outgoing>Flow_1bj4q1g</bpmn:outgoing>
+    </bpmn:callActivity>
+    <bpmn:exclusiveGateway id="Gateway_03oxb21">
+      <bpmn:incoming>Flow_1bj4q1g</bpmn:incoming>
+      <bpmn:outgoing>Flow_0aq3rml</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0wkb4hq</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:parallelGateway id="Gateway_1ee6i9s">
+      <bpmn:incoming>Flow_0aq3rml</bpmn:incoming>
+      <bpmn:outgoing>Flow_13iwl91</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:eventBasedGateway id="Gateway_0v1y6l3">
+      <bpmn:incoming>Flow_13iwl91</bpmn:incoming>
+      <bpmn:outgoing>Flow_0ozoxv7</bpmn:outgoing>
+      <bpmn:outgoing>Flow_1dj62p6</bpmn:outgoing>
+    </bpmn:eventBasedGateway>
+    <bpmn:intermediateCatchEvent id="Event_1xosfgb">
+      <bpmn:incoming>Flow_0ozoxv7</bpmn:incoming>
+      <bpmn:outgoing>Flow_1hk0gog</bpmn:outgoing>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_1gucz9d" messageRef="Message_0inbjmp" />
+    </bpmn:intermediateCatchEvent>
+    <bpmn:intermediateCatchEvent id="Event_0cyp3nd">
+      <bpmn:incoming>Flow_1dj62p6</bpmn:incoming>
+      <bpmn:outgoing>Flow_0uqdyxp</bpmn:outgoing>
+      <bpmn:timerEventDefinition id="TimerEventDefinition_1vu1hns" />
+    </bpmn:intermediateCatchEvent>
+    <bpmn:receiveTask id="Activity_0v05780" name="bar">
+      <bpmn:incoming>Flow_1hk0gog</bpmn:incoming>
+      <bpmn:outgoing>Flow_0k2v5e1</bpmn:outgoing>
+    </bpmn:receiveTask>
+    <bpmn:userTask id="Activity_18h7yic">
+      <bpmn:incoming>Flow_0uqdyxp</bpmn:incoming>
+      <bpmn:outgoing>Flow_1a5127t</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:endEvent id="Event_195u06h">
+      <bpmn:incoming>Flow_1a5127t</bpmn:incoming>
+      <bpmn:errorEventDefinition id="ErrorEventDefinition_075l6v5" errorRef="Error_035q7ey" />
+    </bpmn:endEvent>
+    <bpmn:subProcess id="Activity_09495yf">
+      <bpmn:incoming>Flow_0k2v5e1</bpmn:incoming>
+      <bpmn:startEvent id="Event_0ijiazl">
+        <bpmn:outgoing>Flow_0ydr2ya</bpmn:outgoing>
+      </bpmn:startEvent>
+      <bpmn:sequenceFlow id="Flow_0ydr2ya" sourceRef="Event_0ijiazl" targetRef="Activity_15d1o2q" />
+      <bpmn:businessRuleTask id="Activity_15d1o2q">
+        <bpmn:extensionElements />
+        <bpmn:incoming>Flow_0ydr2ya</bpmn:incoming>
+      </bpmn:businessRuleTask>
+    </bpmn:subProcess>
+    <bpmn:boundaryEvent id="Event_1j12ud3" attachedToRef="Activity_0tmvr8k">
+      <bpmn:outgoing>Flow_0av9in9</bpmn:outgoing>
+      <bpmn:outgoing>Flow_11x8rdy</bpmn:outgoing>
+      <bpmn:errorEventDefinition id="ErrorEventDefinition_0cy2jeo" errorRef="Error_035q7ey" />
+    </bpmn:boundaryEvent>
+    <bpmn:sequenceFlow id="Flow_1c9prry" sourceRef="StartEvent_1" targetRef="Activity_0tmvr8k" />
+    <bpmn:sequenceFlow id="Flow_0av9in9" sourceRef="Event_1j12ud3" targetRef="Event_1vne73h" />
+    <bpmn:sequenceFlow id="Flow_04jud3f" sourceRef="Activity_0tmvr8k" targetRef="Activity_19dosz4" />
+    <bpmn:sequenceFlow id="Flow_1bj4q1g" sourceRef="Activity_19dosz4" targetRef="Gateway_03oxb21" />
+    <bpmn:sequenceFlow id="Flow_0aq3rml" sourceRef="Gateway_03oxb21" targetRef="Gateway_1ee6i9s" />
+    <bpmn:sequenceFlow id="Flow_13iwl91" sourceRef="Gateway_1ee6i9s" targetRef="Gateway_0v1y6l3" />
+    <bpmn:sequenceFlow id="Flow_0ozoxv7" sourceRef="Gateway_0v1y6l3" targetRef="Event_1xosfgb" />
+    <bpmn:sequenceFlow id="Flow_1dj62p6" sourceRef="Gateway_0v1y6l3" targetRef="Event_0cyp3nd" />
+    <bpmn:sequenceFlow id="Flow_1hk0gog" sourceRef="Event_1xosfgb" targetRef="Activity_0v05780" />
+    <bpmn:sequenceFlow id="Flow_0k2v5e1" sourceRef="Activity_0v05780" targetRef="Activity_09495yf" />
+    <bpmn:sequenceFlow id="Flow_0uqdyxp" sourceRef="Event_0cyp3nd" targetRef="Activity_18h7yic" />
+    <bpmn:sequenceFlow id="Flow_1a5127t" sourceRef="Activity_18h7yic" targetRef="Event_195u06h" />
+    <bpmn:complexGateway id="Gateway_1adft3c">
+      <bpmn:incoming>Flow_0wkb4hq</bpmn:incoming>
+      <bpmn:outgoing>Flow_1gvflfp</bpmn:outgoing>
+      <bpmn:outgoing>Flow_08k7vbr</bpmn:outgoing>
+      <bpmn:outgoing>Flow_19rqft2</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0n84ml1</bpmn:outgoing>
+    </bpmn:complexGateway>
+    <bpmn:sequenceFlow id="Flow_0wkb4hq" sourceRef="Gateway_03oxb21" targetRef="Gateway_1adft3c" />
+    <bpmn:sequenceFlow id="Flow_11x8rdy" sourceRef="Event_1j12ud3" targetRef="Event_0el3zk8" />
+    <bpmn:endEvent id="Event_0el3zk8">
+      <bpmn:incoming>Flow_11x8rdy</bpmn:incoming>
+      <bpmn:errorEventDefinition id="ErrorEventDefinition_16vp8au" />
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1gvflfp" sourceRef="Gateway_1adft3c" targetRef="Event_0ghtmm6" />
+    <bpmn:intermediateThrowEvent id="Event_0ghtmm6">
+      <bpmn:incoming>Flow_1gvflfp</bpmn:incoming>
+    </bpmn:intermediateThrowEvent>
+    <bpmn:sequenceFlow id="Flow_08k7vbr" sourceRef="Gateway_1adft3c" targetRef="Event_1fzuab7" />
+    <bpmn:intermediateCatchEvent id="Event_1fzuab7">
+      <bpmn:incoming>Flow_08k7vbr</bpmn:incoming>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_01kef5q" />
+    </bpmn:intermediateCatchEvent>
+    <bpmn:sequenceFlow id="Flow_00dv1kp" sourceRef="StartEvent_1" targetRef="Activity_1knqz62" />
+    <bpmn:manualTask id="Activity_1knqz62">
+      <bpmn:incoming>Flow_00dv1kp</bpmn:incoming>
+      <bpmn:outgoing>Flow_16pvdna</bpmn:outgoing>
+    </bpmn:manualTask>
+    <bpmn:sequenceFlow id="Flow_16pvdna" sourceRef="Activity_1knqz62" targetRef="Activity_1mxteew" />
+    <bpmn:scriptTask id="Activity_1mxteew">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="foo" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_16pvdna</bpmn:incoming>
+      <bpmn:outgoing>Flow_1c7yptg</bpmn:outgoing>
+    </bpmn:scriptTask>
+    <bpmn:sequenceFlow id="Flow_1c7yptg" sourceRef="Activity_1mxteew" targetRef="Activity_1d00s75" />
+    <bpmn:sendTask id="Activity_1d00s75">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="foo" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1c7yptg</bpmn:incoming>
+    </bpmn:sendTask>
+    <bpmn:sequenceFlow id="Flow_19rqft2" sourceRef="Gateway_1adft3c" targetRef="Event_0s4ygc1" />
+    <bpmn:intermediateThrowEvent id="Event_0s4ygc1">
+      <bpmn:incoming>Flow_19rqft2</bpmn:incoming>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_1odggmr" />
+    </bpmn:intermediateThrowEvent>
+    <bpmn:sequenceFlow id="Flow_0n84ml1" sourceRef="Gateway_1adft3c" targetRef="Event_1yqxsot" />
+    <bpmn:endEvent id="Event_1yqxsot">
+      <bpmn:incoming>Flow_0n84ml1</bpmn:incoming>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_04t0675" />
+    </bpmn:endEvent>
+    <bpmn:textAnnotation id="TextAnnotation_092byka">
+      <bpmn:text>foo</bpmn:text>
+    </bpmn:textAnnotation>
+    <bpmn:association id="Association_07pskij" sourceRef="Activity_0tmvr8k" targetRef="TextAnnotation_092byka" />
+  </bpmn:process>
+  <bpmn:message id="Message_0inbjmp" name="Message_0inbjmp">
+    <bpmn:extensionElements>
+      <zeebe:subscription />
+    </bpmn:extensionElements>
+  </bpmn:message>
+  <bpmn:error id="Error_035q7ey" name="Error_07ueecl" errorCode="foo" />
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Collaboration_013oh0t">
+      <bpmndi:BPMNShape id="Participant_1lhpzkq_di" bpmnElement="Participant_1lhpzkq" isHorizontal="true">
+        <dc:Bounds x="129" y="80" width="1601" height="650" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0n84ml1_di" bpmnElement="Flow_0n84ml1">
+        <di:waypoint x="740" y="405" />
+        <di:waypoint x="740" y="630" />
+        <di:waypoint x="842" y="630" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_19rqft2_di" bpmnElement="Flow_19rqft2">
+        <di:waypoint x="740" y="405" />
+        <di:waypoint x="740" y="612" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1c7yptg_di" bpmnElement="Flow_1c7yptg">
+        <di:waypoint x="510" y="630" />
+        <di:waypoint x="560" y="630" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_16pvdna_di" bpmnElement="Flow_16pvdna">
+        <di:waypoint x="360" y="630" />
+        <di:waypoint x="410" y="630" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_00dv1kp_di" bpmnElement="Flow_00dv1kp">
+        <di:waypoint x="215" y="267" />
+        <di:waypoint x="240" y="267" />
+        <di:waypoint x="240" y="630" />
+        <di:waypoint x="260" y="630" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_08k7vbr_di" bpmnElement="Flow_08k7vbr">
+        <di:waypoint x="765" y="380" />
+        <di:waypoint x="860" y="380" />
+        <di:waypoint x="860" y="482" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1gvflfp_di" bpmnElement="Flow_1gvflfp">
+        <di:waypoint x="740" y="405" />
+        <di:waypoint x="740" y="482" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_11x8rdy_di" bpmnElement="Flow_11x8rdy">
+        <di:waypoint x="370" y="325" />
+        <di:waypoint x="370" y="500" />
+        <di:waypoint x="442" y="500" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0wkb4hq_di" bpmnElement="Flow_0wkb4hq">
+        <di:waypoint x="620" y="292" />
+        <di:waypoint x="620" y="380" />
+        <di:waypoint x="715" y="380" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1a5127t_di" bpmnElement="Flow_1a5127t">
+        <di:waypoint x="1180" y="380" />
+        <di:waypoint x="1220" y="380" />
+        <di:waypoint x="1220" y="490" />
+        <di:waypoint x="1262" y="490" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0uqdyxp_di" bpmnElement="Flow_0uqdyxp">
+        <di:waypoint x="998" y="380" />
+        <di:waypoint x="1080" y="380" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0k2v5e1_di" bpmnElement="Flow_0k2v5e1">
+        <di:waypoint x="1180" y="267" />
+        <di:waypoint x="1280" y="267" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1hk0gog_di" bpmnElement="Flow_1hk0gog">
+        <di:waypoint x="998" y="267" />
+        <di:waypoint x="1080" y="267" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1dj62p6_di" bpmnElement="Flow_1dj62p6">
+        <di:waypoint x="860" y="292" />
+        <di:waypoint x="860" y="380" />
+        <di:waypoint x="962" y="380" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0ozoxv7_di" bpmnElement="Flow_0ozoxv7">
+        <di:waypoint x="885" y="267" />
+        <di:waypoint x="962" y="267" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_13iwl91_di" bpmnElement="Flow_13iwl91">
+        <di:waypoint x="765" y="267" />
+        <di:waypoint x="835" y="267" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0aq3rml_di" bpmnElement="Flow_0aq3rml">
+        <di:waypoint x="645" y="267" />
+        <di:waypoint x="715" y="267" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1bj4q1g_di" bpmnElement="Flow_1bj4q1g">
+        <di:waypoint x="530" y="267" />
+        <di:waypoint x="595" y="267" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_04jud3f_di" bpmnElement="Flow_04jud3f">
+        <di:waypoint x="370" y="267" />
+        <di:waypoint x="430" y="267" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0av9in9_di" bpmnElement="Flow_0av9in9">
+        <di:waypoint x="370" y="325" />
+        <di:waypoint x="370" y="390" />
+        <di:waypoint x="442" y="390" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1c9prry_di" bpmnElement="Flow_1c9prry">
+        <di:waypoint x="215" y="267" />
+        <di:waypoint x="270" y="267" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="249" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_18wmzbb_di" bpmnElement="Activity_0tmvr8k">
+        <dc:Bounds x="270" y="227" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1vne73h_di" bpmnElement="Event_1vne73h">
+        <dc:Bounds x="442" y="372" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1wish8i_di" bpmnElement="Activity_19dosz4">
+        <dc:Bounds x="430" y="227" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_03oxb21_di" bpmnElement="Gateway_03oxb21" isMarkerVisible="true">
+        <dc:Bounds x="595" y="242" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0zdq4bc_di" bpmnElement="Gateway_1ee6i9s">
+        <dc:Bounds x="715" y="242" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0ov1azh_di" bpmnElement="Gateway_0v1y6l3">
+        <dc:Bounds x="835" y="242" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1xosfgb_di" bpmnElement="Event_1xosfgb">
+        <dc:Bounds x="962" y="249" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0cyp3nd_di" bpmnElement="Event_0cyp3nd">
+        <dc:Bounds x="962" y="362" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1sak8hk_di" bpmnElement="Activity_0v05780">
+        <dc:Bounds x="1080" y="227" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1fdzcmp_di" bpmnElement="Activity_18h7yic">
+        <dc:Bounds x="1080" y="340" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0gcrrhl_di" bpmnElement="Event_195u06h">
+        <dc:Bounds x="1262" y="472" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_09495yf_di" bpmnElement="Activity_09495yf" isExpanded="true">
+        <dc:Bounds x="1280" y="167" width="350" height="200" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0ydr2ya_di" bpmnElement="Flow_0ydr2ya">
+        <di:waypoint x="1356" y="267" />
+        <di:waypoint x="1410" y="267" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Event_0ijiazl_di" bpmnElement="Event_0ijiazl">
+        <dc:Bounds x="1320" y="249" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_08nc9km_di" bpmnElement="Activity_15d1o2q">
+        <dc:Bounds x="1410" y="227" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1adft3c_di" bpmnElement="Gateway_1adft3c" isMarkerVisible="true">
+        <dc:Bounds x="715" y="355" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_16u5s1h_di" bpmnElement="Event_0el3zk8">
+        <dc:Bounds x="442" y="482" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0hvr4ge_di" bpmnElement="Event_0ghtmm6">
+        <dc:Bounds x="722" y="482" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0200ml6_di" bpmnElement="Event_1fzuab7">
+        <dc:Bounds x="842" y="482" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0g9s8t2_di" bpmnElement="Activity_1knqz62">
+        <dc:Bounds x="260" y="590" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1sh1e8o_di" bpmnElement="Activity_1mxteew">
+        <dc:Bounds x="410" y="590" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0iuc6yg_di" bpmnElement="Activity_1d00s75">
+        <dc:Bounds x="560" y="590" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_13yl25e_di" bpmnElement="Event_0s4ygc1">
+        <dc:Bounds x="722" y="612" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1deoy07_di" bpmnElement="Event_1yqxsot">
+        <dc:Bounds x="842" y="612" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="TextAnnotation_092byka_di" bpmnElement="TextAnnotation_092byka">
+        <dc:Bounds x="370" y="140" width="100" height="30" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0yhfoa2_di" bpmnElement="Event_1j12ud3">
+        <dc:Bounds x="352" y="289" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Association_07pskij_di" bpmnElement="Association_07pskij">
+        <di:waypoint x="356" y="227" />
+        <di:waypoint x="407" y="170" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/spec/camunda-cloud-1-3-valid.bpmn
+++ b/test/spec/camunda-cloud-1-3-valid.bpmn
@@ -1,0 +1,360 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1vc92ax" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.0.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="1.3.0">
+  <bpmn:collaboration id="Collaboration_013oh0t">
+    <bpmn:participant id="Participant_1lhpzkq" processRef="Process_07pko08" />
+  </bpmn:collaboration>
+  <bpmn:process id="Process_07pko08" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1c9prry</bpmn:outgoing>
+      <bpmn:outgoing>Flow_00dv1kp</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:serviceTask id="Activity_0tmvr8k" name="foo">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="foo" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1c9prry</bpmn:incoming>
+      <bpmn:outgoing>Flow_04jud3f</bpmn:outgoing>
+      <bpmn:multiInstanceLoopCharacteristics>
+        <bpmn:extensionElements>
+          <zeebe:loopCharacteristics inputCollection="foo" />
+        </bpmn:extensionElements>
+      </bpmn:multiInstanceLoopCharacteristics>
+    </bpmn:serviceTask>
+    <bpmn:endEvent id="Event_1vne73h">
+      <bpmn:incoming>Flow_0av9in9</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:callActivity id="Activity_19dosz4">
+      <bpmn:extensionElements>
+        <zeebe:calledElement processId="foo" propagateAllChildVariables="false" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_04jud3f</bpmn:incoming>
+      <bpmn:outgoing>Flow_1bj4q1g</bpmn:outgoing>
+      <bpmn:multiInstanceLoopCharacteristics>
+        <bpmn:extensionElements>
+          <zeebe:loopCharacteristics inputCollection="foo" />
+        </bpmn:extensionElements>
+      </bpmn:multiInstanceLoopCharacteristics>
+    </bpmn:callActivity>
+    <bpmn:exclusiveGateway id="Gateway_03oxb21">
+      <bpmn:incoming>Flow_1bj4q1g</bpmn:incoming>
+      <bpmn:outgoing>Flow_0aq3rml</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0wkb4hq</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:parallelGateway id="Gateway_1ee6i9s">
+      <bpmn:incoming>Flow_0aq3rml</bpmn:incoming>
+      <bpmn:outgoing>Flow_13iwl91</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:eventBasedGateway id="Gateway_0v1y6l3">
+      <bpmn:incoming>Flow_13iwl91</bpmn:incoming>
+      <bpmn:outgoing>Flow_0ozoxv7</bpmn:outgoing>
+      <bpmn:outgoing>Flow_1dj62p6</bpmn:outgoing>
+    </bpmn:eventBasedGateway>
+    <bpmn:intermediateCatchEvent id="Event_1xosfgb">
+      <bpmn:incoming>Flow_0ozoxv7</bpmn:incoming>
+      <bpmn:outgoing>Flow_1hk0gog</bpmn:outgoing>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_1gucz9d" messageRef="Message_0inbjmp" />
+    </bpmn:intermediateCatchEvent>
+    <bpmn:intermediateCatchEvent id="Event_0cyp3nd">
+      <bpmn:incoming>Flow_1dj62p6</bpmn:incoming>
+      <bpmn:outgoing>Flow_0uqdyxp</bpmn:outgoing>
+      <bpmn:timerEventDefinition id="TimerEventDefinition_1vu1hns" />
+    </bpmn:intermediateCatchEvent>
+    <bpmn:receiveTask id="Activity_0v05780" name="bar" messageRef="Message_0inbjmp">
+      <bpmn:incoming>Flow_1hk0gog</bpmn:incoming>
+      <bpmn:outgoing>Flow_0k2v5e1</bpmn:outgoing>
+    </bpmn:receiveTask>
+    <bpmn:userTask id="Activity_18h7yic">
+      <bpmn:incoming>Flow_0uqdyxp</bpmn:incoming>
+      <bpmn:outgoing>Flow_1a5127t</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:endEvent id="Event_195u06h">
+      <bpmn:incoming>Flow_1a5127t</bpmn:incoming>
+      <bpmn:errorEventDefinition id="ErrorEventDefinition_075l6v5" errorRef="Error_035q7ey" />
+    </bpmn:endEvent>
+    <bpmn:subProcess id="Activity_09495yf">
+      <bpmn:incoming>Flow_0k2v5e1</bpmn:incoming>
+      <bpmn:startEvent id="Event_0ijiazl">
+        <bpmn:outgoing>Flow_0ydr2ya</bpmn:outgoing>
+      </bpmn:startEvent>
+      <bpmn:sequenceFlow id="Flow_0ydr2ya" sourceRef="Event_0ijiazl" targetRef="Activity_15d1o2q" />
+      <bpmn:businessRuleTask id="Activity_15d1o2q">
+        <bpmn:extensionElements>
+          <zeebe:calledDecision decisionId="foo" resultVariable="bar" />
+        </bpmn:extensionElements>
+        <bpmn:incoming>Flow_0ydr2ya</bpmn:incoming>
+      </bpmn:businessRuleTask>
+    </bpmn:subProcess>
+    <bpmn:boundaryEvent id="Event_1j12ud3" attachedToRef="Activity_0tmvr8k">
+      <bpmn:outgoing>Flow_0av9in9</bpmn:outgoing>
+      <bpmn:outgoing>Flow_11x8rdy</bpmn:outgoing>
+      <bpmn:errorEventDefinition id="ErrorEventDefinition_0cy2jeo" errorRef="Error_035q7ey" />
+    </bpmn:boundaryEvent>
+    <bpmn:sequenceFlow id="Flow_1c9prry" sourceRef="StartEvent_1" targetRef="Activity_0tmvr8k" />
+    <bpmn:sequenceFlow id="Flow_0av9in9" sourceRef="Event_1j12ud3" targetRef="Event_1vne73h" />
+    <bpmn:sequenceFlow id="Flow_04jud3f" sourceRef="Activity_0tmvr8k" targetRef="Activity_19dosz4" />
+    <bpmn:sequenceFlow id="Flow_1bj4q1g" sourceRef="Activity_19dosz4" targetRef="Gateway_03oxb21" />
+    <bpmn:sequenceFlow id="Flow_0aq3rml" sourceRef="Gateway_03oxb21" targetRef="Gateway_1ee6i9s" />
+    <bpmn:sequenceFlow id="Flow_13iwl91" sourceRef="Gateway_1ee6i9s" targetRef="Gateway_0v1y6l3" />
+    <bpmn:sequenceFlow id="Flow_0ozoxv7" sourceRef="Gateway_0v1y6l3" targetRef="Event_1xosfgb" />
+    <bpmn:sequenceFlow id="Flow_1dj62p6" sourceRef="Gateway_0v1y6l3" targetRef="Event_0cyp3nd" />
+    <bpmn:sequenceFlow id="Flow_1hk0gog" sourceRef="Event_1xosfgb" targetRef="Activity_0v05780" />
+    <bpmn:sequenceFlow id="Flow_0k2v5e1" sourceRef="Activity_0v05780" targetRef="Activity_09495yf" />
+    <bpmn:sequenceFlow id="Flow_0uqdyxp" sourceRef="Event_0cyp3nd" targetRef="Activity_18h7yic" />
+    <bpmn:sequenceFlow id="Flow_1a5127t" sourceRef="Activity_18h7yic" targetRef="Event_195u06h" />
+    <bpmn:sequenceFlow id="Flow_0wkb4hq" sourceRef="Gateway_03oxb21" targetRef="Gateway_1adft3c" />
+    <bpmn:sequenceFlow id="Flow_11x8rdy" sourceRef="Event_1j12ud3" targetRef="Event_0el3zk8" />
+    <bpmn:endEvent id="Event_0el3zk8">
+      <bpmn:incoming>Flow_11x8rdy</bpmn:incoming>
+      <bpmn:errorEventDefinition id="ErrorEventDefinition_16vp8au" errorRef="Error_035q7ey" />
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1gvflfp" sourceRef="Gateway_1adft3c" targetRef="Event_0ghtmm6" />
+    <bpmn:intermediateThrowEvent id="Event_0ghtmm6">
+      <bpmn:incoming>Flow_1gvflfp</bpmn:incoming>
+    </bpmn:intermediateThrowEvent>
+    <bpmn:sequenceFlow id="Flow_08k7vbr" sourceRef="Gateway_1adft3c" targetRef="Event_1fzuab7" />
+    <bpmn:intermediateCatchEvent id="Event_1fzuab7">
+      <bpmn:incoming>Flow_08k7vbr</bpmn:incoming>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_01kef5q" messageRef="Message_0inbjmp" />
+    </bpmn:intermediateCatchEvent>
+    <bpmn:sequenceFlow id="Flow_00dv1kp" sourceRef="StartEvent_1" targetRef="Activity_1knqz62" />
+    <bpmn:manualTask id="Activity_1knqz62">
+      <bpmn:incoming>Flow_00dv1kp</bpmn:incoming>
+      <bpmn:outgoing>Flow_16pvdna</bpmn:outgoing>
+    </bpmn:manualTask>
+    <bpmn:sequenceFlow id="Flow_16pvdna" sourceRef="Activity_1knqz62" targetRef="Activity_1mxteew" />
+    <bpmn:scriptTask id="Activity_1mxteew">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="foo" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_16pvdna</bpmn:incoming>
+      <bpmn:outgoing>Flow_1c7yptg</bpmn:outgoing>
+    </bpmn:scriptTask>
+    <bpmn:sequenceFlow id="Flow_1c7yptg" sourceRef="Activity_1mxteew" targetRef="Activity_1d00s75" />
+    <bpmn:sendTask id="Activity_1d00s75">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="foo" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1c7yptg</bpmn:incoming>
+    </bpmn:sendTask>
+    <bpmn:sequenceFlow id="Flow_19rqft2" sourceRef="Gateway_1adft3c" targetRef="Event_0s4ygc1" />
+    <bpmn:intermediateThrowEvent id="Event_0s4ygc1">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="foo" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_19rqft2</bpmn:incoming>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_1odggmr" />
+    </bpmn:intermediateThrowEvent>
+    <bpmn:sequenceFlow id="Flow_0n84ml1" sourceRef="Gateway_1adft3c" targetRef="Event_1yqxsot" />
+    <bpmn:endEvent id="Event_1yqxsot">
+      <bpmn:incoming>Flow_0n84ml1</bpmn:incoming>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_04t0675" />
+    </bpmn:endEvent>
+    <bpmn:exclusiveGateway id="Gateway_1adft3c">
+      <bpmn:incoming>Flow_0wkb4hq</bpmn:incoming>
+      <bpmn:outgoing>Flow_1gvflfp</bpmn:outgoing>
+      <bpmn:outgoing>Flow_08k7vbr</bpmn:outgoing>
+      <bpmn:outgoing>Flow_19rqft2</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0n84ml1</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:textAnnotation id="TextAnnotation_092byka">
+      <bpmn:text>foo</bpmn:text>
+    </bpmn:textAnnotation>
+    <bpmn:association id="Association_07pskij" sourceRef="Activity_0tmvr8k" targetRef="TextAnnotation_092byka" />
+  </bpmn:process>
+  <bpmn:message id="Message_0inbjmp" name="Message_0inbjmp">
+    <bpmn:extensionElements>
+      <zeebe:subscription correlationKey="foo" />
+    </bpmn:extensionElements>
+  </bpmn:message>
+  <bpmn:error id="Error_035q7ey" name="Error_07ueecl" errorCode="foo" />
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Collaboration_013oh0t">
+      <bpmndi:BPMNShape id="Participant_1lhpzkq_di" bpmnElement="Participant_1lhpzkq" isHorizontal="true">
+        <dc:Bounds x="129" y="80" width="1601" height="650" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0n84ml1_di" bpmnElement="Flow_0n84ml1">
+        <di:waypoint x="740" y="405" />
+        <di:waypoint x="740" y="630" />
+        <di:waypoint x="842" y="630" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_19rqft2_di" bpmnElement="Flow_19rqft2">
+        <di:waypoint x="740" y="405" />
+        <di:waypoint x="740" y="612" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1c7yptg_di" bpmnElement="Flow_1c7yptg">
+        <di:waypoint x="510" y="630" />
+        <di:waypoint x="560" y="630" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_16pvdna_di" bpmnElement="Flow_16pvdna">
+        <di:waypoint x="360" y="630" />
+        <di:waypoint x="410" y="630" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_00dv1kp_di" bpmnElement="Flow_00dv1kp">
+        <di:waypoint x="215" y="267" />
+        <di:waypoint x="240" y="267" />
+        <di:waypoint x="240" y="630" />
+        <di:waypoint x="260" y="630" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_08k7vbr_di" bpmnElement="Flow_08k7vbr">
+        <di:waypoint x="765" y="380" />
+        <di:waypoint x="860" y="380" />
+        <di:waypoint x="860" y="482" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1gvflfp_di" bpmnElement="Flow_1gvflfp">
+        <di:waypoint x="740" y="405" />
+        <di:waypoint x="740" y="482" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_11x8rdy_di" bpmnElement="Flow_11x8rdy">
+        <di:waypoint x="370" y="325" />
+        <di:waypoint x="370" y="500" />
+        <di:waypoint x="442" y="500" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0wkb4hq_di" bpmnElement="Flow_0wkb4hq">
+        <di:waypoint x="620" y="292" />
+        <di:waypoint x="620" y="380" />
+        <di:waypoint x="715" y="380" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1a5127t_di" bpmnElement="Flow_1a5127t">
+        <di:waypoint x="1180" y="380" />
+        <di:waypoint x="1220" y="380" />
+        <di:waypoint x="1220" y="490" />
+        <di:waypoint x="1262" y="490" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0uqdyxp_di" bpmnElement="Flow_0uqdyxp">
+        <di:waypoint x="998" y="380" />
+        <di:waypoint x="1080" y="380" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0k2v5e1_di" bpmnElement="Flow_0k2v5e1">
+        <di:waypoint x="1180" y="267" />
+        <di:waypoint x="1280" y="267" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1hk0gog_di" bpmnElement="Flow_1hk0gog">
+        <di:waypoint x="998" y="267" />
+        <di:waypoint x="1080" y="267" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1dj62p6_di" bpmnElement="Flow_1dj62p6">
+        <di:waypoint x="860" y="292" />
+        <di:waypoint x="860" y="380" />
+        <di:waypoint x="962" y="380" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0ozoxv7_di" bpmnElement="Flow_0ozoxv7">
+        <di:waypoint x="885" y="267" />
+        <di:waypoint x="962" y="267" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_13iwl91_di" bpmnElement="Flow_13iwl91">
+        <di:waypoint x="765" y="267" />
+        <di:waypoint x="835" y="267" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0aq3rml_di" bpmnElement="Flow_0aq3rml">
+        <di:waypoint x="645" y="267" />
+        <di:waypoint x="715" y="267" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1bj4q1g_di" bpmnElement="Flow_1bj4q1g">
+        <di:waypoint x="530" y="267" />
+        <di:waypoint x="595" y="267" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_04jud3f_di" bpmnElement="Flow_04jud3f">
+        <di:waypoint x="370" y="267" />
+        <di:waypoint x="430" y="267" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0av9in9_di" bpmnElement="Flow_0av9in9">
+        <di:waypoint x="370" y="325" />
+        <di:waypoint x="370" y="390" />
+        <di:waypoint x="442" y="390" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1c9prry_di" bpmnElement="Flow_1c9prry">
+        <di:waypoint x="215" y="267" />
+        <di:waypoint x="270" y="267" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="249" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_18wmzbb_di" bpmnElement="Activity_0tmvr8k">
+        <dc:Bounds x="270" y="227" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1vne73h_di" bpmnElement="Event_1vne73h">
+        <dc:Bounds x="442" y="372" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1wish8i_di" bpmnElement="Activity_19dosz4">
+        <dc:Bounds x="430" y="227" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_03oxb21_di" bpmnElement="Gateway_03oxb21" isMarkerVisible="true">
+        <dc:Bounds x="595" y="242" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0zdq4bc_di" bpmnElement="Gateway_1ee6i9s">
+        <dc:Bounds x="715" y="242" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0ov1azh_di" bpmnElement="Gateway_0v1y6l3">
+        <dc:Bounds x="835" y="242" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1xosfgb_di" bpmnElement="Event_1xosfgb">
+        <dc:Bounds x="962" y="249" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0cyp3nd_di" bpmnElement="Event_0cyp3nd">
+        <dc:Bounds x="962" y="362" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1sak8hk_di" bpmnElement="Activity_0v05780">
+        <dc:Bounds x="1080" y="227" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1fdzcmp_di" bpmnElement="Activity_18h7yic">
+        <dc:Bounds x="1080" y="340" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0gcrrhl_di" bpmnElement="Event_195u06h">
+        <dc:Bounds x="1262" y="472" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1t2rfhg_di" bpmnElement="Gateway_1adft3c" isMarkerVisible="true">
+        <dc:Bounds x="715" y="355" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_09495yf_di" bpmnElement="Activity_09495yf" isExpanded="true">
+        <dc:Bounds x="1280" y="167" width="350" height="200" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0ydr2ya_di" bpmnElement="Flow_0ydr2ya">
+        <di:waypoint x="1356" y="267" />
+        <di:waypoint x="1410" y="267" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Event_0ijiazl_di" bpmnElement="Event_0ijiazl">
+        <dc:Bounds x="1320" y="249" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_08nc9km_di" bpmnElement="Activity_15d1o2q">
+        <dc:Bounds x="1410" y="227" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_16u5s1h_di" bpmnElement="Event_0el3zk8">
+        <dc:Bounds x="442" y="482" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0hvr4ge_di" bpmnElement="Event_0ghtmm6">
+        <dc:Bounds x="722" y="482" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0200ml6_di" bpmnElement="Event_1fzuab7">
+        <dc:Bounds x="842" y="482" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0g9s8t2_di" bpmnElement="Activity_1knqz62">
+        <dc:Bounds x="260" y="590" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1sh1e8o_di" bpmnElement="Activity_1mxteew">
+        <dc:Bounds x="410" y="590" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0iuc6yg_di" bpmnElement="Activity_1d00s75">
+        <dc:Bounds x="560" y="590" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_13yl25e_di" bpmnElement="Event_0s4ygc1">
+        <dc:Bounds x="722" y="612" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1deoy07_di" bpmnElement="Event_1yqxsot">
+        <dc:Bounds x="842" y="612" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="TextAnnotation_092byka_di" bpmnElement="TextAnnotation_092byka">
+        <dc:Bounds x="370" y="140" width="100" height="30" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0yhfoa2_di" bpmnElement="Event_1j12ud3">
+        <dc:Bounds x="352" y="289" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Association_07pskij_di" bpmnElement="Association_07pskij">
+        <di:waypoint x="356" y="227" />
+        <di:waypoint x="407" y="170" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/spec/camunda-cloud-8-0-invalid.bpmn
+++ b/test/spec/camunda-cloud-8-0-invalid.bpmn
@@ -1,0 +1,350 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1vc92ax" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.0.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.0.0">
+  <bpmn:collaboration id="Collaboration_013oh0t">
+    <bpmn:participant id="Participant_1lhpzkq" processRef="Process_07pko08" />
+  </bpmn:collaboration>
+  <bpmn:process id="Process_07pko08" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1c9prry</bpmn:outgoing>
+      <bpmn:outgoing>Flow_00dv1kp</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:serviceTask id="Activity_0tmvr8k" name="foo">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1c9prry</bpmn:incoming>
+      <bpmn:outgoing>Flow_04jud3f</bpmn:outgoing>
+      <bpmn:multiInstanceLoopCharacteristics>
+        <bpmn:extensionElements>
+          <zeebe:loopCharacteristics />
+        </bpmn:extensionElements>
+      </bpmn:multiInstanceLoopCharacteristics>
+    </bpmn:serviceTask>
+    <bpmn:endEvent id="Event_1vne73h">
+      <bpmn:incoming>Flow_0av9in9</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:callActivity id="Activity_19dosz4">
+      <bpmn:extensionElements>
+        <zeebe:calledElement propagateAllChildVariables="false" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_04jud3f</bpmn:incoming>
+      <bpmn:outgoing>Flow_1bj4q1g</bpmn:outgoing>
+    </bpmn:callActivity>
+    <bpmn:exclusiveGateway id="Gateway_03oxb21">
+      <bpmn:incoming>Flow_1bj4q1g</bpmn:incoming>
+      <bpmn:outgoing>Flow_0aq3rml</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0wkb4hq</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:parallelGateway id="Gateway_1ee6i9s">
+      <bpmn:incoming>Flow_0aq3rml</bpmn:incoming>
+      <bpmn:outgoing>Flow_13iwl91</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:eventBasedGateway id="Gateway_0v1y6l3">
+      <bpmn:incoming>Flow_13iwl91</bpmn:incoming>
+      <bpmn:outgoing>Flow_0ozoxv7</bpmn:outgoing>
+      <bpmn:outgoing>Flow_1dj62p6</bpmn:outgoing>
+    </bpmn:eventBasedGateway>
+    <bpmn:intermediateCatchEvent id="Event_1xosfgb">
+      <bpmn:incoming>Flow_0ozoxv7</bpmn:incoming>
+      <bpmn:outgoing>Flow_1hk0gog</bpmn:outgoing>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_1gucz9d" messageRef="Message_0inbjmp" />
+    </bpmn:intermediateCatchEvent>
+    <bpmn:intermediateCatchEvent id="Event_0cyp3nd">
+      <bpmn:incoming>Flow_1dj62p6</bpmn:incoming>
+      <bpmn:outgoing>Flow_0uqdyxp</bpmn:outgoing>
+      <bpmn:timerEventDefinition id="TimerEventDefinition_1vu1hns" />
+    </bpmn:intermediateCatchEvent>
+    <bpmn:receiveTask id="Activity_0v05780" name="bar">
+      <bpmn:incoming>Flow_1hk0gog</bpmn:incoming>
+      <bpmn:outgoing>Flow_0k2v5e1</bpmn:outgoing>
+    </bpmn:receiveTask>
+    <bpmn:userTask id="Activity_18h7yic">
+      <bpmn:incoming>Flow_0uqdyxp</bpmn:incoming>
+      <bpmn:outgoing>Flow_1a5127t</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:endEvent id="Event_195u06h">
+      <bpmn:incoming>Flow_1a5127t</bpmn:incoming>
+      <bpmn:errorEventDefinition id="ErrorEventDefinition_075l6v5" errorRef="Error_035q7ey" />
+    </bpmn:endEvent>
+    <bpmn:subProcess id="Activity_09495yf">
+      <bpmn:incoming>Flow_0k2v5e1</bpmn:incoming>
+      <bpmn:startEvent id="Event_0ijiazl">
+        <bpmn:outgoing>Flow_0ydr2ya</bpmn:outgoing>
+      </bpmn:startEvent>
+      <bpmn:sequenceFlow id="Flow_0ydr2ya" sourceRef="Event_0ijiazl" targetRef="Activity_15d1o2q" />
+      <bpmn:businessRuleTask id="Activity_15d1o2q">
+        <bpmn:extensionElements />
+        <bpmn:incoming>Flow_0ydr2ya</bpmn:incoming>
+      </bpmn:businessRuleTask>
+    </bpmn:subProcess>
+    <bpmn:boundaryEvent id="Event_1j12ud3" attachedToRef="Activity_0tmvr8k">
+      <bpmn:outgoing>Flow_0av9in9</bpmn:outgoing>
+      <bpmn:outgoing>Flow_11x8rdy</bpmn:outgoing>
+      <bpmn:errorEventDefinition id="ErrorEventDefinition_0cy2jeo" errorRef="Error_035q7ey" />
+    </bpmn:boundaryEvent>
+    <bpmn:sequenceFlow id="Flow_1c9prry" sourceRef="StartEvent_1" targetRef="Activity_0tmvr8k" />
+    <bpmn:sequenceFlow id="Flow_0av9in9" sourceRef="Event_1j12ud3" targetRef="Event_1vne73h" />
+    <bpmn:sequenceFlow id="Flow_04jud3f" sourceRef="Activity_0tmvr8k" targetRef="Activity_19dosz4" />
+    <bpmn:sequenceFlow id="Flow_1bj4q1g" sourceRef="Activity_19dosz4" targetRef="Gateway_03oxb21" />
+    <bpmn:sequenceFlow id="Flow_0aq3rml" sourceRef="Gateway_03oxb21" targetRef="Gateway_1ee6i9s" />
+    <bpmn:sequenceFlow id="Flow_13iwl91" sourceRef="Gateway_1ee6i9s" targetRef="Gateway_0v1y6l3" />
+    <bpmn:sequenceFlow id="Flow_0ozoxv7" sourceRef="Gateway_0v1y6l3" targetRef="Event_1xosfgb" />
+    <bpmn:sequenceFlow id="Flow_1dj62p6" sourceRef="Gateway_0v1y6l3" targetRef="Event_0cyp3nd" />
+    <bpmn:sequenceFlow id="Flow_1hk0gog" sourceRef="Event_1xosfgb" targetRef="Activity_0v05780" />
+    <bpmn:sequenceFlow id="Flow_0k2v5e1" sourceRef="Activity_0v05780" targetRef="Activity_09495yf" />
+    <bpmn:sequenceFlow id="Flow_0uqdyxp" sourceRef="Event_0cyp3nd" targetRef="Activity_18h7yic" />
+    <bpmn:sequenceFlow id="Flow_1a5127t" sourceRef="Activity_18h7yic" targetRef="Event_195u06h" />
+    <bpmn:complexGateway id="Gateway_1adft3c">
+      <bpmn:incoming>Flow_0wkb4hq</bpmn:incoming>
+      <bpmn:outgoing>Flow_1gvflfp</bpmn:outgoing>
+      <bpmn:outgoing>Flow_08k7vbr</bpmn:outgoing>
+      <bpmn:outgoing>Flow_19rqft2</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0n84ml1</bpmn:outgoing>
+    </bpmn:complexGateway>
+    <bpmn:sequenceFlow id="Flow_0wkb4hq" sourceRef="Gateway_03oxb21" targetRef="Gateway_1adft3c" />
+    <bpmn:sequenceFlow id="Flow_11x8rdy" sourceRef="Event_1j12ud3" targetRef="Event_0el3zk8" />
+    <bpmn:endEvent id="Event_0el3zk8">
+      <bpmn:incoming>Flow_11x8rdy</bpmn:incoming>
+      <bpmn:errorEventDefinition id="ErrorEventDefinition_16vp8au" />
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1gvflfp" sourceRef="Gateway_1adft3c" targetRef="Event_0ghtmm6" />
+    <bpmn:intermediateThrowEvent id="Event_0ghtmm6">
+      <bpmn:incoming>Flow_1gvflfp</bpmn:incoming>
+    </bpmn:intermediateThrowEvent>
+    <bpmn:sequenceFlow id="Flow_08k7vbr" sourceRef="Gateway_1adft3c" targetRef="Event_1fzuab7" />
+    <bpmn:intermediateCatchEvent id="Event_1fzuab7">
+      <bpmn:incoming>Flow_08k7vbr</bpmn:incoming>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_01kef5q" />
+    </bpmn:intermediateCatchEvent>
+    <bpmn:sequenceFlow id="Flow_00dv1kp" sourceRef="StartEvent_1" targetRef="Activity_1knqz62" />
+    <bpmn:manualTask id="Activity_1knqz62">
+      <bpmn:incoming>Flow_00dv1kp</bpmn:incoming>
+      <bpmn:outgoing>Flow_16pvdna</bpmn:outgoing>
+    </bpmn:manualTask>
+    <bpmn:sequenceFlow id="Flow_16pvdna" sourceRef="Activity_1knqz62" targetRef="Activity_1mxteew" />
+    <bpmn:scriptTask id="Activity_1mxteew">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="foo" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_16pvdna</bpmn:incoming>
+      <bpmn:outgoing>Flow_1c7yptg</bpmn:outgoing>
+    </bpmn:scriptTask>
+    <bpmn:sequenceFlow id="Flow_1c7yptg" sourceRef="Activity_1mxteew" targetRef="Activity_1d00s75" />
+    <bpmn:sendTask id="Activity_1d00s75">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="foo" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1c7yptg</bpmn:incoming>
+    </bpmn:sendTask>
+    <bpmn:sequenceFlow id="Flow_19rqft2" sourceRef="Gateway_1adft3c" targetRef="Event_0s4ygc1" />
+    <bpmn:intermediateThrowEvent id="Event_0s4ygc1">
+      <bpmn:incoming>Flow_19rqft2</bpmn:incoming>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_1odggmr" />
+    </bpmn:intermediateThrowEvent>
+    <bpmn:sequenceFlow id="Flow_0n84ml1" sourceRef="Gateway_1adft3c" targetRef="Event_1yqxsot" />
+    <bpmn:endEvent id="Event_1yqxsot">
+      <bpmn:incoming>Flow_0n84ml1</bpmn:incoming>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_04t0675" />
+    </bpmn:endEvent>
+    <bpmn:textAnnotation id="TextAnnotation_092byka">
+      <bpmn:text>foo</bpmn:text>
+    </bpmn:textAnnotation>
+    <bpmn:association id="Association_07pskij" sourceRef="Activity_0tmvr8k" targetRef="TextAnnotation_092byka" />
+  </bpmn:process>
+  <bpmn:message id="Message_0inbjmp" name="Message_0inbjmp">
+    <bpmn:extensionElements>
+      <zeebe:subscription />
+    </bpmn:extensionElements>
+  </bpmn:message>
+  <bpmn:error id="Error_035q7ey" name="Error_07ueecl" errorCode="foo" />
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Collaboration_013oh0t">
+      <bpmndi:BPMNShape id="Participant_1lhpzkq_di" bpmnElement="Participant_1lhpzkq" isHorizontal="true">
+        <dc:Bounds x="129" y="80" width="1601" height="650" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0n84ml1_di" bpmnElement="Flow_0n84ml1">
+        <di:waypoint x="740" y="405" />
+        <di:waypoint x="740" y="630" />
+        <di:waypoint x="842" y="630" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_19rqft2_di" bpmnElement="Flow_19rqft2">
+        <di:waypoint x="740" y="405" />
+        <di:waypoint x="740" y="612" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1c7yptg_di" bpmnElement="Flow_1c7yptg">
+        <di:waypoint x="510" y="630" />
+        <di:waypoint x="560" y="630" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_16pvdna_di" bpmnElement="Flow_16pvdna">
+        <di:waypoint x="360" y="630" />
+        <di:waypoint x="410" y="630" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_00dv1kp_di" bpmnElement="Flow_00dv1kp">
+        <di:waypoint x="215" y="267" />
+        <di:waypoint x="240" y="267" />
+        <di:waypoint x="240" y="630" />
+        <di:waypoint x="260" y="630" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_08k7vbr_di" bpmnElement="Flow_08k7vbr">
+        <di:waypoint x="765" y="380" />
+        <di:waypoint x="860" y="380" />
+        <di:waypoint x="860" y="482" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1gvflfp_di" bpmnElement="Flow_1gvflfp">
+        <di:waypoint x="740" y="405" />
+        <di:waypoint x="740" y="482" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_11x8rdy_di" bpmnElement="Flow_11x8rdy">
+        <di:waypoint x="370" y="325" />
+        <di:waypoint x="370" y="500" />
+        <di:waypoint x="442" y="500" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0wkb4hq_di" bpmnElement="Flow_0wkb4hq">
+        <di:waypoint x="620" y="292" />
+        <di:waypoint x="620" y="380" />
+        <di:waypoint x="715" y="380" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1a5127t_di" bpmnElement="Flow_1a5127t">
+        <di:waypoint x="1180" y="380" />
+        <di:waypoint x="1220" y="380" />
+        <di:waypoint x="1220" y="490" />
+        <di:waypoint x="1262" y="490" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0uqdyxp_di" bpmnElement="Flow_0uqdyxp">
+        <di:waypoint x="998" y="380" />
+        <di:waypoint x="1080" y="380" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0k2v5e1_di" bpmnElement="Flow_0k2v5e1">
+        <di:waypoint x="1180" y="267" />
+        <di:waypoint x="1280" y="267" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1hk0gog_di" bpmnElement="Flow_1hk0gog">
+        <di:waypoint x="998" y="267" />
+        <di:waypoint x="1080" y="267" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1dj62p6_di" bpmnElement="Flow_1dj62p6">
+        <di:waypoint x="860" y="292" />
+        <di:waypoint x="860" y="380" />
+        <di:waypoint x="962" y="380" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0ozoxv7_di" bpmnElement="Flow_0ozoxv7">
+        <di:waypoint x="885" y="267" />
+        <di:waypoint x="962" y="267" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_13iwl91_di" bpmnElement="Flow_13iwl91">
+        <di:waypoint x="765" y="267" />
+        <di:waypoint x="835" y="267" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0aq3rml_di" bpmnElement="Flow_0aq3rml">
+        <di:waypoint x="645" y="267" />
+        <di:waypoint x="715" y="267" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1bj4q1g_di" bpmnElement="Flow_1bj4q1g">
+        <di:waypoint x="530" y="267" />
+        <di:waypoint x="595" y="267" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_04jud3f_di" bpmnElement="Flow_04jud3f">
+        <di:waypoint x="370" y="267" />
+        <di:waypoint x="430" y="267" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0av9in9_di" bpmnElement="Flow_0av9in9">
+        <di:waypoint x="370" y="325" />
+        <di:waypoint x="370" y="390" />
+        <di:waypoint x="442" y="390" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1c9prry_di" bpmnElement="Flow_1c9prry">
+        <di:waypoint x="215" y="267" />
+        <di:waypoint x="270" y="267" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="249" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_18wmzbb_di" bpmnElement="Activity_0tmvr8k">
+        <dc:Bounds x="270" y="227" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1vne73h_di" bpmnElement="Event_1vne73h">
+        <dc:Bounds x="442" y="372" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1wish8i_di" bpmnElement="Activity_19dosz4">
+        <dc:Bounds x="430" y="227" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_03oxb21_di" bpmnElement="Gateway_03oxb21" isMarkerVisible="true">
+        <dc:Bounds x="595" y="242" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0zdq4bc_di" bpmnElement="Gateway_1ee6i9s">
+        <dc:Bounds x="715" y="242" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0ov1azh_di" bpmnElement="Gateway_0v1y6l3">
+        <dc:Bounds x="835" y="242" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1xosfgb_di" bpmnElement="Event_1xosfgb">
+        <dc:Bounds x="962" y="249" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0cyp3nd_di" bpmnElement="Event_0cyp3nd">
+        <dc:Bounds x="962" y="362" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1sak8hk_di" bpmnElement="Activity_0v05780">
+        <dc:Bounds x="1080" y="227" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1fdzcmp_di" bpmnElement="Activity_18h7yic">
+        <dc:Bounds x="1080" y="340" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0gcrrhl_di" bpmnElement="Event_195u06h">
+        <dc:Bounds x="1262" y="472" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_09495yf_di" bpmnElement="Activity_09495yf" isExpanded="true">
+        <dc:Bounds x="1280" y="167" width="350" height="200" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0ydr2ya_di" bpmnElement="Flow_0ydr2ya">
+        <di:waypoint x="1356" y="267" />
+        <di:waypoint x="1410" y="267" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Event_0ijiazl_di" bpmnElement="Event_0ijiazl">
+        <dc:Bounds x="1320" y="249" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_08nc9km_di" bpmnElement="Activity_15d1o2q">
+        <dc:Bounds x="1410" y="227" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1adft3c_di" bpmnElement="Gateway_1adft3c" isMarkerVisible="true">
+        <dc:Bounds x="715" y="355" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_16u5s1h_di" bpmnElement="Event_0el3zk8">
+        <dc:Bounds x="442" y="482" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0hvr4ge_di" bpmnElement="Event_0ghtmm6">
+        <dc:Bounds x="722" y="482" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0200ml6_di" bpmnElement="Event_1fzuab7">
+        <dc:Bounds x="842" y="482" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0g9s8t2_di" bpmnElement="Activity_1knqz62">
+        <dc:Bounds x="260" y="590" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1sh1e8o_di" bpmnElement="Activity_1mxteew">
+        <dc:Bounds x="410" y="590" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0iuc6yg_di" bpmnElement="Activity_1d00s75">
+        <dc:Bounds x="560" y="590" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_13yl25e_di" bpmnElement="Event_0s4ygc1">
+        <dc:Bounds x="722" y="612" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1deoy07_di" bpmnElement="Event_1yqxsot">
+        <dc:Bounds x="842" y="612" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="TextAnnotation_092byka_di" bpmnElement="TextAnnotation_092byka">
+        <dc:Bounds x="370" y="140" width="100" height="30" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0yhfoa2_di" bpmnElement="Event_1j12ud3">
+        <dc:Bounds x="352" y="289" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Association_07pskij_di" bpmnElement="Association_07pskij">
+        <di:waypoint x="356" y="227" />
+        <di:waypoint x="407" y="170" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/spec/camunda-cloud-8-0-valid.bpmn
+++ b/test/spec/camunda-cloud-8-0-valid.bpmn
@@ -1,0 +1,360 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1vc92ax" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.0.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.0.0">
+  <bpmn:collaboration id="Collaboration_013oh0t">
+    <bpmn:participant id="Participant_1lhpzkq" processRef="Process_07pko08" />
+  </bpmn:collaboration>
+  <bpmn:process id="Process_07pko08" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1c9prry</bpmn:outgoing>
+      <bpmn:outgoing>Flow_00dv1kp</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:serviceTask id="Activity_0tmvr8k" name="foo">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="foo" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1c9prry</bpmn:incoming>
+      <bpmn:outgoing>Flow_04jud3f</bpmn:outgoing>
+      <bpmn:multiInstanceLoopCharacteristics>
+        <bpmn:extensionElements>
+          <zeebe:loopCharacteristics inputCollection="foo" />
+        </bpmn:extensionElements>
+      </bpmn:multiInstanceLoopCharacteristics>
+    </bpmn:serviceTask>
+    <bpmn:endEvent id="Event_1vne73h">
+      <bpmn:incoming>Flow_0av9in9</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:callActivity id="Activity_19dosz4">
+      <bpmn:extensionElements>
+        <zeebe:calledElement processId="foo" propagateAllChildVariables="false" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_04jud3f</bpmn:incoming>
+      <bpmn:outgoing>Flow_1bj4q1g</bpmn:outgoing>
+      <bpmn:multiInstanceLoopCharacteristics>
+        <bpmn:extensionElements>
+          <zeebe:loopCharacteristics inputCollection="foo" />
+        </bpmn:extensionElements>
+      </bpmn:multiInstanceLoopCharacteristics>
+    </bpmn:callActivity>
+    <bpmn:exclusiveGateway id="Gateway_03oxb21">
+      <bpmn:incoming>Flow_1bj4q1g</bpmn:incoming>
+      <bpmn:outgoing>Flow_0aq3rml</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0wkb4hq</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:parallelGateway id="Gateway_1ee6i9s">
+      <bpmn:incoming>Flow_0aq3rml</bpmn:incoming>
+      <bpmn:outgoing>Flow_13iwl91</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:eventBasedGateway id="Gateway_0v1y6l3">
+      <bpmn:incoming>Flow_13iwl91</bpmn:incoming>
+      <bpmn:outgoing>Flow_0ozoxv7</bpmn:outgoing>
+      <bpmn:outgoing>Flow_1dj62p6</bpmn:outgoing>
+    </bpmn:eventBasedGateway>
+    <bpmn:intermediateCatchEvent id="Event_1xosfgb">
+      <bpmn:incoming>Flow_0ozoxv7</bpmn:incoming>
+      <bpmn:outgoing>Flow_1hk0gog</bpmn:outgoing>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_1gucz9d" messageRef="Message_0inbjmp" />
+    </bpmn:intermediateCatchEvent>
+    <bpmn:intermediateCatchEvent id="Event_0cyp3nd">
+      <bpmn:incoming>Flow_1dj62p6</bpmn:incoming>
+      <bpmn:outgoing>Flow_0uqdyxp</bpmn:outgoing>
+      <bpmn:timerEventDefinition id="TimerEventDefinition_1vu1hns" />
+    </bpmn:intermediateCatchEvent>
+    <bpmn:receiveTask id="Activity_0v05780" name="bar" messageRef="Message_0inbjmp">
+      <bpmn:incoming>Flow_1hk0gog</bpmn:incoming>
+      <bpmn:outgoing>Flow_0k2v5e1</bpmn:outgoing>
+    </bpmn:receiveTask>
+    <bpmn:userTask id="Activity_18h7yic">
+      <bpmn:incoming>Flow_0uqdyxp</bpmn:incoming>
+      <bpmn:outgoing>Flow_1a5127t</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:endEvent id="Event_195u06h">
+      <bpmn:incoming>Flow_1a5127t</bpmn:incoming>
+      <bpmn:errorEventDefinition id="ErrorEventDefinition_075l6v5" errorRef="Error_035q7ey" />
+    </bpmn:endEvent>
+    <bpmn:subProcess id="Activity_09495yf">
+      <bpmn:incoming>Flow_0k2v5e1</bpmn:incoming>
+      <bpmn:startEvent id="Event_0ijiazl">
+        <bpmn:outgoing>Flow_0ydr2ya</bpmn:outgoing>
+      </bpmn:startEvent>
+      <bpmn:sequenceFlow id="Flow_0ydr2ya" sourceRef="Event_0ijiazl" targetRef="Activity_15d1o2q" />
+      <bpmn:businessRuleTask id="Activity_15d1o2q">
+        <bpmn:extensionElements>
+          <zeebe:calledDecision decisionId="foo" resultVariable="bar" />
+        </bpmn:extensionElements>
+        <bpmn:incoming>Flow_0ydr2ya</bpmn:incoming>
+      </bpmn:businessRuleTask>
+    </bpmn:subProcess>
+    <bpmn:boundaryEvent id="Event_1j12ud3" attachedToRef="Activity_0tmvr8k">
+      <bpmn:outgoing>Flow_0av9in9</bpmn:outgoing>
+      <bpmn:outgoing>Flow_11x8rdy</bpmn:outgoing>
+      <bpmn:errorEventDefinition id="ErrorEventDefinition_0cy2jeo" errorRef="Error_035q7ey" />
+    </bpmn:boundaryEvent>
+    <bpmn:sequenceFlow id="Flow_1c9prry" sourceRef="StartEvent_1" targetRef="Activity_0tmvr8k" />
+    <bpmn:sequenceFlow id="Flow_0av9in9" sourceRef="Event_1j12ud3" targetRef="Event_1vne73h" />
+    <bpmn:sequenceFlow id="Flow_04jud3f" sourceRef="Activity_0tmvr8k" targetRef="Activity_19dosz4" />
+    <bpmn:sequenceFlow id="Flow_1bj4q1g" sourceRef="Activity_19dosz4" targetRef="Gateway_03oxb21" />
+    <bpmn:sequenceFlow id="Flow_0aq3rml" sourceRef="Gateway_03oxb21" targetRef="Gateway_1ee6i9s" />
+    <bpmn:sequenceFlow id="Flow_13iwl91" sourceRef="Gateway_1ee6i9s" targetRef="Gateway_0v1y6l3" />
+    <bpmn:sequenceFlow id="Flow_0ozoxv7" sourceRef="Gateway_0v1y6l3" targetRef="Event_1xosfgb" />
+    <bpmn:sequenceFlow id="Flow_1dj62p6" sourceRef="Gateway_0v1y6l3" targetRef="Event_0cyp3nd" />
+    <bpmn:sequenceFlow id="Flow_1hk0gog" sourceRef="Event_1xosfgb" targetRef="Activity_0v05780" />
+    <bpmn:sequenceFlow id="Flow_0k2v5e1" sourceRef="Activity_0v05780" targetRef="Activity_09495yf" />
+    <bpmn:sequenceFlow id="Flow_0uqdyxp" sourceRef="Event_0cyp3nd" targetRef="Activity_18h7yic" />
+    <bpmn:sequenceFlow id="Flow_1a5127t" sourceRef="Activity_18h7yic" targetRef="Event_195u06h" />
+    <bpmn:sequenceFlow id="Flow_0wkb4hq" sourceRef="Gateway_03oxb21" targetRef="Gateway_1adft3c" />
+    <bpmn:sequenceFlow id="Flow_11x8rdy" sourceRef="Event_1j12ud3" targetRef="Event_0el3zk8" />
+    <bpmn:endEvent id="Event_0el3zk8">
+      <bpmn:incoming>Flow_11x8rdy</bpmn:incoming>
+      <bpmn:errorEventDefinition id="ErrorEventDefinition_16vp8au" errorRef="Error_035q7ey" />
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1gvflfp" sourceRef="Gateway_1adft3c" targetRef="Event_0ghtmm6" />
+    <bpmn:intermediateThrowEvent id="Event_0ghtmm6">
+      <bpmn:incoming>Flow_1gvflfp</bpmn:incoming>
+    </bpmn:intermediateThrowEvent>
+    <bpmn:sequenceFlow id="Flow_08k7vbr" sourceRef="Gateway_1adft3c" targetRef="Event_1fzuab7" />
+    <bpmn:intermediateCatchEvent id="Event_1fzuab7">
+      <bpmn:incoming>Flow_08k7vbr</bpmn:incoming>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_01kef5q" messageRef="Message_0inbjmp" />
+    </bpmn:intermediateCatchEvent>
+    <bpmn:sequenceFlow id="Flow_00dv1kp" sourceRef="StartEvent_1" targetRef="Activity_1knqz62" />
+    <bpmn:manualTask id="Activity_1knqz62">
+      <bpmn:incoming>Flow_00dv1kp</bpmn:incoming>
+      <bpmn:outgoing>Flow_16pvdna</bpmn:outgoing>
+    </bpmn:manualTask>
+    <bpmn:sequenceFlow id="Flow_16pvdna" sourceRef="Activity_1knqz62" targetRef="Activity_1mxteew" />
+    <bpmn:scriptTask id="Activity_1mxteew">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="foo" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_16pvdna</bpmn:incoming>
+      <bpmn:outgoing>Flow_1c7yptg</bpmn:outgoing>
+    </bpmn:scriptTask>
+    <bpmn:sequenceFlow id="Flow_1c7yptg" sourceRef="Activity_1mxteew" targetRef="Activity_1d00s75" />
+    <bpmn:sendTask id="Activity_1d00s75">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="foo" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1c7yptg</bpmn:incoming>
+    </bpmn:sendTask>
+    <bpmn:sequenceFlow id="Flow_19rqft2" sourceRef="Gateway_1adft3c" targetRef="Event_0s4ygc1" />
+    <bpmn:intermediateThrowEvent id="Event_0s4ygc1">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="foo" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_19rqft2</bpmn:incoming>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_1odggmr" />
+    </bpmn:intermediateThrowEvent>
+    <bpmn:sequenceFlow id="Flow_0n84ml1" sourceRef="Gateway_1adft3c" targetRef="Event_1yqxsot" />
+    <bpmn:endEvent id="Event_1yqxsot">
+      <bpmn:incoming>Flow_0n84ml1</bpmn:incoming>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_04t0675" />
+    </bpmn:endEvent>
+    <bpmn:exclusiveGateway id="Gateway_1adft3c">
+      <bpmn:incoming>Flow_0wkb4hq</bpmn:incoming>
+      <bpmn:outgoing>Flow_1gvflfp</bpmn:outgoing>
+      <bpmn:outgoing>Flow_08k7vbr</bpmn:outgoing>
+      <bpmn:outgoing>Flow_19rqft2</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0n84ml1</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:textAnnotation id="TextAnnotation_092byka">
+      <bpmn:text>foo</bpmn:text>
+    </bpmn:textAnnotation>
+    <bpmn:association id="Association_07pskij" sourceRef="Activity_0tmvr8k" targetRef="TextAnnotation_092byka" />
+  </bpmn:process>
+  <bpmn:message id="Message_0inbjmp" name="Message_0inbjmp">
+    <bpmn:extensionElements>
+      <zeebe:subscription correlationKey="foo" />
+    </bpmn:extensionElements>
+  </bpmn:message>
+  <bpmn:error id="Error_035q7ey" name="Error_07ueecl" errorCode="foo" />
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Collaboration_013oh0t">
+      <bpmndi:BPMNShape id="Participant_1lhpzkq_di" bpmnElement="Participant_1lhpzkq" isHorizontal="true">
+        <dc:Bounds x="129" y="80" width="1601" height="650" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0n84ml1_di" bpmnElement="Flow_0n84ml1">
+        <di:waypoint x="740" y="405" />
+        <di:waypoint x="740" y="630" />
+        <di:waypoint x="842" y="630" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_19rqft2_di" bpmnElement="Flow_19rqft2">
+        <di:waypoint x="740" y="405" />
+        <di:waypoint x="740" y="612" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1c7yptg_di" bpmnElement="Flow_1c7yptg">
+        <di:waypoint x="510" y="630" />
+        <di:waypoint x="560" y="630" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_16pvdna_di" bpmnElement="Flow_16pvdna">
+        <di:waypoint x="360" y="630" />
+        <di:waypoint x="410" y="630" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_00dv1kp_di" bpmnElement="Flow_00dv1kp">
+        <di:waypoint x="215" y="267" />
+        <di:waypoint x="240" y="267" />
+        <di:waypoint x="240" y="630" />
+        <di:waypoint x="260" y="630" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_08k7vbr_di" bpmnElement="Flow_08k7vbr">
+        <di:waypoint x="765" y="380" />
+        <di:waypoint x="860" y="380" />
+        <di:waypoint x="860" y="482" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1gvflfp_di" bpmnElement="Flow_1gvflfp">
+        <di:waypoint x="740" y="405" />
+        <di:waypoint x="740" y="482" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_11x8rdy_di" bpmnElement="Flow_11x8rdy">
+        <di:waypoint x="370" y="325" />
+        <di:waypoint x="370" y="500" />
+        <di:waypoint x="442" y="500" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0wkb4hq_di" bpmnElement="Flow_0wkb4hq">
+        <di:waypoint x="620" y="292" />
+        <di:waypoint x="620" y="380" />
+        <di:waypoint x="715" y="380" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1a5127t_di" bpmnElement="Flow_1a5127t">
+        <di:waypoint x="1180" y="380" />
+        <di:waypoint x="1220" y="380" />
+        <di:waypoint x="1220" y="490" />
+        <di:waypoint x="1262" y="490" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0uqdyxp_di" bpmnElement="Flow_0uqdyxp">
+        <di:waypoint x="998" y="380" />
+        <di:waypoint x="1080" y="380" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0k2v5e1_di" bpmnElement="Flow_0k2v5e1">
+        <di:waypoint x="1180" y="267" />
+        <di:waypoint x="1280" y="267" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1hk0gog_di" bpmnElement="Flow_1hk0gog">
+        <di:waypoint x="998" y="267" />
+        <di:waypoint x="1080" y="267" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1dj62p6_di" bpmnElement="Flow_1dj62p6">
+        <di:waypoint x="860" y="292" />
+        <di:waypoint x="860" y="380" />
+        <di:waypoint x="962" y="380" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0ozoxv7_di" bpmnElement="Flow_0ozoxv7">
+        <di:waypoint x="885" y="267" />
+        <di:waypoint x="962" y="267" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_13iwl91_di" bpmnElement="Flow_13iwl91">
+        <di:waypoint x="765" y="267" />
+        <di:waypoint x="835" y="267" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0aq3rml_di" bpmnElement="Flow_0aq3rml">
+        <di:waypoint x="645" y="267" />
+        <di:waypoint x="715" y="267" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1bj4q1g_di" bpmnElement="Flow_1bj4q1g">
+        <di:waypoint x="530" y="267" />
+        <di:waypoint x="595" y="267" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_04jud3f_di" bpmnElement="Flow_04jud3f">
+        <di:waypoint x="370" y="267" />
+        <di:waypoint x="430" y="267" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0av9in9_di" bpmnElement="Flow_0av9in9">
+        <di:waypoint x="370" y="325" />
+        <di:waypoint x="370" y="390" />
+        <di:waypoint x="442" y="390" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1c9prry_di" bpmnElement="Flow_1c9prry">
+        <di:waypoint x="215" y="267" />
+        <di:waypoint x="270" y="267" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="249" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_18wmzbb_di" bpmnElement="Activity_0tmvr8k">
+        <dc:Bounds x="270" y="227" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1vne73h_di" bpmnElement="Event_1vne73h">
+        <dc:Bounds x="442" y="372" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1wish8i_di" bpmnElement="Activity_19dosz4">
+        <dc:Bounds x="430" y="227" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_03oxb21_di" bpmnElement="Gateway_03oxb21" isMarkerVisible="true">
+        <dc:Bounds x="595" y="242" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0zdq4bc_di" bpmnElement="Gateway_1ee6i9s">
+        <dc:Bounds x="715" y="242" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0ov1azh_di" bpmnElement="Gateway_0v1y6l3">
+        <dc:Bounds x="835" y="242" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1xosfgb_di" bpmnElement="Event_1xosfgb">
+        <dc:Bounds x="962" y="249" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0cyp3nd_di" bpmnElement="Event_0cyp3nd">
+        <dc:Bounds x="962" y="362" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1sak8hk_di" bpmnElement="Activity_0v05780">
+        <dc:Bounds x="1080" y="227" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1fdzcmp_di" bpmnElement="Activity_18h7yic">
+        <dc:Bounds x="1080" y="340" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0gcrrhl_di" bpmnElement="Event_195u06h">
+        <dc:Bounds x="1262" y="472" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1t2rfhg_di" bpmnElement="Gateway_1adft3c" isMarkerVisible="true">
+        <dc:Bounds x="715" y="355" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_09495yf_di" bpmnElement="Activity_09495yf" isExpanded="true">
+        <dc:Bounds x="1280" y="167" width="350" height="200" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0ydr2ya_di" bpmnElement="Flow_0ydr2ya">
+        <di:waypoint x="1356" y="267" />
+        <di:waypoint x="1410" y="267" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Event_0ijiazl_di" bpmnElement="Event_0ijiazl">
+        <dc:Bounds x="1320" y="249" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_08nc9km_di" bpmnElement="Activity_15d1o2q">
+        <dc:Bounds x="1410" y="227" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_16u5s1h_di" bpmnElement="Event_0el3zk8">
+        <dc:Bounds x="442" y="482" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0hvr4ge_di" bpmnElement="Event_0ghtmm6">
+        <dc:Bounds x="722" y="482" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0200ml6_di" bpmnElement="Event_1fzuab7">
+        <dc:Bounds x="842" y="482" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0g9s8t2_di" bpmnElement="Activity_1knqz62">
+        <dc:Bounds x="260" y="590" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1sh1e8o_di" bpmnElement="Activity_1mxteew">
+        <dc:Bounds x="410" y="590" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0iuc6yg_di" bpmnElement="Activity_1d00s75">
+        <dc:Bounds x="560" y="590" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_13yl25e_di" bpmnElement="Event_0s4ygc1">
+        <dc:Bounds x="722" y="612" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1deoy07_di" bpmnElement="Event_1yqxsot">
+        <dc:Bounds x="842" y="612" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="TextAnnotation_092byka_di" bpmnElement="TextAnnotation_092byka">
+        <dc:Bounds x="370" y="140" width="100" height="30" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0yhfoa2_di" bpmnElement="Event_1j12ud3">
+        <dc:Bounds x="352" y="289" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Association_07pskij_di" bpmnElement="Association_07pskij">
+        <di:waypoint x="356" y="227" />
+        <di:waypoint x="407" y="170" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/spec/camunda-platform-7-17.bpmn
+++ b/test/spec/camunda-platform-7-17.bpmn
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_19bxjpz" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.0.0" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.17.0">
+  <bpmn:process id="Process_0fdds93" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_06awcz8</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:task id="Activity_09orc6r">
+      <bpmn:incoming>Flow_06awcz8</bpmn:incoming>
+      <bpmn:outgoing>Flow_1fx1veh</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_06awcz8" sourceRef="StartEvent_1" targetRef="Activity_09orc6r" />
+    <bpmn:endEvent id="Event_1lss22g">
+      <bpmn:incoming>Flow_1fx1veh</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1fx1veh" sourceRef="Activity_09orc6r" targetRef="Event_1lss22g" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_0fdds93">
+      <bpmndi:BPMNEdge id="Flow_06awcz8_di" bpmnElement="Flow_06awcz8">
+        <di:waypoint x="215" y="117" />
+        <di:waypoint x="270" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1fx1veh_di" bpmnElement="Flow_1fx1veh">
+        <di:waypoint x="370" y="117" />
+        <di:waypoint x="432" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_09orc6r_di" bpmnElement="Activity_09orc6r">
+        <dc:Bounds x="270" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1lss22g_di" bpmnElement="Event_1lss22g">
+        <dc:Bounds x="432" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/spec/no-execution-platform.bpmn
+++ b/test/spec/no-execution-platform.bpmn
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_0nber99" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.0.0">
+  <bpmn:process id="Process_051ks7f" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_0tqc5m8</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_0tqc5m8" sourceRef="StartEvent_1" targetRef="Activity_09d1jqt" />
+    <bpmn:endEvent id="Event_0ex06bl">
+      <bpmn:incoming>Flow_1skmy8s</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1skmy8s" sourceRef="Activity_09d1jqt" targetRef="Event_0ex06bl" />
+    <bpmn:serviceTask id="Activity_09d1jqt">
+      <bpmn:incoming>Flow_0tqc5m8</bpmn:incoming>
+      <bpmn:outgoing>Flow_1skmy8s</bpmn:outgoing>
+    </bpmn:serviceTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_051ks7f">
+      <bpmndi:BPMNEdge id="Flow_0tqc5m8_di" bpmnElement="Flow_0tqc5m8">
+        <di:waypoint x="215" y="117" />
+        <di:waypoint x="270" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1skmy8s_di" bpmnElement="Flow_1skmy8s">
+        <di:waypoint x="370" y="117" />
+        <di:waypoint x="432" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0ex06bl_di" bpmnElement="Event_0ex06bl">
+        <dc:Bounds x="432" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_172cnll_di" bpmnElement="Activity_09d1jqt">
+        <dc:Bounds x="270" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/spec/utils/error-messages.spec.js
+++ b/test/spec/utils/error-messages.spec.js
@@ -1,0 +1,612 @@
+import { expect } from 'chai';
+
+import { flatten } from 'min-dash';
+
+import { ERROR_TYPES } from 'bpmnlint-plugin-camunda-compat/rules/utils/error-types';
+
+import {
+  adjustErrorMessage,
+  adjustErrorMessages
+} from '../../../lib/utils/error-messages';
+
+import { createElement } from '../../helper';
+
+import { getLintError } from './lint-helper';
+
+describe('utils/error-messages', function() {
+
+  describe('#adjustErrorMessages', function() {
+
+    it('should adjust error messages', function() {
+
+      // given
+      const reports = {
+        'foo': [
+          createReport({
+            error: {
+              type: ERROR_TYPES.ELEMENT_TYPE_NOT_ALLOWED,
+              node: createElement('bpmn:Task'),
+            }
+          }),
+          createReport({
+            error: {
+              type: ERROR_TYPES.EXTENSION_ELEMENT_REQUIRED,
+              node: createElement('bpmn:ServiceTask'),
+              requiredExtensionElement: 'zeebe:TaskDefinition'
+            }
+          })
+        ]
+      };
+
+      // when
+      const adjusted = adjustErrorMessages(reports, 'Camunda Fox');
+
+      // then
+      expect(getErrorMessages(adjusted)).to.eql([
+        'An <Undefined Task> is not supported by Camunda Fox',
+        'A <Service Task> must have a <Task definition type>'
+      ]);
+    });
+
+  });
+
+
+  describe('#adjustErrorMessage', function() {
+
+    describe('element type not allowed', function() {
+
+      it('should adjust (undefined task)', async function() {
+
+        // given
+        const node = createElement('bpmn:Task');
+
+        const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/is-element');
+
+        const report = await getLintError(node, rule);
+
+        // when
+        const errorMessage = adjustErrorMessage(report, 'Camunda Fox');
+
+        // then
+        expect(errorMessage).to.equal('An <Undefined Task> is not supported by Camunda Fox');
+      });
+
+
+      it('should adjust (undefined intermediate catch event)', async function() {
+
+        // given
+        const node = createElement('bpmn:IntermediateCatchEvent');
+
+        const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/is-element');
+
+        const report = await getLintError(node, rule);
+
+        // when
+        const errorMessage = adjustErrorMessage(report, 'Camunda Fox');
+
+        // then
+        expect(errorMessage).to.equal('An <Undefined Intermediate Catch Event> is not supported by Camunda Fox');
+      });
+
+    });
+
+
+    describe('extension element not allowed', function() {
+
+      it('should adjust (business rule task with called decision)', async function() {
+
+        // given
+        const node = createElement('bpmn:BusinessRuleTask', {
+          extensionElements: createElement('bpmn:ExtensionElements', {
+            values: [
+              createElement('zeebe:CalledDecision')
+            ]
+          })
+        });
+
+        const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/has-called-decision-or-task-definition');
+
+        const { camundaCloud11: config } = await  import('bpmnlint-plugin-camunda-compat/rules/has-called-decision-or-task-definition/config');
+
+        const report = await getLintError(node, rule, config);
+
+        // when
+        const errorMessage = adjustErrorMessage(report, 'Camunda Fox');
+
+        // then
+        expect(errorMessage).to.equal('A <Business Rule Task> with <Implementation: DMN decision> is not supported by Camunda Fox');
+      });
+
+    });
+
+
+    describe('extension element required', function() {
+
+      it('should adjust (called element)', async function() {
+
+        // given
+        const node = createElement('bpmn:CallActivity');
+
+        const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/has-called-element');
+
+        const report = await getLintError(node, rule);
+
+        // when
+        const errorMessage = adjustErrorMessage(report);
+
+        // then
+        expect(errorMessage).to.equal('A <Call Activity> must have a defined <Called element>');
+      });
+
+
+      it('should adjust (loop characteristics)', async function() {
+
+        // given
+        const node = createElement('bpmn:ServiceTask', {
+          loopCharacteristics: createElement('bpmn:MultiInstanceLoopCharacteristics')
+        });
+
+        const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/has-loop-characteristics');
+
+        const report = await getLintError(node, rule);
+
+        // when
+        const errorMessage = adjustErrorMessage(report);
+
+        // then
+        expect(errorMessage).to.equal('A <Service Task> with <Multi-instance marker> must have a defined <Input collection>');
+      });
+
+
+      it('should adjust (subscription)', async function() {
+
+        // given
+        const node = createElement('bpmn:ReceiveTask', {
+          messageRef: createElement('bpmn:Message')
+        });
+
+        const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/has-subscription');
+
+        const report = await getLintError(node, rule);
+
+        // when
+        const errorMessage = adjustErrorMessage(report);
+
+        // then
+        expect(errorMessage).to.equal('A <Receive Task> with <Message Reference> must have a defined <Subscription correlation key>');
+      });
+
+
+      it('should adjust (task definition)', async function() {
+
+        // given
+        const node = createElement('bpmn:ServiceTask');
+
+        const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/has-called-decision-or-task-definition');
+
+        const { camundaCloud10: config } = await import('bpmnlint-plugin-camunda-compat/rules/has-called-decision-or-task-definition/config');
+
+        const report = await getLintError(node, rule, config);
+
+        // when
+        const errorMessage = adjustErrorMessage(report);
+
+        // then
+        expect(errorMessage).to.equal('A <Service Task> must have a <Task definition type>');
+      });
+
+
+      it('should adjust (called decision and task definition)', async function() {
+
+        // given
+        const node = createElement('bpmn:BusinessRuleTask');
+
+        const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/has-called-decision-or-task-definition');
+
+        const { camundaCloud13: config } = await import('bpmnlint-plugin-camunda-compat/rules/has-called-decision-or-task-definition/config');
+
+        const report = await getLintError(node, rule, config);
+
+        // when
+        const errorMessage = adjustErrorMessage(report);
+
+        // then
+        expect(errorMessage).to.equal('A <Business Rule Task> must have a defined <Implementation>');
+      });
+
+    });
+
+
+    describe('property dependend required', function() {
+
+      it('should adjust (output collection)', async function() {
+
+        // given
+        const node = createElement('bpmn:ServiceTask', {
+          loopCharacteristics: createElement('bpmn:MultiInstanceLoopCharacteristics', {
+            extensionElements: createElement('bpmn:ExtensionElements', {
+              values: [
+                createElement('zeebe:LoopCharacteristics', {
+                  inputCollection: 'foo',
+                  outputElement: 'bar'
+                })
+              ]
+            })
+          })
+        });
+
+        const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/has-loop-characteristics');
+
+        const report = await getLintError(node, rule);
+
+        // when
+        const errorMessage = adjustErrorMessage(report);
+
+        // then
+        expect(errorMessage).to.equal('A <Service Task> with <Multi-instance marker> and defined <Output element> must have a defined <Output collection>');
+      });
+
+
+      it('should adjust (output element)', async function() {
+
+        // given
+        const node = createElement('bpmn:ServiceTask', {
+          loopCharacteristics: createElement('bpmn:MultiInstanceLoopCharacteristics', {
+            extensionElements: createElement('bpmn:ExtensionElements', {
+              values: [
+                createElement('zeebe:LoopCharacteristics', {
+                  inputCollection: 'foo',
+                  outputCollection: 'bar'
+                })
+              ]
+            })
+          })
+        });
+
+        const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/has-loop-characteristics');
+
+        const report = await getLintError(node, rule);
+
+        // when
+        const errorMessage = adjustErrorMessage(report);
+
+        // then
+        expect(errorMessage).to.equal('A <Service Task> with <Multi-instance marker> and defined <Output collection> must have a defined <Output element>');
+      });
+
+    });
+
+
+    describe('property required', function() {
+
+      it('should adjust (decision ID)', async function() {
+
+        // given
+        const node = createElement('bpmn:BusinessRuleTask', {
+          extensionElements: createElement('bpmn:ExtensionElements', {
+            values: [
+              createElement('zeebe:CalledDecision', {
+                resultVariable: 'foo'
+              })
+            ]
+          })
+        });
+
+        const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/has-called-decision-or-task-definition');
+
+        const { camundaCloud13: config } = await import('bpmnlint-plugin-camunda-compat/rules/has-called-decision-or-task-definition/config');
+
+        const report = await getLintError(node, rule, config);
+
+        // when
+        const errorMessage = adjustErrorMessage(report);
+
+        // then
+        expect(errorMessage).to.equal('A <Business Rule Task> with <Implementation: DMN decision> must have a defined <Called decision ID>');
+      });
+
+
+      it('should adjust (result variable)', async function() {
+
+        // given
+        const node = createElement('bpmn:BusinessRuleTask', {
+          extensionElements: createElement('bpmn:ExtensionElements', {
+            values: [
+              createElement('zeebe:CalledDecision', {
+                decisionId: 'foo'
+              })
+            ]
+          })
+        });
+
+        const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/has-called-decision-or-task-definition');
+
+        const { camundaCloud13: config } = await import('bpmnlint-plugin-camunda-compat/rules/has-called-decision-or-task-definition/config');
+
+        const report = await getLintError(node, rule, config);
+
+        // when
+        const errorMessage = adjustErrorMessage(report);
+
+        // then
+        expect(errorMessage).to.equal('A <Business Rule Task> with <Implementation: DMN decision> must have a defined <Result variable>');
+      });
+
+
+      it('should adjust (task definition type)', async function() {
+
+        // given
+        const node = createElement('bpmn:BusinessRuleTask', {
+          extensionElements: createElement('bpmn:ExtensionElements', {
+            values: [
+              createElement('zeebe:TaskDefinition')
+            ]
+          })
+        });
+
+        const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/has-called-decision-or-task-definition');
+
+        const { camundaCloud13: config } = await import('bpmnlint-plugin-camunda-compat/rules/has-called-decision-or-task-definition/config');
+
+        const report = await getLintError(node, rule, config);
+
+        // when
+        const errorMessage = adjustErrorMessage(report);
+
+        // then
+        expect(errorMessage).to.equal('A <Business Rule Task> with <Implementation: Job worker> must have a defined <Task definition type>');
+      });
+
+
+      it('should adjust (process ID)', async function() {
+
+        // given
+        const node = createElement('bpmn:CallActivity', {
+          extensionElements: createElement('bpmn:ExtensionElements', {
+            values: [
+              createElement('zeebe:CalledElement')
+            ]
+          })
+        });
+
+        const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/has-called-element');
+
+        const report = await getLintError(node, rule);
+
+        // when
+        const errorMessage = adjustErrorMessage(report);
+
+        // then
+        expect(errorMessage).to.equal('A <Call Activity> must have a defined <Called element>');
+      });
+
+
+      it('should adjust (error code)', async function() {
+
+        // given
+        const node = createElement('bpmn:EndEvent', {
+          eventDefinitions: [
+            createElement('bpmn:ErrorEventDefinition', {
+              errorRef: createElement('bpmn:Error')
+            })
+          ]
+        });
+
+        const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/has-error-reference');
+
+        const report = await getLintError(node, rule);
+
+        // when
+        const errorMessage = adjustErrorMessage(report);
+
+        // then
+        expect(errorMessage).to.equal('An <Error End Event> with <Error Reference> must have a defined <Error code>');
+      });
+
+
+      it('should adjust (event definitions)', async function() {
+
+        // given
+        const node = createElement('bpmn:IntermediateThrowEvent');
+
+        const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/is-element');
+
+        const { camundaCloud10: config } = await import('bpmnlint-plugin-camunda-compat/rules/is-element/config');
+
+        const report = await getLintError(node, rule, config);
+
+        // when
+        const errorMessage = adjustErrorMessage(report, 'Camunda Fox');
+
+        // then
+        expect(errorMessage).to.equal('An <Undefined Intermediate Throw Event> is not supported by Camunda Fox');
+      });
+
+
+      it('should adjust (input collection)', async function() {
+
+        // given
+        const node = createElement('bpmn:ServiceTask', {
+          loopCharacteristics: createElement('bpmn:MultiInstanceLoopCharacteristics', {
+            extensionElements: createElement('bpmn:ExtensionElements', {
+              values: [
+                createElement('zeebe:LoopCharacteristics')
+              ]
+            })
+          })
+        });
+
+        const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/has-loop-characteristics');
+
+        const report = await getLintError(node, rule);
+
+        // when
+        const errorMessage = adjustErrorMessage(report);
+
+        // then
+        expect(errorMessage).to.equal('A <Service Task> with <Multi-instance marker> must have a defined <Input collection>');
+      });
+
+
+      it('should adjust (message name)', async function() {
+
+        // given
+        const node = createElement('bpmn:IntermediateCatchEvent', {
+          eventDefinitions: [
+            createElement('bpmn:MessageEventDefinition', {
+              messageRef: createElement('bpmn:Message')
+            })
+          ]
+        });
+
+        const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/has-message-reference');
+
+        const report = await getLintError(node, rule);
+
+        // when
+        const errorMessage = adjustErrorMessage(report);
+
+        // then
+        expect(errorMessage).to.equal('A <Message Intermediate Catch Event> with <Message Reference> must have a defined <Name>');
+      });
+
+
+      it('should adjust (correlation key)', async function() {
+
+        // given
+        const node = createElement('bpmn:IntermediateCatchEvent', {
+          eventDefinitions: [
+            createElement('bpmn:MessageEventDefinition', {
+              messageRef: createElement('bpmn:Message', {
+                name: 'foo',
+                extensionElements: createElement('bpmn:ExtensionElements', {
+                  values: [
+                    createElement('zeebe:Subscription')
+                  ]
+                })
+              })
+            })
+          ]
+        });
+
+        const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/has-subscription');
+
+        const report = await getLintError(node, rule);
+
+        // when
+        const errorMessage = adjustErrorMessage(report);
+
+        // then
+        expect(errorMessage).to.equal('A <Message Intermediate Catch Event> with <Message Reference> must have a defined <Subscription correlation key>');
+      });
+
+
+      it('should adjust (task definition type)', async function() {
+
+        // given
+        const node = createElement('bpmn:ServiceTask', {
+          extensionElements: createElement('bpmn:ExtensionElements', {
+            values: [
+              createElement('zeebe:TaskDefinition')
+            ]
+          })
+        });
+
+        const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/has-called-decision-or-task-definition');
+
+        const { camundaCloud10: config } = await import('bpmnlint-plugin-camunda-compat/rules/has-called-decision-or-task-definition/config');
+
+        const report = await getLintError(node, rule, config);
+
+        // when
+        const errorMessage = adjustErrorMessage(report);
+
+        // then
+        expect(errorMessage).to.equal('A <Service Task> with <Implementation: Job worker> must have a defined <Task definition type>');
+      });
+
+
+      it('should adjust (error ref)', async function() {
+
+        // given
+        const node = createElement('bpmn:EndEvent', {
+          eventDefinitions: [
+            createElement('bpmn:ErrorEventDefinition')
+          ]
+        });
+
+        const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/has-error-reference');
+
+        const report = await getLintError(node, rule);
+
+        // when
+        const errorMessage = adjustErrorMessage(report);
+
+        // then
+        expect(errorMessage).to.equal('An <Error End Event> must have a defined <Error Reference>');
+      });
+
+
+      it('should adjust (message ref)', async function() {
+
+        // given
+        const node = createElement('bpmn:IntermediateCatchEvent', {
+          eventDefinitions: [
+            createElement('bpmn:MessageEventDefinition')
+          ]
+        });
+
+        const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/has-message-reference');
+
+        const report = await getLintError(node, rule);
+
+        // when
+        const errorMessage = adjustErrorMessage(report);
+
+        // then
+        expect(errorMessage).to.equal('A <Message Intermediate Catch Event> must have a defined <Message Reference>');
+      });
+
+    });
+
+
+    describe('property type not allowed', function() {
+
+      it('should adjust (event definitions)', async function() {
+
+        // given
+        const node = createElement('bpmn:IntermediateThrowEvent', {
+          eventDefinitions: [
+            createElement('bpmn:MessageEventDefinition')
+          ]
+        });
+
+        const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/is-element');
+
+        const { camundaCloud10: config } = await import('bpmnlint-plugin-camunda-compat/rules/is-element/config');
+
+        const report = await getLintError(node, rule, config);
+
+        // when
+        const errorMessage = adjustErrorMessage(report, 'Camunda Fox');
+
+        // then
+        expect(errorMessage).to.equal('A <Message Intermediate Throw Event> is not supported by Camunda Fox');
+      });
+
+    });
+
+  });
+
+});
+
+function createReport(options) {
+  return {
+    type: 'error',
+    ...options
+  };
+}
+
+function getErrorMessages(reports) {
+  return flatten(Object.values(reports)).map(({ message }) => message);
+}

--- a/test/spec/utils/lint-helper.js
+++ b/test/spec/utils/lint-helper.js
@@ -1,0 +1,53 @@
+import { expect } from 'chai';
+
+import Linter from 'bpmnlint/lib/linter';
+
+async function lintNode(node, rule, config = {}) {
+  const linter = new Linter({
+    resolver: {
+      resolveRule: () => Promise.resolve(rule)
+    }
+  });
+
+  return linter.lint(node, {
+    rules: { 'ruleName': [ 2, config ] }
+  });
+}
+
+/**
+ * Lint node with given rule and configuration expecting one report.
+ *
+ * @param {Object} node
+ * @param {Function} rule
+ * @param {Object} [config]
+ *
+ * @returns {Object}
+ */
+export async function getLintError(node, rule, config = {}) {
+  const { ruleName } = await lintNode(node, rule, config);
+
+  // assume
+  expect(ruleName).to.exist;
+  expect(ruleName).to.have.length(1);
+
+  return ruleName[ 0 ];
+}
+
+/**
+ * Lint node with given rule and configuration expecting one or more reports.
+ *
+ * @param {Object} node
+ * @param {Function} rule
+ * @param {Object} [config]
+ *
+ * @returns {Object}
+ */
+export async function getLintErrors(node, rule, config = {}) {
+  const { ruleName } = await lintNode(node, rule, config);
+
+  // assume
+  expect(ruleName).to.exist;
+  expect(ruleName).to.have.lengthOf.greaterThanOrEqual(1);
+
+  return ruleName;
+}

--- a/test/spec/utils/types.spec.js
+++ b/test/spec/utils/types.spec.js
@@ -1,0 +1,56 @@
+import { expect } from 'chai';
+
+import { getTypeString } from '../../../lib/utils/types';
+
+import { createElement } from '../../helper';
+
+describe('utils/types', function() {
+
+  it('should get type (undefined task)', function() {
+
+    // given
+    const element = createElement('bpmn:Task');
+
+    // when
+    // then
+    expect(getTypeString(element)).to.equal('Undefined Task');
+  });
+
+
+  it('should get type (service task)', function() {
+
+    // given
+    const element = createElement('bpmn:ServiceTask');
+
+    // when
+    // then
+    expect(getTypeString(element)).to.equal('Service Task');
+  });
+
+
+  it('should get type (undefined intermediate catch event)', function() {
+
+    // given
+    const element = createElement('bpmn:IntermediateCatchEvent');
+
+    // when
+    // then
+    expect(getTypeString(element)).to.equal('Undefined Intermediate Catch Event');
+  });
+
+
+  it('should get type (message intermediate catch event)', function() {
+
+    // given
+    const element = createElement('bpmn:IntermediateCatchEvent', {
+      eventDefinitions: [
+        createElement('bpmn:MessageEventDefinition')
+      ]
+    });
+
+    // when
+    // then
+    expect(getTypeString(element)).to.equal('Message Intermediate Catch Event');
+  });
+
+});


### PR DESCRIPTION
The BPMN linter used by the Camunda Desktop and Web Modeler. Batteries included. 🔋

# Features

* bundles [bpmnlint](https://github.com/bpmn-io/bpmnlint) and [bpmnlint-plugin-camunda-compat](https://github.com/camunda/bpmnlint-plugin-camunda-compat/)
* configures linter based on `modeler:executionPlatform` and `modeler:executionPlatformVersion`
* adjusts error messages to be shown in desktop and web modeler

# Usage

```javascript
import { Linter } from '@camunda/linting';

...

// lint by passing definitions
const reports = await Linter.lint(definitions);

// or passing XML
const reports = await Linter.lint(xml);
```

---

Depends on https://github.com/camunda/bpmnlint-plugin-camunda-compat/pull/29
Related to https://github.com/bpmn-io/internal-docs/issues/517