### PR TITLE
chore: explicitly state platform support for cron time cycle

### DIFF
--- a/lib/utils/error-messages.js
+++ b/lib/utils/error-messages.js
@@ -363,7 +363,7 @@ function getPropertyValueNotAllowedErrorMessage(report, executionPlatformLabel) 
     && property === 'body'
     && secondLast(report.path) === 'timeCycle'
   ) {
-    return `${ getIndefiniteArticle(typeString) } <${ typeString }> <Time cycle> should be an expression, an ISO 8601 repeating interval, or a cron expression`;
+    return `${ getIndefiniteArticle(typeString) } <${ typeString }> <Time cycle> should be an expression, an ISO 8601 repeating interval, or a cron expression (Camunda Platform 8.1 or newer)`;
   }
 
   if (is(node, 'bpmn:FormalExpression')

--- a/lib/utils/error-messages.js
+++ b/lib/utils/error-messages.js
@@ -363,7 +363,7 @@ function getPropertyValueNotAllowedErrorMessage(report, executionPlatformLabel) 
     && property === 'body'
     && secondLast(report.path) === 'timeCycle'
   ) {
-    return `${ getIndefiniteArticle(typeString) } <${ typeString }> <Time cycle> should be an expression, an ISO 8601 repeating interval, or a cron expression (Camunda Platform 8.1 or newer)`;
+    return `${ getIndefiniteArticle(typeString) } <${ typeString }> <Time cycle> should be an expression, an ISO 8601 repeating interval, or a cron expression (cron requires Camunda Platform 8.1 or newer)`;
   }
 
   if (is(node, 'bpmn:FormalExpression')

--- a/lib/utils/properties-panel.js
+++ b/lib/utils/properties-panel.js
@@ -247,7 +247,7 @@ export function getErrorMessage(id, report) {
     const property = secondLast(report.path);
 
     if (property === 'timeCycle') {
-      return 'Must be an expression, an ISO 8601 repeating interval, or a cron expression (Camunda Platform 8.1 or newer).';
+      return 'Must be an expression, an ISO 8601 repeating interval, or a cron expression (cron requires Camunda Platform 8.1 or newer).';
     }
 
     if (property === 'timeDate') {

--- a/lib/utils/properties-panel.js
+++ b/lib/utils/properties-panel.js
@@ -247,7 +247,7 @@ export function getErrorMessage(id, report) {
     const property = secondLast(report.path);
 
     if (property === 'timeCycle') {
-      return 'Must be an expression, an ISO 8601 repeating interval, or a cron expression.';
+      return 'Must be an expression, an ISO 8601 repeating interval, or a cron expression (Camunda Platform 8.1 or newer).';
     }
 
     if (property === 'timeDate') {

--- a/test/spec/utils/error-messages.spec.js
+++ b/test/spec/utils/error-messages.spec.js
@@ -825,7 +825,7 @@ describe('utils/error-messages', function() {
         const errorMessage = getErrorMessage(report);
 
         // then
-        expect(errorMessage).to.equal('A <Timer Boundary Event> <Time cycle> should be an expression, an ISO 8601 repeating interval, or a cron expression');
+        expect(errorMessage).to.equal('A <Timer Boundary Event> <Time cycle> should be an expression, an ISO 8601 repeating interval, or a cron expression (Camunda Platform 8.1 or newer)');
       });
 
 

--- a/test/spec/utils/error-messages.spec.js
+++ b/test/spec/utils/error-messages.spec.js
@@ -825,7 +825,7 @@ describe('utils/error-messages', function() {
         const errorMessage = getErrorMessage(report);
 
         // then
-        expect(errorMessage).to.equal('A <Timer Boundary Event> <Time cycle> should be an expression, an ISO 8601 repeating interval, or a cron expression (Camunda Platform 8.1 or newer)');
+        expect(errorMessage).to.equal('A <Timer Boundary Event> <Time cycle> should be an expression, an ISO 8601 repeating interval, or a cron expression (cron requires Camunda Platform 8.1 or newer)');
       });
 
 

--- a/test/spec/utils/properties-panel.spec.js
+++ b/test/spec/utils/properties-panel.spec.js
@@ -780,7 +780,7 @@ describe('utils/properties-panel', function() {
       // then
       expect(entryIds).to.eql([ 'timerEventDefinitionValue' ]);
 
-      expectErrorMessage(entryIds[ 0 ], 'Must be an expression, an ISO 8601 repeating interval, or a cron expression.', report);
+      expectErrorMessage(entryIds[ 0 ], 'Must be an expression, an ISO 8601 repeating interval, or a cron expression (Camunda Platform 8.1 or newer).', report);
     });
 
 

--- a/test/spec/utils/properties-panel.spec.js
+++ b/test/spec/utils/properties-panel.spec.js
@@ -780,7 +780,7 @@ describe('utils/properties-panel', function() {
       // then
       expect(entryIds).to.eql([ 'timerEventDefinitionValue' ]);
 
-      expectErrorMessage(entryIds[ 0 ], 'Must be an expression, an ISO 8601 repeating interval, or a cron expression (Camunda Platform 8.1 or newer).', report);
+      expectErrorMessage(entryIds[ 0 ], 'Must be an expression, an ISO 8601 repeating interval, or a cron expression (cron requires Camunda Platform 8.1 or newer).', report);
     });
 
 


### PR DESCRIPTION
We want the users to know that cron is available only in Camunda Platform 8.1 or newer.