### PR TITLE
fix: do not show annotations on update if inactive

### DIFF
--- a/lib/modeler/Linting.js
+++ b/lib/modeler/Linting.js
@@ -1,13 +1,14 @@
 import { getErrors } from '../utils/properties-panel';
 
 export default class Linting {
-  constructor(canvas, elementRegistry, eventBus, lintingAnnotations, selection) {
+  constructor(canvas, config, elementRegistry, eventBus, lintingAnnotations, selection) {
     this._canvas = canvas;
     this._elementRegistry = elementRegistry;
     this._eventBus = eventBus;
     this._lintingAnnotations = lintingAnnotations;
     this._selection = selection;
 
+    this._active = config && config.active || false;
     this._reports = [];
 
     eventBus.on('selection.changed', () => this._update());
@@ -43,20 +44,25 @@ export default class Linting {
   }
 
   activate() {
+    this._active = true;
+
     this._update();
   }
 
   deactivate() {
-    this._update([]);
+    this._active = false;
+
+    this._update();
   }
 
-  _update(reports) {
-    if (!reports) {
-      reports = this._reports;
-    }
+  isActive() {
+    return this._active;
+  }
+
+  _update() {
 
     // set annotations
-    this._lintingAnnotations.setErrors(reports);
+    this._lintingAnnotations.setErrors(this.isActive() ? this._reports : []);
 
     // set properties panel errors
     const selectedElement = this._getSelectedElement();
@@ -85,6 +91,7 @@ export default class Linting {
 
 Linting.$inject = [
   'canvas',
+  'config.linting',
   'elementRegistry',
   'eventBus',
   'lintingAnnotations',


### PR DESCRIPTION
* add active state to linting
* only show annotations on selection changed if active
* be able to configure initial active state

---

Related to https://github.com/camunda/camunda-modeler/pull/3118#issuecomment-1240321426