### PR TITLE
fix: make bpmn-moddle and zeebe-bpmn-moddle production dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2108,8 +2108,7 @@
     "zeebe-bpmn-moddle": {
       "version": "0.12.1",
       "resolved": "https://registry.npmjs.org/zeebe-bpmn-moddle/-/zeebe-bpmn-moddle-0.12.1.tgz",
-      "integrity": "sha512-rnUoK+A/gzinOGUlmJKeXmnjorgEm4yf7qgeaowXGZOFtFqtM2lvJ7XYTJNsKClaNfFG245JtKHH3G/caJxE6g==",
-      "dev": true
+      "integrity": "sha512-rnUoK+A/gzinOGUlmJKeXmnjorgEm4yf7qgeaowXGZOFtFqtM2lvJ7XYTJNsKClaNfFG245JtKHH3G/caJxE6g=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,20 +19,20 @@
   },
   "license": "MIT",
   "dependencies": {
+    "bpmn-moddle": "^7.1.2",
     "bpmnlint": "^7.8.0",
     "bpmnlint-plugin-camunda-compat": "^0.9.1",
     "bpmnlint-utils": "^1.0.2",
-    "modeler-moddle": "^0.2.0"
+    "modeler-moddle": "^0.2.0",
+    "zeebe-bpmn-moddle": "^0.12.1"
   },
   "devDependencies": {
-    "bpmn-moddle": "^7.1.2",
     "chai": "^4.3.6",
     "eslint": "^4.11.0",
     "eslint-plugin-bpmn-io": "^0.4.1",
     "esm": "^3.2.25",
     "min-dash": "^3.8.1",
-    "mocha": "^4.0.1",
-    "zeebe-bpmn-moddle": "^0.12.1"
+    "mocha": "^4.0.1"
   },
   "peerDependencies": {
     "bpmn-js-properties-panel": "1.3.x"


### PR DESCRIPTION
* didn't blow up in the past because these are dependencies of camunda-bpmn-js 🤡 