### PR TITLE
feat: adjust error message for `zeebe:Properties`

### DIFF
--- a/lib/utils/error-messages.js
+++ b/lib/utils/error-messages.js
@@ -108,11 +108,18 @@ function getExtensionElementNotAllowedErrorMessage(report, executionPlatformLabe
 
   const {
     node,
+    parentNode,
     extensionElement
   } = error;
 
+  const typeString = getTypeString(parentNode || node);
+
   if (is(node, 'bpmn:BusinessRuleTask') && is(extensionElement, 'zeebe:CalledDecision')) {
     return `A <Business Rule Task> with <Implementation: DMN decision> is not supported by ${ executionPlatformLabel }`;
+  }
+
+  if (is(extensionElement, 'zeebe:Properties')) {
+    return `${ getIndefiniteArticle(typeString) } <${ typeString }> with <Extension properties> is not supported by ${ executionPlatformLabel }`;
   }
 
   return message;

--- a/lib/utils/properties-panel.js
+++ b/lib/utils/properties-panel.js
@@ -122,6 +122,14 @@ export function getEntryIds(report) {
     });
   }
 
+  if (isExtensionElementNotAllowedError(error, 'zeebe:Properties')) {
+    const { extensionElement } = error;
+
+    return extensionElement.get('zeebe:properties').map((zeebeProperty, index) => {
+      return `${ id }-extensionProperty-${ index }-name`;
+    });
+  }
+
   return [];
 }
 
@@ -189,6 +197,16 @@ export function getErrorMessage(id) {
   if (/^.+-header-[0-9]+-key$/.test(id)) {
     return 'Must be unique.';
   }
+
+  if (/^.+-extensionProperty-[0-9]+-name$/.test(id)) {
+    return 'Not supported.';
+  }
+}
+
+function isExtensionElementNotAllowedError(error, extensionElement, type) {
+  return error.type === ERROR_TYPES.EXTENSION_ELEMENT_NOT_ALLOWED
+    && is(error.extensionElement, extensionElement)
+    && (!type || is(error.node, type));
 }
 
 function isExtensionElementRequiredError(error, requiredExtensionElement, type) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -331,13 +331,13 @@
       }
     },
     "bpmnlint-plugin-camunda-compat": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/bpmnlint-plugin-camunda-compat/-/bpmnlint-plugin-camunda-compat-0.10.0.tgz",
-      "integrity": "sha512-FhD53vzviGkQLb+9pFAGEKTCqxexmvo/t8Sgvr+Jw6MY551IQrF96pqxgcXb6hvXs2pi13tw9ZkZGlHk8+CIpA==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/bpmnlint-plugin-camunda-compat/-/bpmnlint-plugin-camunda-compat-0.11.0.tgz",
+      "integrity": "sha512-Z09VY3f4/h7zoVDR7hmzardpVRWOgazqsA/tTzP33yA/Iq6wNHMHu1no8q43EhOoU43ZwWrBSU/zZMnYIrnL3g==",
       "requires": {
         "@bpmn-io/moddle-utils": "^0.1.0",
         "bpmnlint-utils": "^1.0.2",
-        "min-dash": "^3.8.0"
+        "min-dash": "^3.8.1"
       }
     },
     "bpmnlint-utils": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2106,9 +2106,9 @@
       "dev": true
     },
     "zeebe-bpmn-moddle": {
-      "version": "0.12.1",
-      "resolved": "https://registry.npmjs.org/zeebe-bpmn-moddle/-/zeebe-bpmn-moddle-0.12.1.tgz",
-      "integrity": "sha512-rnUoK+A/gzinOGUlmJKeXmnjorgEm4yf7qgeaowXGZOFtFqtM2lvJ7XYTJNsKClaNfFG245JtKHH3G/caJxE6g=="
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/zeebe-bpmn-moddle/-/zeebe-bpmn-moddle-0.14.0.tgz",
+      "integrity": "sha512-NofnLlxxbWfEBcWNQf9JHMZdDVtG/8fuZ3CDr3oxjKe4hrgldthrjdu+6o1h+lTZ+QdClgcArZMijNUsMae2FQ=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "bpmn-moddle": "^7.1.2",
     "bpmnlint": "^7.8.0",
-    "bpmnlint-plugin-camunda-compat": "^0.10.0",
+    "bpmnlint-plugin-camunda-compat": "^0.11.0",
     "bpmnlint-utils": "^1.0.2",
     "modeler-moddle": "^0.2.0",
     "zeebe-bpmn-moddle": "^0.12.1"

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "bpmnlint-plugin-camunda-compat": "^0.11.0",
     "bpmnlint-utils": "^1.0.2",
     "modeler-moddle": "^0.2.0",
-    "zeebe-bpmn-moddle": "^0.12.1"
+    "zeebe-bpmn-moddle": "^0.14.0"
   },
   "devDependencies": {
     "chai": "^4.3.6",

--- a/test/spec/Linter.spec.js
+++ b/test/spec/Linter.spec.js
@@ -183,6 +183,32 @@ describe('Linter', function() {
         expect(reports).not.to.be.empty;
       });
 
+
+      it('should lint without errors (Camunda Cloud 8.1.0)', async function() {
+
+        // given
+        const { root } = await readModdle('test/spec/camunda-cloud-8-1-valid.bpmn');
+
+        // when
+        const reports = await linter.lint(root);
+
+        // then
+        expect(reports).to.be.empty;
+      });
+
+
+      it('should lint with errors (Camunda Cloud 8.1.0)', async function() {
+
+        // given
+        const { root } = await readModdle('test/spec/camunda-cloud-8-1-invalid.bpmn');
+
+        // when
+        const reports = await linter.lint(root);
+
+        // then
+        expect(reports).not.to.be.empty;
+      });
+
     });
 
 

--- a/test/spec/camunda-cloud-1-0-invalid.bpmn
+++ b/test/spec/camunda-cloud-1-0-invalid.bpmn
@@ -14,6 +14,9 @@
           <zeebe:header key="foo" />
           <zeebe:header key="foo" />
         </zeebe:taskHeaders>
+        <zeebe:Properties>
+          <zeebe:Property name="foo" value="bar" />
+        </zeebe:Properties>
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_1c9prry</bpmn:incoming>
       <bpmn:outgoing>Flow_04jud3f</bpmn:outgoing>

--- a/test/spec/camunda-cloud-1-2-invalid.bpmn
+++ b/test/spec/camunda-cloud-1-2-invalid.bpmn
@@ -15,6 +15,9 @@
           <zeebe:header key="foo" />
           <zeebe:header key="foo" />
         </zeebe:taskHeaders>
+        <zeebe:Properties>
+          <zeebe:Property name="foo" value="bar" />
+        </zeebe:Properties>
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_1c9prry</bpmn:incoming>
       <bpmn:outgoing>Flow_04jud3f</bpmn:outgoing>

--- a/test/spec/camunda-cloud-1-3-invalid.bpmn
+++ b/test/spec/camunda-cloud-1-3-invalid.bpmn
@@ -15,6 +15,9 @@
           <zeebe:header key="foo" />
           <zeebe:header key="foo" />
         </zeebe:taskHeaders>
+        <zeebe:Properties>
+          <zeebe:Property name="foo" value="bar" />
+        </zeebe:Properties>
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_1c9prry</bpmn:incoming>
       <bpmn:outgoing>Flow_04jud3f</bpmn:outgoing>

--- a/test/spec/camunda-cloud-8-0-invalid.bpmn
+++ b/test/spec/camunda-cloud-8-0-invalid.bpmn
@@ -15,6 +15,9 @@
           <zeebe:header key="foo" />
           <zeebe:header key="foo" />
         </zeebe:taskHeaders>
+        <zeebe:Properties>
+          <zeebe:Property name="foo" value="bar" />
+        </zeebe:Properties>
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_1c9prry</bpmn:incoming>
       <bpmn:outgoing>Flow_04jud3f</bpmn:outgoing>

--- a/test/spec/camunda-cloud-8-1-invalid.bpmn
+++ b/test/spec/camunda-cloud-8-1-invalid.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1vc92ax" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.0.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="1.1.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1vc92ax" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.0.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.1.0">
   <bpmn:collaboration id="Collaboration_013oh0t">
     <bpmn:participant id="Participant_1lhpzkq" processRef="Process_07pko08" />
   </bpmn:collaboration>
@@ -80,9 +80,7 @@
       </bpmn:startEvent>
       <bpmn:sequenceFlow id="Flow_0ydr2ya" sourceRef="Event_0ijiazl" targetRef="Activity_15d1o2q" />
       <bpmn:businessRuleTask id="Activity_15d1o2q">
-        <bpmn:extensionElements>
-          <zeebe:taskDefinition type="foo" />
-        </bpmn:extensionElements>
+        <bpmn:extensionElements />
         <bpmn:incoming>Flow_0ydr2ya</bpmn:incoming>
       </bpmn:businessRuleTask>
     </bpmn:subProcess>
@@ -107,6 +105,8 @@
       <bpmn:incoming>Flow_0wkb4hq</bpmn:incoming>
       <bpmn:outgoing>Flow_1gvflfp</bpmn:outgoing>
       <bpmn:outgoing>Flow_08k7vbr</bpmn:outgoing>
+      <bpmn:outgoing>Flow_19rqft2</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0n84ml1</bpmn:outgoing>
     </bpmn:complexGateway>
     <bpmn:sequenceFlow id="Flow_0wkb4hq" sourceRef="Gateway_03oxb21" targetRef="Gateway_1adft3c" />
     <bpmn:sequenceFlow id="Flow_11x8rdy" sourceRef="Event_1j12ud3" targetRef="Event_0el3zk8" />
@@ -143,6 +143,16 @@
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_1c7yptg</bpmn:incoming>
     </bpmn:sendTask>
+    <bpmn:sequenceFlow id="Flow_19rqft2" sourceRef="Gateway_1adft3c" targetRef="Event_0s4ygc1" />
+    <bpmn:intermediateThrowEvent id="Event_0s4ygc1">
+      <bpmn:incoming>Flow_19rqft2</bpmn:incoming>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_1odggmr" />
+    </bpmn:intermediateThrowEvent>
+    <bpmn:sequenceFlow id="Flow_0n84ml1" sourceRef="Gateway_1adft3c" targetRef="Event_1yqxsot" />
+    <bpmn:endEvent id="Event_1yqxsot">
+      <bpmn:incoming>Flow_0n84ml1</bpmn:incoming>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_04t0675" />
+    </bpmn:endEvent>
     <bpmn:textAnnotation id="TextAnnotation_092byka">
       <bpmn:text>foo</bpmn:text>
     </bpmn:textAnnotation>
@@ -159,6 +169,15 @@
       <bpmndi:BPMNShape id="Participant_1lhpzkq_di" bpmnElement="Participant_1lhpzkq" isHorizontal="true">
         <dc:Bounds x="129" y="80" width="1601" height="650" />
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0n84ml1_di" bpmnElement="Flow_0n84ml1">
+        <di:waypoint x="740" y="405" />
+        <di:waypoint x="740" y="630" />
+        <di:waypoint x="842" y="630" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_19rqft2_di" bpmnElement="Flow_19rqft2">
+        <di:waypoint x="740" y="405" />
+        <di:waypoint x="740" y="612" />
+      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1c7yptg_di" bpmnElement="Flow_1c7yptg">
         <di:waypoint x="510" y="630" />
         <di:waypoint x="560" y="630" />
@@ -315,6 +334,12 @@
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_0iuc6yg_di" bpmnElement="Activity_1d00s75">
         <dc:Bounds x="560" y="590" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_13yl25e_di" bpmnElement="Event_0s4ygc1">
+        <dc:Bounds x="722" y="612" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1deoy07_di" bpmnElement="Event_1yqxsot">
+        <dc:Bounds x="842" y="612" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="TextAnnotation_092byka_di" bpmnElement="TextAnnotation_092byka">
         <dc:Bounds x="370" y="140" width="100" height="30" />

--- a/test/spec/camunda-cloud-8-1-valid.bpmn
+++ b/test/spec/camunda-cloud-8-1-valid.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1vc92ax" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.0.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="1.1.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1vc92ax" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.0.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.1.0">
   <bpmn:collaboration id="Collaboration_013oh0t">
     <bpmn:participant id="Participant_1lhpzkq" processRef="Process_07pko08" />
   </bpmn:collaboration>
@@ -10,10 +10,10 @@
     </bpmn:startEvent>
     <bpmn:serviceTask id="Activity_0tmvr8k" name="foo">
       <bpmn:extensionElements>
-        <zeebe:taskDefinition />
+        <zeebe:taskDefinition type="foo" />
         <zeebe:taskHeaders>
           <zeebe:header key="foo" />
-          <zeebe:header key="foo" />
+          <zeebe:header key="bar" />
         </zeebe:taskHeaders>
         <zeebe:Properties>
           <zeebe:Property name="foo" value="bar" />
@@ -23,7 +23,7 @@
       <bpmn:outgoing>Flow_04jud3f</bpmn:outgoing>
       <bpmn:multiInstanceLoopCharacteristics>
         <bpmn:extensionElements>
-          <zeebe:loopCharacteristics />
+          <zeebe:loopCharacteristics inputCollection="foo" />
         </bpmn:extensionElements>
       </bpmn:multiInstanceLoopCharacteristics>
     </bpmn:serviceTask>
@@ -32,10 +32,15 @@
     </bpmn:endEvent>
     <bpmn:callActivity id="Activity_19dosz4">
       <bpmn:extensionElements>
-        <zeebe:calledElement propagateAllChildVariables="false" />
+        <zeebe:calledElement processId="foo" propagateAllChildVariables="false" />
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_04jud3f</bpmn:incoming>
       <bpmn:outgoing>Flow_1bj4q1g</bpmn:outgoing>
+      <bpmn:multiInstanceLoopCharacteristics>
+        <bpmn:extensionElements>
+          <zeebe:loopCharacteristics inputCollection="foo" />
+        </bpmn:extensionElements>
+      </bpmn:multiInstanceLoopCharacteristics>
     </bpmn:callActivity>
     <bpmn:exclusiveGateway id="Gateway_03oxb21">
       <bpmn:incoming>Flow_1bj4q1g</bpmn:incoming>
@@ -61,7 +66,7 @@
       <bpmn:outgoing>Flow_0uqdyxp</bpmn:outgoing>
       <bpmn:timerEventDefinition id="TimerEventDefinition_1vu1hns" />
     </bpmn:intermediateCatchEvent>
-    <bpmn:receiveTask id="Activity_0v05780" name="bar">
+    <bpmn:receiveTask id="Activity_0v05780" name="bar" messageRef="Message_0inbjmp">
       <bpmn:incoming>Flow_1hk0gog</bpmn:incoming>
       <bpmn:outgoing>Flow_0k2v5e1</bpmn:outgoing>
     </bpmn:receiveTask>
@@ -81,7 +86,7 @@
       <bpmn:sequenceFlow id="Flow_0ydr2ya" sourceRef="Event_0ijiazl" targetRef="Activity_15d1o2q" />
       <bpmn:businessRuleTask id="Activity_15d1o2q">
         <bpmn:extensionElements>
-          <zeebe:taskDefinition type="foo" />
+          <zeebe:calledDecision decisionId="foo" resultVariable="bar" />
         </bpmn:extensionElements>
         <bpmn:incoming>Flow_0ydr2ya</bpmn:incoming>
       </bpmn:businessRuleTask>
@@ -103,16 +108,11 @@
     <bpmn:sequenceFlow id="Flow_0k2v5e1" sourceRef="Activity_0v05780" targetRef="Activity_09495yf" />
     <bpmn:sequenceFlow id="Flow_0uqdyxp" sourceRef="Event_0cyp3nd" targetRef="Activity_18h7yic" />
     <bpmn:sequenceFlow id="Flow_1a5127t" sourceRef="Activity_18h7yic" targetRef="Event_195u06h" />
-    <bpmn:complexGateway id="Gateway_1adft3c">
-      <bpmn:incoming>Flow_0wkb4hq</bpmn:incoming>
-      <bpmn:outgoing>Flow_1gvflfp</bpmn:outgoing>
-      <bpmn:outgoing>Flow_08k7vbr</bpmn:outgoing>
-    </bpmn:complexGateway>
     <bpmn:sequenceFlow id="Flow_0wkb4hq" sourceRef="Gateway_03oxb21" targetRef="Gateway_1adft3c" />
     <bpmn:sequenceFlow id="Flow_11x8rdy" sourceRef="Event_1j12ud3" targetRef="Event_0el3zk8" />
     <bpmn:endEvent id="Event_0el3zk8">
       <bpmn:incoming>Flow_11x8rdy</bpmn:incoming>
-      <bpmn:errorEventDefinition id="ErrorEventDefinition_16vp8au" />
+      <bpmn:errorEventDefinition id="ErrorEventDefinition_16vp8au" errorRef="Error_035q7ey" />
     </bpmn:endEvent>
     <bpmn:sequenceFlow id="Flow_1gvflfp" sourceRef="Gateway_1adft3c" targetRef="Event_0ghtmm6" />
     <bpmn:intermediateThrowEvent id="Event_0ghtmm6">
@@ -121,7 +121,7 @@
     <bpmn:sequenceFlow id="Flow_08k7vbr" sourceRef="Gateway_1adft3c" targetRef="Event_1fzuab7" />
     <bpmn:intermediateCatchEvent id="Event_1fzuab7">
       <bpmn:incoming>Flow_08k7vbr</bpmn:incoming>
-      <bpmn:messageEventDefinition id="MessageEventDefinition_01kef5q" />
+      <bpmn:messageEventDefinition id="MessageEventDefinition_01kef5q" messageRef="Message_0inbjmp" />
     </bpmn:intermediateCatchEvent>
     <bpmn:sequenceFlow id="Flow_00dv1kp" sourceRef="StartEvent_1" targetRef="Activity_1knqz62" />
     <bpmn:manualTask id="Activity_1knqz62">
@@ -143,6 +143,26 @@
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_1c7yptg</bpmn:incoming>
     </bpmn:sendTask>
+    <bpmn:sequenceFlow id="Flow_19rqft2" sourceRef="Gateway_1adft3c" targetRef="Event_0s4ygc1" />
+    <bpmn:intermediateThrowEvent id="Event_0s4ygc1">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="foo" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_19rqft2</bpmn:incoming>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_1odggmr" />
+    </bpmn:intermediateThrowEvent>
+    <bpmn:sequenceFlow id="Flow_0n84ml1" sourceRef="Gateway_1adft3c" targetRef="Event_1yqxsot" />
+    <bpmn:endEvent id="Event_1yqxsot">
+      <bpmn:incoming>Flow_0n84ml1</bpmn:incoming>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_04t0675" />
+    </bpmn:endEvent>
+    <bpmn:exclusiveGateway id="Gateway_1adft3c">
+      <bpmn:incoming>Flow_0wkb4hq</bpmn:incoming>
+      <bpmn:outgoing>Flow_1gvflfp</bpmn:outgoing>
+      <bpmn:outgoing>Flow_08k7vbr</bpmn:outgoing>
+      <bpmn:outgoing>Flow_19rqft2</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0n84ml1</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
     <bpmn:textAnnotation id="TextAnnotation_092byka">
       <bpmn:text>foo</bpmn:text>
     </bpmn:textAnnotation>
@@ -150,7 +170,7 @@
   </bpmn:process>
   <bpmn:message id="Message_0inbjmp" name="Message_0inbjmp">
     <bpmn:extensionElements>
-      <zeebe:subscription />
+      <zeebe:subscription correlationKey="foo" />
     </bpmn:extensionElements>
   </bpmn:message>
   <bpmn:error id="Error_035q7ey" name="Error_07ueecl" errorCode="foo" />
@@ -159,6 +179,15 @@
       <bpmndi:BPMNShape id="Participant_1lhpzkq_di" bpmnElement="Participant_1lhpzkq" isHorizontal="true">
         <dc:Bounds x="129" y="80" width="1601" height="650" />
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0n84ml1_di" bpmnElement="Flow_0n84ml1">
+        <di:waypoint x="740" y="405" />
+        <di:waypoint x="740" y="630" />
+        <di:waypoint x="842" y="630" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_19rqft2_di" bpmnElement="Flow_19rqft2">
+        <di:waypoint x="740" y="405" />
+        <di:waypoint x="740" y="612" />
+      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1c7yptg_di" bpmnElement="Flow_1c7yptg">
         <di:waypoint x="510" y="630" />
         <di:waypoint x="560" y="630" />
@@ -282,6 +311,9 @@
       <bpmndi:BPMNShape id="Event_0gcrrhl_di" bpmnElement="Event_195u06h">
         <dc:Bounds x="1262" y="472" width="36" height="36" />
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1t2rfhg_di" bpmnElement="Gateway_1adft3c" isMarkerVisible="true">
+        <dc:Bounds x="715" y="355" width="50" height="50" />
+      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_09495yf_di" bpmnElement="Activity_09495yf" isExpanded="true">
         <dc:Bounds x="1280" y="167" width="350" height="200" />
       </bpmndi:BPMNShape>
@@ -294,9 +326,6 @@
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_08nc9km_di" bpmnElement="Activity_15d1o2q">
         <dc:Bounds x="1410" y="227" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Gateway_1adft3c_di" bpmnElement="Gateway_1adft3c" isMarkerVisible="true">
-        <dc:Bounds x="715" y="355" width="50" height="50" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_16u5s1h_di" bpmnElement="Event_0el3zk8">
         <dc:Bounds x="442" y="482" width="36" height="36" />
@@ -315,6 +344,12 @@
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_0iuc6yg_di" bpmnElement="Activity_1d00s75">
         <dc:Bounds x="560" y="590" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_13yl25e_di" bpmnElement="Event_0s4ygc1">
+        <dc:Bounds x="722" y="612" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1deoy07_di" bpmnElement="Event_1yqxsot">
+        <dc:Bounds x="842" y="612" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="TextAnnotation_092byka_di" bpmnElement="TextAnnotation_092byka">
         <dc:Bounds x="370" y="140" width="100" height="30" />

--- a/test/spec/utils/error-messages.spec.js
+++ b/test/spec/utils/error-messages.spec.js
@@ -74,6 +74,29 @@ describe('utils/error-messages', function() {
         expect(errorMessage).to.equal('A <Business Rule Task> with <Implementation: DMN decision> is not supported by Camunda Fox');
       });
 
+
+      it('should adjust (zeebe:Properties)', async function() {
+
+        // given
+        const node = createElement('bpmn:ServiceTask', {
+          extensionElements: createElement('bpmn:ExtensionElements', {
+            values: [
+              createElement('zeebe:Properties')
+            ]
+          })
+        });
+
+        const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/no-zeebe-properties');
+
+        const report = await getLintError(node, rule);
+
+        // when
+        const errorMessage = getErrorMessage(report, 'Camunda Fox');
+
+        // then
+        expect(errorMessage).to.equal('A <Service Task> with <Extension properties> is not supported by Camunda Fox');
+      });
+
     });
 
 

--- a/test/spec/utils/properties-panel.spec.js
+++ b/test/spec/utils/properties-panel.spec.js
@@ -19,7 +19,7 @@ describe('utils/properties-panel', function() {
 
   describe('#getEntryId and #getErrorMessage', function() {
 
-    it('businessRuleImplementation', async function() {
+    it('called-decision-or-task-definition - Implementation', async function() {
 
       // given
       const node = createElement('bpmn:BusinessRuleTask');
@@ -40,7 +40,7 @@ describe('utils/properties-panel', function() {
     });
 
 
-    it('errorRef', async function() {
+    it('error-reference - Global error reference', async function() {
 
       // given
       const node = createElement('bpmn:EndEvent', {
@@ -63,7 +63,7 @@ describe('utils/properties-panel', function() {
     });
 
 
-    it('messageRef', async function() {
+    it('message-reference - Global message reference', async function() {
 
       // given
       const node = createElement('bpmn:IntermediateCatchEvent', {
@@ -86,7 +86,7 @@ describe('utils/properties-panel', function() {
     });
 
 
-    it('decisionId', async function() {
+    it('called-decision-or-task-definition - Decision ID', async function() {
 
       // given
       const node = createElement('bpmn:BusinessRuleTask', {
@@ -115,7 +115,7 @@ describe('utils/properties-panel', function() {
     });
 
 
-    it('resultVariable', async function() {
+    it('called-decision-or-task-definition - Result variable', async function() {
 
       // given
       const node = createElement('bpmn:BusinessRuleTask', {
@@ -144,7 +144,7 @@ describe('utils/properties-panel', function() {
     });
 
 
-    it('errorCode', async function() {
+    it('error-reference - Code', async function() {
 
       // given
       const node = createElement('bpmn:EndEvent', {
@@ -169,7 +169,7 @@ describe('utils/properties-panel', function() {
     });
 
 
-    it('messageName', async function() {
+    it('message-reference - Name', async function() {
 
       // given
       const node = createElement('bpmn:IntermediateCatchEvent', {
@@ -194,9 +194,9 @@ describe('utils/properties-panel', function() {
     });
 
 
-    describe('multiInstance-inputCollection', function() {
+    describe('loop-characteristics', function() {
 
-      it('no loop characteristics', async function() {
+      it('Input collection (no loop characteristics)', async function() {
 
         // given
         const node = createElement('bpmn:ServiceTask', {
@@ -217,7 +217,7 @@ describe('utils/properties-panel', function() {
       });
 
 
-      it('no input collection', async function() {
+      it('Input collection (no input collection)', async function() {
 
         // given
         const node = createElement('bpmn:ServiceTask', {
@@ -246,7 +246,7 @@ describe('utils/properties-panel', function() {
     });
 
 
-    it('multiInstance-outputCollection', async function() {
+    it('loop-characteristics - Output collection', async function() {
 
       // given
       const node = createElement('bpmn:ServiceTask', {
@@ -276,7 +276,7 @@ describe('utils/properties-panel', function() {
     });
 
 
-    it('multiInstance-outputElement', async function() {
+    it('loop-characteristics - Output element', async function() {
 
       // given
       const node = createElement('bpmn:ServiceTask', {
@@ -306,9 +306,9 @@ describe('utils/properties-panel', function() {
     });
 
 
-    describe('targetProcessId', function() {
+    describe('called-element', function() {
 
-      it('no called element', async function() {
+      it('Process ID (no called element)', async function() {
 
         // given
         const node = createElement('bpmn:CallActivity');
@@ -327,7 +327,7 @@ describe('utils/properties-panel', function() {
       });
 
 
-      it('no process ID', async function() {
+      it('Process ID (no process ID)', async function() {
 
         // given
         const node = createElement('bpmn:CallActivity', {
@@ -354,9 +354,9 @@ describe('utils/properties-panel', function() {
     });
 
 
-    describe('taskDefinitionType', function() {
+    describe('called-decision-or-task-definition', function() {
 
-      it('no task definition', async function() {
+      it('Type (no task definition)', async function() {
 
         // given
         const node = createElement('bpmn:ServiceTask');
@@ -377,7 +377,7 @@ describe('utils/properties-panel', function() {
       });
 
 
-      it('no type', async function() {
+      it('Type (no type)', async function() {
 
         // given
         const node = createElement('bpmn:ServiceTask', {
@@ -406,9 +406,9 @@ describe('utils/properties-panel', function() {
     });
 
 
-    describe('messageSubscriptionCorrelationKey', function() {
+    describe('subscription', function() {
 
-      it('no subscription', async function() {
+      it('Subscription correlation key (no subscription)', async function() {
 
         // given
         const node = createElement('bpmn:ReceiveTask', {
@@ -429,7 +429,7 @@ describe('utils/properties-panel', function() {
       });
 
 
-      it('no correlation key', async function() {
+      it('Subscription correlation key (no correlation key)', async function() {
 
         // given
         const node = createElement('bpmn:ReceiveTask', {
@@ -458,7 +458,7 @@ describe('utils/properties-panel', function() {
     });
 
 
-    it('customFormKey', async function() {
+    it('user-task-form - Form key', async function() {
 
       // given
       const node = createElement('bpmn:UserTask', {
@@ -483,7 +483,7 @@ describe('utils/properties-panel', function() {
     });
 
 
-    it('formConfiguration', async function() {
+    it('user-task-form - Form JSON configuration', async function() {
 
       // given
       const process = createElement('bpmn:Process', {
@@ -523,7 +523,7 @@ describe('utils/properties-panel', function() {
     });
 
 
-    it('headerKey', async function() {
+    it('duplicate-task-headers - Key', async function() {
 
       // given
       const node = createElement('bpmn:ServiceTask', {
@@ -554,6 +554,40 @@ describe('utils/properties-panel', function() {
       ]);
 
       expectErrorMessage(entryIds[ 0 ], 'Must be unique.');
+    });
+
+
+    it('no-zeebe-properties - Name', async function() {
+
+      // given
+      const node = createElement('bpmn:ServiceTask', {
+        id: 'ServiceTask_1',
+        extensionElements: createElement('bpmn:ExtensionElements', {
+          values: [
+            createElement('zeebe:Properties', {
+              properties: [
+                createElement('zeebe:Property'),
+                createElement('zeebe:Property')
+              ]
+            })
+          ]
+        })
+      });
+
+      const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/no-zeebe-properties');
+
+      const report = await getLintError(node, rule);
+
+      // when
+      const entryIds = getEntryIds(report);
+
+      // then
+      expect(entryIds).to.eql([
+        'ServiceTask_1-extensionProperty-0-name',
+        'ServiceTask_1-extensionProperty-1-name'
+      ]);
+
+      expectErrorMessage(entryIds[ 0 ], 'Not supported.');
     });
 
   });


### PR DESCRIPTION
* error message in error panel adjusted
* error shown in properties panel for every extension property

We can only show errors for individual entries at the moment so the error is shown for the first entry of every extension property even though the extension property itself isn't allowed. In the future we could add error states for groups and list entries.

![image](https://user-images.githubusercontent.com/7633572/188399540-113ad0b6-9550-444f-bf5e-e46cfbada95b.png)

---

Depends on https://github.com/camunda/bpmnlint-plugin-camunda-compat/pull/43
Related https://github.com/camunda/product-hub/issues/335