### PR TITLE
Set error message for `duplicate-task-headers` rule

### DIFF
--- a/lib/Linter.js
+++ b/lib/Linter.js
@@ -12,7 +12,7 @@ import modelerModdle from 'modeler-moddle/resources/modeler.json';
 import zeebeModdle from 'zeebe-bpmn-moddle/resources/zeebe.json';
 
 import { getErrorMessage } from './utils/error-messages';
-import { getEntryId } from './utils/properties-panel';
+import { getEntryIds } from './utils/properties-panel';
 
 const moddle = new BpmnModdle({
   modeler: modelerModdle,
@@ -63,6 +63,8 @@ export class Linter {
       return [
         ...allReports,
         ...reports.map(report => {
+          const entryIds = getEntryIds(report);
+
           return {
             ...report,
             message: getErrorMessage(
@@ -71,7 +73,7 @@ export class Linter {
               this._modeler
             ),
             propertiesPanel: {
-              entryId: getEntryId(report)
+              entryId: entryIds[ Math.max(0, entryIds.length - 1) ]
             }
           };
         })

--- a/lib/utils/error-messages.js
+++ b/lib/utils/error-messages.js
@@ -1,6 +1,7 @@
 import { ERROR_TYPES } from 'bpmnlint-plugin-camunda-compat/rules/utils/element';
 
 import { is } from 'bpmnlint-utils';
+import { every } from 'min-dash';
 
 import { isArray } from 'min-dash';
 
@@ -46,6 +47,10 @@ export function getErrorMessage(report, executionPlatformLabel, modeler = 'deskt
     return getPropertyTypeNotAllowedErrorMessage(report, executionPlatformLabel);
   }
 
+  if (type === ERROR_TYPES.PROPERTY_VALUE_DUPLICATED) {
+    return getPropertyValueDuplicatedErrorMessage(report);
+  }
+
   return message;
 }
 
@@ -71,6 +76,28 @@ function getElementTypeNotAllowedErrorMessage(report, executionPlatformLabel) {
   const typeString = getTypeString(node);
 
   return `${ getIndefiniteArticle(typeString) } <${ typeString }> is not supported by ${ executionPlatformLabel }`;
+}
+
+function getPropertyValueDuplicatedErrorMessage(report) {
+  const {
+    error,
+    message
+  } = report;
+
+  const {
+    node,
+    parentNode,
+    duplicatedPropertyValue,
+    properties
+  } = error;
+
+  const typeString = getTypeString(parentNode || node);
+
+  if (is(node, 'zeebe:TaskHeaders') && every(properties, property => is(property, 'zeebe:Header'))) {
+    return `${ getIndefiniteArticle(typeString) } <${ typeString }> with two or more <Headers> with the same <Key> (${ duplicatedPropertyValue }) is not supported`;
+  }
+
+  return message;
 }
 
 function getExtensionElementNotAllowedErrorMessage(report, executionPlatformLabel) {

--- a/lib/utils/properties-panel.js
+++ b/lib/utils/properties-panel.js
@@ -4,78 +4,6 @@ import { is } from 'bpmnlint-utils';
 
 import { ERROR_TYPES } from 'bpmnlint-plugin-camunda-compat/rules/utils/error-types';
 
-export function getEntryId(report) {
-  const {
-    error = {}
-  } = report;
-
-  if (isExtensionElementRequiredError(error, 'zeebe:CalledDecision', 'bpmn:BusinessRuleTask')) {
-    return 'businessRuleImplementation';
-  }
-
-  if (isPropertyRequiredError(error, 'errorRef')) {
-    return 'errorRef';
-  }
-
-  if (isPropertyRequiredError(error, 'messageRef')) {
-    return 'messageRef';
-  }
-
-  if (isPropertyRequiredError(error, 'decisionId', 'zeebe:CalledDecision')) {
-    return 'decisionId';
-  }
-
-  if (isPropertyRequiredError(error, 'resultVariable', 'zeebe:CalledDecision')) {
-    return 'resultVariable';
-  }
-
-  if (isPropertyRequiredError(error, 'errorCode', 'bpmn:Error')) {
-    return 'errorCode';
-  }
-
-  if (isPropertyRequiredError(error, 'name', 'bpmn:Message')) {
-    return 'messageName';
-  }
-
-  if (isExtensionElementRequiredError(error, 'zeebe:LoopCharacteristics', 'bpmn:MultiInstanceLoopCharacteristics')
-    || isPropertyRequiredError(error, 'inputCollection', 'zeebe:LoopCharacteristics')) {
-    return 'multiInstance-inputCollection';
-  }
-
-  if (isPropertyDependendRequiredError(error, 'outputCollection', 'zeebe:LoopCharacteristics')) {
-    return 'multiInstance-outputCollection';
-  }
-
-  if (isPropertyDependendRequiredError(error, 'outputElement', 'zeebe:LoopCharacteristics')) {
-    return 'multiInstance-outputElement';
-  }
-
-  if (isExtensionElementRequiredError(error, 'zeebe:CalledElement', 'bpmn:CallActivity')
-    || isPropertyRequiredError(error, 'processId', 'zeebe:CalledElement')) {
-    return 'targetProcessId';
-  }
-
-  if (isExtensionElementRequiredError(error, 'zeebe:TaskDefinition')
-    || isPropertyRequiredError(error, 'type', 'zeebe:TaskDefinition')) {
-    return 'taskDefinitionType';
-  }
-
-  if (isExtensionElementRequiredError(error, 'zeebe:Subscription')
-    || isPropertyRequiredError(error, 'correlationKey', 'zeebe:Subscription')) {
-    return 'messageSubscriptionCorrelationKey';
-  }
-
-  if (isPropertyRequiredError(error, 'formKey', 'zeebe:FormDefinition')) {
-    return 'customFormKey';
-  }
-
-  if (isPropertyRequiredError(error, 'body', 'zeebe:UserTaskForm')) {
-    return 'formConfiguration';
-  }
-
-  return null;
-}
-
 /**
  * Get errors for a given element.
  *
@@ -90,21 +18,111 @@ export function getErrors(reports, element) {
       return errors;
     }
 
-    const id = getEntryId(report);
+    const ids = getEntryIds(report);
 
-    if (!id) {
+    if (!ids.length) {
       return errors;
     }
 
     let { message } = report;
 
-    message = getErrorMessage(id) || message;
-
     return {
       ...errors,
-      [ id ]: message
+      ...ids.reduce((errors, id) => {
+        return {
+          ...errors,
+          [ id ]: getErrorMessage(id) || message
+        };
+      }, {})
     };
   }, {});
+}
+
+export function getEntryIds(report) {
+  const {
+    error = {},
+    id
+  } = report;
+
+  if (isExtensionElementRequiredError(error, 'zeebe:CalledDecision', 'bpmn:BusinessRuleTask')) {
+    return [ 'businessRuleImplementation' ];
+  }
+
+  if (isPropertyRequiredError(error, 'errorRef')) {
+    return [ 'errorRef' ];
+  }
+
+  if (isPropertyRequiredError(error, 'messageRef')) {
+    return [ 'messageRef' ];
+  }
+
+  if (isPropertyRequiredError(error, 'decisionId', 'zeebe:CalledDecision')) {
+    return [ 'decisionId' ];
+  }
+
+  if (isPropertyRequiredError(error, 'resultVariable', 'zeebe:CalledDecision')) {
+    return [ 'resultVariable' ];
+  }
+
+  if (isPropertyRequiredError(error, 'errorCode', 'bpmn:Error')) {
+    return [ 'errorCode' ];
+  }
+
+  if (isPropertyRequiredError(error, 'name', 'bpmn:Message')) {
+    return [ 'messageName' ];
+  }
+
+  if (isExtensionElementRequiredError(error, 'zeebe:LoopCharacteristics', 'bpmn:MultiInstanceLoopCharacteristics')
+    || isPropertyRequiredError(error, 'inputCollection', 'zeebe:LoopCharacteristics')) {
+    return [ 'multiInstance-inputCollection' ];
+  }
+
+  if (isPropertyDependendRequiredError(error, 'outputCollection', 'zeebe:LoopCharacteristics')) {
+    return [ 'multiInstance-outputCollection' ];
+  }
+
+  if (isPropertyDependendRequiredError(error, 'outputElement', 'zeebe:LoopCharacteristics')) {
+    return [ 'multiInstance-outputElement' ];
+  }
+
+  if (isExtensionElementRequiredError(error, 'zeebe:CalledElement', 'bpmn:CallActivity')
+    || isPropertyRequiredError(error, 'processId', 'zeebe:CalledElement')) {
+    return [ 'targetProcessId' ];
+  }
+
+  if (isExtensionElementRequiredError(error, 'zeebe:TaskDefinition')
+    || isPropertyRequiredError(error, 'type', 'zeebe:TaskDefinition')) {
+    return [ 'taskDefinitionType' ];
+  }
+
+  if (isExtensionElementRequiredError(error, 'zeebe:Subscription')
+    || isPropertyRequiredError(error, 'correlationKey', 'zeebe:Subscription')) {
+    return [ 'messageSubscriptionCorrelationKey' ];
+  }
+
+  if (isPropertyRequiredError(error, 'formKey', 'zeebe:FormDefinition')) {
+    return [ 'customFormKey' ];
+  }
+
+  if (isPropertyRequiredError(error, 'body', 'zeebe:UserTaskForm')) {
+    return [ 'formConfiguration' ];
+  }
+
+  if (isPropertyValueDuplicatedError(error, 'values', 'key', 'zeebe:TaskHeaders')) {
+    const {
+      node,
+      properties,
+      propertiesName
+    } = error;
+
+    return properties.map(property => {
+      const index = node.get(propertiesName).indexOf(property);
+
+      return `${ id }-header-${ index }-key`;
+    });
+  }
+
+  return [];
 }
 
 export function getErrorMessage(id) {
@@ -167,6 +185,10 @@ export function getErrorMessage(id) {
   if (id === 'formConfiguration') {
     return 'Form JSON configuration must be defined.';
   }
+
+  if (/^.+-header-[0-9]+-key$/.test(id)) {
+    return 'Must be unique.';
+  }
 }
 
 function isExtensionElementRequiredError(error, requiredExtensionElement, type) {
@@ -185,6 +207,13 @@ function isPropertyDependendRequiredError(error, dependendRequiredProperty, type
 function isPropertyRequiredError(error, requiredProperty, type) {
   return error.type === ERROR_TYPES.PROPERTY_REQUIRED
     && error.requiredProperty === requiredProperty
+    && (!type || is(error.node, type));
+}
+
+function isPropertyValueDuplicatedError(error, propertiesName, duplicatedProperty, type) {
+  return error.type === ERROR_TYPES.PROPERTY_VALUE_DUPLICATED
+    && error.propertiesName === propertiesName
+    && error.duplicatedProperty === duplicatedProperty
     && (!type || is(error.node, type));
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -331,9 +331,9 @@
       }
     },
     "bpmnlint-plugin-camunda-compat": {
-      "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/bpmnlint-plugin-camunda-compat/-/bpmnlint-plugin-camunda-compat-0.9.2.tgz",
-      "integrity": "sha512-Wu8hTfK3LEJJX5QVNbnuSkaulo+/NvClA0I+aTGep2aPiDV4pljdkPaqVQEKeiUufbj39FySaCQzutkq8DzDKQ==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/bpmnlint-plugin-camunda-compat/-/bpmnlint-plugin-camunda-compat-0.10.0.tgz",
+      "integrity": "sha512-FhD53vzviGkQLb+9pFAGEKTCqxexmvo/t8Sgvr+Jw6MY551IQrF96pqxgcXb6hvXs2pi13tw9ZkZGlHk8+CIpA==",
       "requires": {
         "@bpmn-io/moddle-utils": "^0.1.0",
         "bpmnlint-utils": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "bpmn-moddle": "^7.1.2",
     "bpmnlint": "^7.8.0",
-    "bpmnlint-plugin-camunda-compat": "^0.9.2",
+    "bpmnlint-plugin-camunda-compat": "^0.10.0",
     "bpmnlint-utils": "^1.0.2",
     "modeler-moddle": "^0.2.0",
     "zeebe-bpmn-moddle": "^0.12.1"

--- a/package.json
+++ b/package.json
@@ -17,6 +17,10 @@
     "name": "Philipp Fromme",
     "url": "https://github.com/philippfromme"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/camunda/linting"
+  },
   "license": "MIT",
   "dependencies": {
     "bpmn-moddle": "^7.1.2",

--- a/test/spec/camunda-cloud-1-0-invalid.bpmn
+++ b/test/spec/camunda-cloud-1-0-invalid.bpmn
@@ -10,6 +10,10 @@
     <bpmn:serviceTask id="Activity_0tmvr8k" name="foo">
       <bpmn:extensionElements>
         <zeebe:taskDefinition />
+        <zeebe:taskHeaders>
+          <zeebe:header key="foo" />
+          <zeebe:header key="foo" />
+        </zeebe:taskHeaders>
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_1c9prry</bpmn:incoming>
       <bpmn:outgoing>Flow_04jud3f</bpmn:outgoing>

--- a/test/spec/camunda-cloud-1-0-valid.bpmn
+++ b/test/spec/camunda-cloud-1-0-valid.bpmn
@@ -10,6 +10,10 @@
     <bpmn:serviceTask id="Activity_0tmvr8k" name="foo">
       <bpmn:extensionElements>
         <zeebe:taskDefinition type="foo" />
+        <zeebe:taskHeaders>
+          <zeebe:header key="foo" />
+          <zeebe:header key="bar" />
+        </zeebe:taskHeaders>
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_1c9prry</bpmn:incoming>
       <bpmn:outgoing>Flow_04jud3f</bpmn:outgoing>

--- a/test/spec/camunda-cloud-1-1-invalid.bpmn
+++ b/test/spec/camunda-cloud-1-1-invalid.bpmn
@@ -11,6 +11,10 @@
     <bpmn:serviceTask id="Activity_0tmvr8k" name="foo">
       <bpmn:extensionElements>
         <zeebe:taskDefinition />
+        <zeebe:taskHeaders>
+          <zeebe:header key="foo" />
+          <zeebe:header key="foo" />
+        </zeebe:taskHeaders>
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_1c9prry</bpmn:incoming>
       <bpmn:outgoing>Flow_04jud3f</bpmn:outgoing>

--- a/test/spec/camunda-cloud-1-1-valid.bpmn
+++ b/test/spec/camunda-cloud-1-1-valid.bpmn
@@ -11,6 +11,10 @@
     <bpmn:serviceTask id="Activity_0tmvr8k" name="foo">
       <bpmn:extensionElements>
         <zeebe:taskDefinition type="foo" />
+        <zeebe:taskHeaders>
+          <zeebe:header key="foo" />
+          <zeebe:header key="bar" />
+        </zeebe:taskHeaders>
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_1c9prry</bpmn:incoming>
       <bpmn:outgoing>Flow_04jud3f</bpmn:outgoing>

--- a/test/spec/camunda-cloud-1-2-invalid.bpmn
+++ b/test/spec/camunda-cloud-1-2-invalid.bpmn
@@ -11,6 +11,10 @@
     <bpmn:serviceTask id="Activity_0tmvr8k" name="foo">
       <bpmn:extensionElements>
         <zeebe:taskDefinition />
+        <zeebe:taskHeaders>
+          <zeebe:header key="foo" />
+          <zeebe:header key="foo" />
+        </zeebe:taskHeaders>
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_1c9prry</bpmn:incoming>
       <bpmn:outgoing>Flow_04jud3f</bpmn:outgoing>

--- a/test/spec/camunda-cloud-1-2-valid.bpmn
+++ b/test/spec/camunda-cloud-1-2-valid.bpmn
@@ -11,6 +11,10 @@
     <bpmn:serviceTask id="Activity_0tmvr8k" name="foo">
       <bpmn:extensionElements>
         <zeebe:taskDefinition type="foo" />
+        <zeebe:taskHeaders>
+          <zeebe:header key="foo" />
+          <zeebe:header key="bar" />
+        </zeebe:taskHeaders>
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_1c9prry</bpmn:incoming>
       <bpmn:outgoing>Flow_04jud3f</bpmn:outgoing>

--- a/test/spec/camunda-cloud-1-3-invalid.bpmn
+++ b/test/spec/camunda-cloud-1-3-invalid.bpmn
@@ -11,6 +11,10 @@
     <bpmn:serviceTask id="Activity_0tmvr8k" name="foo">
       <bpmn:extensionElements>
         <zeebe:taskDefinition />
+        <zeebe:taskHeaders>
+          <zeebe:header key="foo" />
+          <zeebe:header key="foo" />
+        </zeebe:taskHeaders>
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_1c9prry</bpmn:incoming>
       <bpmn:outgoing>Flow_04jud3f</bpmn:outgoing>

--- a/test/spec/camunda-cloud-1-3-valid.bpmn
+++ b/test/spec/camunda-cloud-1-3-valid.bpmn
@@ -11,6 +11,10 @@
     <bpmn:serviceTask id="Activity_0tmvr8k" name="foo">
       <bpmn:extensionElements>
         <zeebe:taskDefinition type="foo" />
+        <zeebe:taskHeaders>
+          <zeebe:header key="foo" />
+          <zeebe:header key="bar" />
+        </zeebe:taskHeaders>
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_1c9prry</bpmn:incoming>
       <bpmn:outgoing>Flow_04jud3f</bpmn:outgoing>

--- a/test/spec/camunda-cloud-8-0-invalid.bpmn
+++ b/test/spec/camunda-cloud-8-0-invalid.bpmn
@@ -11,6 +11,10 @@
     <bpmn:serviceTask id="Activity_0tmvr8k" name="foo">
       <bpmn:extensionElements>
         <zeebe:taskDefinition />
+        <zeebe:taskHeaders>
+          <zeebe:header key="foo" />
+          <zeebe:header key="foo" />
+        </zeebe:taskHeaders>
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_1c9prry</bpmn:incoming>
       <bpmn:outgoing>Flow_04jud3f</bpmn:outgoing>

--- a/test/spec/camunda-cloud-8-0-valid.bpmn
+++ b/test/spec/camunda-cloud-8-0-valid.bpmn
@@ -11,6 +11,10 @@
     <bpmn:serviceTask id="Activity_0tmvr8k" name="foo">
       <bpmn:extensionElements>
         <zeebe:taskDefinition type="foo" />
+        <zeebe:taskHeaders>
+          <zeebe:header key="foo" />
+          <zeebe:header key="bar" />
+        </zeebe:taskHeaders>
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_1c9prry</bpmn:incoming>
       <bpmn:outgoing>Flow_04jud3f</bpmn:outgoing>

--- a/test/spec/utils/error-messages.spec.js
+++ b/test/spec/utils/error-messages.spec.js
@@ -656,6 +656,38 @@ describe('utils/error-messages', function() {
 
     });
 
+
+    describe('property value duplicated', function() {
+
+      it('should adjust (two headers with same key)', async function() {
+
+        // given
+        const node = createElement('bpmn:ServiceTask', {
+          extensionElements: createElement('bpmn:ExtensionElements', {
+            values: [
+              createElement('zeebe:TaskHeaders', {
+                values: [
+                  createElement('zeebe:Header', { key: 'foo' }),
+                  createElement('zeebe:Header', { key: 'foo' })
+                ]
+              })
+            ]
+          })
+        });
+
+        const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/duplicate-task-headers');
+
+        const report = await getLintError(node, rule);
+
+        // when
+        const errorMessage = getErrorMessage(report);
+
+        // then
+        expect(errorMessage).to.equal('A <Service Task> with two or more <Headers> with the same <Key> (foo) is not supported');
+      });
+
+    });
+
   });
 
 });

--- a/test/spec/utils/properties-panel.spec.js
+++ b/test/spec/utils/properties-panel.spec.js
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import { Linter } from '../../..';
 
 import {
-  getEntryId,
+  getEntryIds,
   getErrorMessage,
   getErrors
 } from '../../../lib/utils/properties-panel';
@@ -31,12 +31,12 @@ describe('utils/properties-panel', function() {
       const report = await getLintError(node, rule, config);
 
       // when
-      const entryId = getEntryId(report);
+      const entryIds = getEntryIds(report);
 
       // then
-      expect(entryId).to.equal('businessRuleImplementation');
+      expect(entryIds).to.eql([ 'businessRuleImplementation' ]);
 
-      expectErrorMessage(entryId, 'Implementation must be defined.');
+      expectErrorMessage(entryIds[ 0 ], 'Implementation must be defined.');
     });
 
 
@@ -54,12 +54,12 @@ describe('utils/properties-panel', function() {
       const report = await getLintError(node, rule);
 
       // when
-      const entryId = getEntryId(report);
+      const entryIds = getEntryIds(report);
 
       // then
-      expect(entryId).to.equal('errorRef');
+      expect(entryIds).to.eql([ 'errorRef' ]);
 
-      expectErrorMessage(entryId, 'Global error reference must be defined.');
+      expectErrorMessage(entryIds[ 0 ], 'Global error reference must be defined.');
     });
 
 
@@ -77,12 +77,12 @@ describe('utils/properties-panel', function() {
       const report = await getLintError(node, rule);
 
       // when
-      const entryId = getEntryId(report);
+      const entryIds = getEntryIds(report);
 
       // then
-      expect(entryId).to.equal('messageRef');
+      expect(entryIds).to.eql([ 'messageRef' ]);
 
-      expectErrorMessage(entryId, 'Global message reference must be defined.');
+      expectErrorMessage(entryIds[ 0 ], 'Global message reference must be defined.');
     });
 
 
@@ -106,12 +106,12 @@ describe('utils/properties-panel', function() {
       const report = await getLintError(node, rule, config);
 
       // when
-      const entryId = getEntryId(report);
+      const entryIds = getEntryIds(report);
 
       // then
-      expect(entryId).to.equal('decisionId');
+      expect(entryIds).to.eql([ 'decisionId' ]);
 
-      expectErrorMessage(entryId, 'Decision ID must be defined.');
+      expectErrorMessage(entryIds[ 0 ], 'Decision ID must be defined.');
     });
 
 
@@ -135,12 +135,12 @@ describe('utils/properties-panel', function() {
       const report = await getLintError(node, rule, config);
 
       // when
-      const entryId = getEntryId(report);
+      const entryIds = getEntryIds(report);
 
       // then
-      expect(entryId).to.equal('resultVariable');
+      expect(entryIds).to.eql([ 'resultVariable' ]);
 
-      expectErrorMessage(entryId, 'Result variable must be defined.');
+      expectErrorMessage(entryIds[ 0 ], 'Result variable must be defined.');
     });
 
 
@@ -160,12 +160,12 @@ describe('utils/properties-panel', function() {
       const report = await getLintError(node, rule);
 
       // when
-      const entryId = getEntryId(report);
+      const entryIds = getEntryIds(report);
 
       // then
-      expect(entryId).to.equal('errorCode');
+      expect(entryIds).to.eql([ 'errorCode' ]);
 
-      expectErrorMessage(entryId, 'Code must be defined.');
+      expectErrorMessage(entryIds[ 0 ], 'Code must be defined.');
     });
 
 
@@ -185,12 +185,12 @@ describe('utils/properties-panel', function() {
       const report = await getLintError(node, rule);
 
       // when
-      const entryId = getEntryId(report);
+      const entryIds = getEntryIds(report);
 
       // then
-      expect(entryId).to.equal('messageName');
+      expect(entryIds).to.eql([ 'messageName' ]);
 
-      expectErrorMessage(entryId, 'Name must be defined.');
+      expectErrorMessage(entryIds[ 0 ], 'Name must be defined.');
     });
 
 
@@ -208,12 +208,12 @@ describe('utils/properties-panel', function() {
         const report = await getLintError(node, rule);
 
         // when
-        const entryId = getEntryId(report);
+        const entryIds = getEntryIds(report);
 
         // then
-        expect(entryId).to.equal('multiInstance-inputCollection');
+        expect(entryIds).to.eql([ 'multiInstance-inputCollection' ]);
 
-        expectErrorMessage(entryId, 'Input collection must be defined.');
+        expectErrorMessage(entryIds[ 0 ], 'Input collection must be defined.');
       });
 
 
@@ -235,12 +235,12 @@ describe('utils/properties-panel', function() {
         const report = await getLintError(node, rule);
 
         // when
-        const entryId = getEntryId(report);
+        const entryIds = getEntryIds(report);
 
         // then
-        expect(entryId).to.equal('multiInstance-inputCollection');
+        expect(entryIds).to.eql([ 'multiInstance-inputCollection' ]);
 
-        expectErrorMessage(entryId, 'Input collection must be defined.');
+        expectErrorMessage(entryIds[ 0 ], 'Input collection must be defined.');
       });
 
     });
@@ -267,12 +267,12 @@ describe('utils/properties-panel', function() {
       const report = await getLintError(node, rule);
 
       // when
-      const entryId = getEntryId(report);
+      const entryIds = getEntryIds(report);
 
       // then
-      expect(entryId).to.equal('multiInstance-outputCollection');
+      expect(entryIds).to.eql([ 'multiInstance-outputCollection' ]);
 
-      expectErrorMessage(entryId, 'Output collection must be defined.');
+      expectErrorMessage(entryIds[ 0 ], 'Output collection must be defined.');
     });
 
 
@@ -297,12 +297,12 @@ describe('utils/properties-panel', function() {
       const report = await getLintError(node, rule);
 
       // when
-      const entryId = getEntryId(report);
+      const entryIds = getEntryIds(report);
 
       // then
-      expect(entryId).to.equal('multiInstance-outputElement');
+      expect(entryIds).to.eql([ 'multiInstance-outputElement' ]);
 
-      expectErrorMessage(entryId, 'Output element must be defined.');
+      expectErrorMessage(entryIds[ 0 ], 'Output element must be defined.');
     });
 
 
@@ -318,12 +318,12 @@ describe('utils/properties-panel', function() {
         const report = await getLintError(node, rule);
 
         // when
-        const entryId = getEntryId(report);
+        const entryIds = getEntryIds(report);
 
         // then
-        expect(entryId).to.equal('targetProcessId');
+        expect(entryIds).to.eql([ 'targetProcessId' ]);
 
-        expectErrorMessage(entryId, 'Process ID must be defined.');
+        expectErrorMessage(entryIds[ 0 ], 'Process ID must be defined.');
       });
 
 
@@ -343,12 +343,12 @@ describe('utils/properties-panel', function() {
         const report = await getLintError(node, rule);
 
         // when
-        const entryId = getEntryId(report);
+        const entryIds = getEntryIds(report);
 
         // then
-        expect(entryId).to.equal('targetProcessId');
+        expect(entryIds).to.eql([ 'targetProcessId' ]);
 
-        expectErrorMessage(entryId, 'Process ID must be defined.');
+        expectErrorMessage(entryIds[ 0 ], 'Process ID must be defined.');
       });
 
     });
@@ -368,12 +368,12 @@ describe('utils/properties-panel', function() {
         const report = await getLintError(node, rule, config);
 
         // when
-        const entryId = getEntryId(report);
+        const entryIds = getEntryIds(report);
 
         // then
-        expect(entryId).to.equal('taskDefinitionType');
+        expect(entryIds).to.eql([ 'taskDefinitionType' ]);
 
-        expectErrorMessage(entryId, 'Type must be defined.');
+        expectErrorMessage(entryIds[ 0 ], 'Type must be defined.');
       });
 
 
@@ -395,12 +395,12 @@ describe('utils/properties-panel', function() {
         const report = await getLintError(node, rule, config);
 
         // when
-        const entryId = getEntryId(report);
+        const entryIds = getEntryIds(report);
 
         // then
-        expect(entryId).to.equal('taskDefinitionType');
+        expect(entryIds).to.eql([ 'taskDefinitionType' ]);
 
-        expectErrorMessage(entryId, 'Type must be defined.');
+        expectErrorMessage(entryIds[ 0 ], 'Type must be defined.');
       });
 
     });
@@ -420,12 +420,12 @@ describe('utils/properties-panel', function() {
         const report = await getLintError(node, rule);
 
         // when
-        const entryId = getEntryId(report);
+        const entryIds = getEntryIds(report);
 
         // then
-        expect(entryId).to.equal('messageSubscriptionCorrelationKey');
+        expect(entryIds).to.eql([ 'messageSubscriptionCorrelationKey' ]);
 
-        expectErrorMessage(entryId, 'Subscription correlation key must be defined.');
+        expectErrorMessage(entryIds[ 0 ], 'Subscription correlation key must be defined.');
       });
 
 
@@ -447,12 +447,12 @@ describe('utils/properties-panel', function() {
         const report = await getLintError(node, rule);
 
         // when
-        const entryId = getEntryId(report);
+        const entryIds = getEntryIds(report);
 
         // then
-        expect(entryId).to.equal('messageSubscriptionCorrelationKey');
+        expect(entryIds).to.eql([ 'messageSubscriptionCorrelationKey' ]);
 
-        expectErrorMessage(entryId, 'Subscription correlation key must be defined.');
+        expectErrorMessage(entryIds[ 0 ], 'Subscription correlation key must be defined.');
       });
 
     });
@@ -474,12 +474,12 @@ describe('utils/properties-panel', function() {
       const report = await getLintError(node, rule);
 
       // when
-      const entryId = getEntryId(report);
+      const entryIds = getEntryIds(report);
 
       // then
-      expect(entryId).to.equal('customFormKey');
+      expect(entryIds).to.eql([ 'customFormKey' ]);
 
-      expectErrorMessage(entryId, 'Form key must be defined.');
+      expectErrorMessage(entryIds[ 0 ], 'Form key must be defined.');
     });
 
 
@@ -514,12 +514,46 @@ describe('utils/properties-panel', function() {
       const report = await getLintError(node, rule);
 
       // when
-      const entryId = getEntryId(report);
+      const entryIds = getEntryIds(report);
 
       // then
-      expect(entryId).to.equal('formConfiguration');
+      expect(entryIds).to.eql([ 'formConfiguration' ]);
 
-      expectErrorMessage(entryId, 'Form JSON configuration must be defined.');
+      expectErrorMessage(entryIds[ 0 ], 'Form JSON configuration must be defined.');
+    });
+
+
+    it('headerKey', async function() {
+
+      // given
+      const node = createElement('bpmn:ServiceTask', {
+        id: 'ServiceTask_1',
+        extensionElements: createElement('bpmn:ExtensionElements', {
+          values: [
+            createElement('zeebe:TaskHeaders', {
+              values: [
+                createElement('zeebe:Header', { key: 'foo' }),
+                createElement('zeebe:Header', { key: 'foo' })
+              ]
+            })
+          ]
+        })
+      });
+
+      const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/duplicate-task-headers');
+
+      const report = await getLintError(node, rule);
+
+      // when
+      const entryIds = getEntryIds(report);
+
+      // then
+      expect(entryIds).to.eql([
+        'ServiceTask_1-header-0-key',
+        'ServiceTask_1-header-1-key'
+      ]);
+
+      expectErrorMessage(entryIds[ 0 ], 'Must be unique.');
     });
 
   });
@@ -562,12 +596,10 @@ describe('utils/properties-panel', function() {
 });
 
 function expectErrorMessage(id, expectedErrorMessage) {
-  it(id, function() {
 
-    // when
-    const errorMessage = getErrorMessage(id);
+  // when
+  const errorMessage = getErrorMessage(id);
 
-    // then
-    expect(errorMessage).to.equal(expectedErrorMessage);
-  });
+  // then
+  expect(errorMessage).to.equal(expectedErrorMessage);
 }


### PR DESCRIPTION
Requires https://github.com/camunda/bpmnlint-plugin-camunda-compat/pull/41
Closes #4 

Note this is added for all Camunda 8 versions, as it has been failing on deployment since the first supported Zeebe version (cf. https://github.com/camunda/linting/issues/4#issuecomment-1214751256).

----

![image](https://user-images.githubusercontent.com/9433996/185353791-d91a91cf-c276-4e98-af6d-6a260655960c.png)
