### PR TITLE
Use Timeout to Account for Async Rendering of Properties Panel

### DIFF
--- a/lib/modeler/Linting.js
+++ b/lib/modeler/Linting.js
@@ -32,8 +32,11 @@ export default class Linting {
 
     const { entryId } = propertiesPanel;
 
-    this._eventBus.fire('propertiesPanel.showEntry', {
-      id: entryId
+    // TODO(philippfromme): remove timeout once properties panel is fixed
+    setTimeout(() => {
+      this._eventBus.fire('propertiesPanel.showEntry', {
+        id: entryId
+      });
     });
   }
 

--- a/test/spec/modeler/Linting.spec.js
+++ b/test/spec/modeler/Linting.spec.js
@@ -446,6 +446,7 @@ describe('Linting', function() {
         // when
         eventBus.fire('lintingAnnotations.click', { report: reports[ 0 ] });
 
+        // TODO(philippfromme): remove timeout once properties panel is fixed
         clock.tick();
 
         // then

--- a/test/spec/modeler/Linting.spec.js
+++ b/test/spec/modeler/Linting.spec.js
@@ -110,7 +110,7 @@ describe('Linting', function() {
   }));
 
 
-  (singleStart ? it.only : it)('example', inject(function(bpmnjs, canvas, eventBus, linting, modeling, propertiesPanel) {
+  (singleStart ? it.only : it.skip)('example', inject(function(bpmnjs, canvas, eventBus, linting, modeling, propertiesPanel) {
 
     // given
     const linter = new Linter();
@@ -363,88 +363,107 @@ describe('Linting', function() {
   ));
 
 
-  it('should show error', inject(
-    async function(bpmnjs, elementRegistry, eventBus, linting, selection) {
+  describe('show error', function() {
 
-      // given
-      const serviceTask = elementRegistry.get('ServiceTask_1');
+    let clock;
 
-      const reports = await linter.lint(bpmnjs.getDefinitions());
+    beforeEach(function() {
+      clock = sinon.useFakeTimers();
+    });
 
-      // assume
-      expect(reports).to.have.length(1);
-
-      linting.setErrors(reports);
-
-      linting.activate();
-
-      const propertiesPanelSetErrorSpy = sinon.spy();
-
-      eventBus.on('propertiesPanel.setErrors', propertiesPanelSetErrorSpy);
-
-      const propertiesPanelShowEntrySpy = sinon.spy();
-
-      eventBus.on('propertiesPanel.showEntry', propertiesPanelShowEntrySpy);
-
-      // when
-      linting.showError(reports[ 0 ]);
-
-      // then
-      expect(selection.get()).to.eql([ serviceTask ]);
-
-      expect(propertiesPanelSetErrorSpy).to.have.been.calledOnce;
-      expect(propertiesPanelSetErrorSpy).to.have.been.calledWithMatch({
-        errors: getErrors(reports, serviceTask)
-      });
-
-      expect(propertiesPanelShowEntrySpy).to.have.been.calledOnce;
-      expect(propertiesPanelShowEntrySpy).to.have.been.calledWithMatch({
-        id: 'taskDefinitionType'
-      });
-    }
-  ));
+    afterEach(function() {
+      clock.restore();
+    });
 
 
-  it('should show error on lintingAnnotations.click', inject(
-    async function(bpmnjs, elementRegistry, eventBus, linting, selection) {
+    it('should show error', inject(
+      async function(bpmnjs, elementRegistry, eventBus, linting, selection) {
 
-      // given
-      const serviceTask = elementRegistry.get('ServiceTask_1');
+        // given
+        const serviceTask = elementRegistry.get('ServiceTask_1');
 
-      const reports = await linter.lint(bpmnjs.getDefinitions());
+        const reports = await linter.lint(bpmnjs.getDefinitions());
 
-      // assume
-      expect(reports).to.have.length(1);
+        // assume
+        expect(reports).to.have.length(1);
 
-      linting.setErrors(reports);
+        linting.setErrors(reports);
 
-      linting.activate();
+        linting.activate();
 
-      const propertiesPanelSetErrorSpy = sinon.spy();
+        const propertiesPanelSetErrorSpy = sinon.spy();
 
-      eventBus.on('propertiesPanel.setErrors', propertiesPanelSetErrorSpy);
+        eventBus.on('propertiesPanel.setErrors', propertiesPanelSetErrorSpy);
 
-      const propertiesPanelShowEntrySpy = sinon.spy();
+        const propertiesPanelShowEntrySpy = sinon.spy();
 
-      eventBus.on('propertiesPanel.showEntry', propertiesPanelShowEntrySpy);
+        eventBus.on('propertiesPanel.showEntry', propertiesPanelShowEntrySpy);
 
-      // when
-      eventBus.fire('lintingAnnotations.click', { report: reports[ 0 ] });
+        // when
+        linting.showError(reports[ 0 ]);
 
-      // then
-      expect(selection.get()).to.eql([ serviceTask ]);
+        clock.tick();
 
-      expect(propertiesPanelSetErrorSpy).to.have.been.calledOnce;
-      expect(propertiesPanelSetErrorSpy).to.have.been.calledWithMatch({
-        errors: getErrors(reports, serviceTask)
-      });
+        // then
+        expect(selection.get()).to.eql([ serviceTask ]);
 
-      expect(propertiesPanelShowEntrySpy).to.have.been.calledOnce;
-      expect(propertiesPanelShowEntrySpy).to.have.been.calledWithMatch({
-        id: 'taskDefinitionType'
-      });
-    }
-  ));
+        expect(propertiesPanelSetErrorSpy).to.have.been.calledOnce;
+        expect(propertiesPanelSetErrorSpy).to.have.been.calledWithMatch({
+          errors: getErrors(reports, serviceTask)
+        });
+
+        expect(propertiesPanelShowEntrySpy).to.have.been.calledOnce;
+        expect(propertiesPanelShowEntrySpy).to.have.been.calledWithMatch({
+          id: 'taskDefinitionType'
+        });
+      }
+    ));
+
+
+    it('should show error on lintingAnnotations.click', inject(
+      async function(bpmnjs, elementRegistry, eventBus, linting, selection) {
+
+        // given
+        const serviceTask = elementRegistry.get('ServiceTask_1');
+
+        const reports = await linter.lint(bpmnjs.getDefinitions());
+
+        // assume
+        expect(reports).to.have.length(1);
+
+        linting.setErrors(reports);
+
+        linting.activate();
+
+        const propertiesPanelSetErrorSpy = sinon.spy();
+
+        eventBus.on('propertiesPanel.setErrors', propertiesPanelSetErrorSpy);
+
+        const propertiesPanelShowEntrySpy = sinon.spy();
+
+        eventBus.on('propertiesPanel.showEntry', propertiesPanelShowEntrySpy);
+
+        // when
+        eventBus.fire('lintingAnnotations.click', { report: reports[ 0 ] });
+
+        clock.tick();
+
+        // then
+        expect(selection.get()).to.eql([ serviceTask ]);
+
+        expect(propertiesPanelSetErrorSpy).to.have.been.calledOnce;
+        expect(propertiesPanelSetErrorSpy).to.have.been.calledWithMatch({
+          errors: getErrors(reports, serviceTask)
+        });
+
+        expect(propertiesPanelShowEntrySpy).to.have.been.calledOnce;
+        expect(propertiesPanelShowEntrySpy).to.have.been.calledWithMatch({
+          id: 'taskDefinitionType'
+        });
+      }
+    ));
+
+  });
 
 
   describe('canvas scrolling', function() {

--- a/test/spec/modeler/Linting.spec.js
+++ b/test/spec/modeler/Linting.spec.js
@@ -110,7 +110,7 @@ describe('Linting', function() {
   }));
 
 
-  (singleStart ? it.only : it.skip)('example', inject(function(bpmnjs, canvas, eventBus, linting, modeling, propertiesPanel) {
+  (singleStart ? it.only : it)('example', inject(function(bpmnjs, canvas, eventBus, linting, modeling, propertiesPanel) {
 
     // given
     const linter = new Linter();


### PR DESCRIPTION
# Context

Due to the issue described in https://github.com/bpmn-io/properties-panel/pull/186#issue-1378022895 the properties panel isn't always focused on `showEntry`. To fix this issue a timeout is introduced to account for the async rendering of the properties panel. Once the issue has been fixed in the properties panel the timeout can be safely removed. In the meantime, nothing is going to change for users of `@camunda/linting` as the timeout is only used internally.

---

Related to https://github.com/bpmn-io/properties-panel/pull/186
Related to https://github.com/camunda/camunda-modeler/issues/3144