### PR TITLE
feat(utils): make getEntryIds independent of error type

### DIFF
--- a/lib/utils/properties-panel.js
+++ b/lib/utils/properties-panel.js
@@ -322,7 +322,7 @@ function isPropertyDependendRequiredError(data, dependendRequiredProperty, type)
 
 
 function isPropertyError(data, property, type) {
-  return (getPropertyName(data) === property)
+  return getPropertyName(data) === property
     && (!type || is(data.node, type));
 }
 
@@ -333,7 +333,7 @@ function hasType(data, type) {
 function getPropertyName(data) {
   const propertyKey = data.type === ERROR_TYPES.PROPERTY_REQUIRED ? 'requiredProperty' : 'property';
 
-  return data[propertyKey];
+  return data[ propertyKey ];
 }
 
 function isOneOfPropertiesRequiredError(data, requiredProperty, type) {

--- a/lib/utils/properties-panel.js
+++ b/lib/utils/properties-panel.js
@@ -47,39 +47,40 @@ export function getErrors(reports, element) {
 export function getEntryIds(report) {
   const {
     data = {},
-    id
+    id,
+    path
   } = report;
 
   if (isExtensionElementRequiredError(data, 'zeebe:CalledDecision', 'bpmn:BusinessRuleTask')) {
     return [ 'businessRuleImplementation' ];
   }
 
-  if (isPropertyRequiredError(data, 'errorRef')) {
+  if (isPropertyError(data, 'errorRef')) {
     return [ 'errorRef' ];
   }
 
-  if (isPropertyRequiredError(data, 'messageRef')) {
+  if (isPropertyError(data, 'messageRef')) {
     return [ 'messageRef' ];
   }
 
-  if (isPropertyRequiredError(data, 'decisionId', 'zeebe:CalledDecision')) {
+  if (isPropertyError(data, 'decisionId', 'zeebe:CalledDecision')) {
     return [ 'decisionId' ];
   }
 
-  if (isPropertyRequiredError(data, 'resultVariable', 'zeebe:CalledDecision')) {
+  if (isPropertyError(data, 'resultVariable', 'zeebe:CalledDecision')) {
     return [ 'resultVariable' ];
   }
 
-  if (isPropertyRequiredError(data, 'errorCode', 'bpmn:Error')) {
+  if (isPropertyError(data, 'errorCode', 'bpmn:Error')) {
     return [ 'errorCode' ];
   }
 
-  if (isPropertyRequiredError(data, 'name', 'bpmn:Message')) {
+  if (isPropertyError(data, 'name', 'bpmn:Message')) {
     return [ 'messageName' ];
   }
 
   if (isExtensionElementRequiredError(data, 'zeebe:LoopCharacteristics', 'bpmn:MultiInstanceLoopCharacteristics')
-    || isPropertyRequiredError(data, 'inputCollection', 'zeebe:LoopCharacteristics')) {
+    || isPropertyError(data, 'inputCollection', 'zeebe:LoopCharacteristics')) {
     return [ 'multiInstance-inputCollection' ];
   }
 
@@ -92,25 +93,29 @@ export function getEntryIds(report) {
   }
 
   if (isExtensionElementRequiredError(data, 'zeebe:CalledElement', 'bpmn:CallActivity')
-    || isPropertyRequiredError(data, 'processId', 'zeebe:CalledElement')) {
+    || isPropertyError(data, 'processId', 'zeebe:CalledElement')) {
     return [ 'targetProcessId' ];
   }
 
   if (isExtensionElementRequiredError(data, 'zeebe:TaskDefinition')
-    || isPropertyRequiredError(data, 'type', 'zeebe:TaskDefinition')) {
+    || isPropertyError(data, 'type', 'zeebe:TaskDefinition')) {
     return [ 'taskDefinitionType' ];
   }
 
+  if (isPropertyError(data, 'retries', 'zeebe:TaskDefinition')) {
+    return [ 'taskDefinitionRetries' ];
+  }
+
   if (isExtensionElementRequiredError(data, 'zeebe:Subscription')
-    || isPropertyRequiredError(data, 'correlationKey', 'zeebe:Subscription')) {
+    || isPropertyError(data, 'correlationKey', 'zeebe:Subscription')) {
     return [ 'messageSubscriptionCorrelationKey' ];
   }
 
-  if (isPropertyRequiredError(data, 'formKey', 'zeebe:FormDefinition')) {
+  if (isPropertyError(data, 'formKey', 'zeebe:FormDefinition')) {
     return [ 'customFormKey' ];
   }
 
-  if (isPropertyRequiredError(data, 'body', 'zeebe:UserTaskForm')) {
+  if (isPropertyError(data, 'body', 'zeebe:UserTaskForm')) {
     return [ 'formConfiguration' ];
   }
 
@@ -136,16 +141,20 @@ export function getEntryIds(report) {
     });
   }
 
-  if (isPropertyRequiredError(data, 'conditionExpression', 'bpmn:SequenceFlow')) {
+  if (isPropertyError(data, 'conditionExpression', 'bpmn:SequenceFlow')) {
     return [ 'conditionExpression' ];
   }
 
-  if (isPropertyRequiredError(data, 'timeDuration', 'bpmn:TimerEventDefinition')) {
+  if (isPropertyError(data, 'timeDuration', 'bpmn:TimerEventDefinition')) {
     return [ 'timerEventDefinitionDurationValue' ];
   }
 
+  if (isPropertyError(data, 'completionCondition', 'bpmn:MultiInstanceLoopCharacteristics')) {
+    return [ 'multiInstance-completionCondition' ];
+  }
+
   if (TIMER_PROPERTIES.some(property =>
-    isOneOfPropertiesRequiredError(data, property , 'bpmn:TimerEventDefinition'))
+    isOneOfPropertiesRequiredError(data, property, 'bpmn:TimerEventDefinition'))
   ) {
     return [ 'timerEventDefinitionType' ];
   }
@@ -162,11 +171,37 @@ export function getEntryIds(report) {
     return hasOnlyDurationTimer(data.parentNode) ? [ 'timerEventDefinitionDurationValue' ] : [ 'timerEventDefinitionValue' ];
   }
 
+  const LIST_PROPERTIES = [
+    [ 'zeebe:Input', 'input' ],
+    [ 'zeebe:Output', 'output' ],
+    [ 'zeebe:Property', 'extensionProperty' ],
+    [ 'zeebe:Header', 'header' ]
+  ];
+
+  for (const [ type, prefix ] of LIST_PROPERTIES) {
+    if (hasType(data, type)
+        && getPropertyName(data)) {
+
+      const index = path[path.length - 2];
+
+      return [ `${ id }-${prefix}-${index}-${ getPropertyName(data) }` ];
+    }
+  }
+
+  if (hasType(data, 'zeebe:LoopCharacteristics')) {
+    return [ `multiInstance-${getPropertyName(data)}` ];
+  }
+
   return [];
 }
 
 export function getErrorMessage(id, report) {
   const { data } = report;
+
+  // do not override FEEL message
+  if (data.type === ERROR_TYPES.FEEL_EXPRESSION_INVALID) {
+    return;
+  }
 
   if (id === 'businessRuleImplementation') {
     return 'Implementation must be defined.';
@@ -285,10 +320,20 @@ function isPropertyDependendRequiredError(data, dependendRequiredProperty, type)
     && (!type || is(data.node, type));
 }
 
-function isPropertyRequiredError(data, requiredProperty, type) {
-  return data.type === ERROR_TYPES.PROPERTY_REQUIRED
-    && (data.requiredProperty === requiredProperty)
+
+function isPropertyError(data, property, type) {
+  return (getPropertyName(data) === property)
     && (!type || is(data.node, type));
+}
+
+function hasType(data, type) {
+  return data.node && is(data.node, type);
+}
+
+function getPropertyName(data) {
+  const propertyKey = data.type === ERROR_TYPES.PROPERTY_REQUIRED ? 'requiredProperty' : 'property';
+
+  return data[propertyKey];
 }
 
 function isOneOfPropertiesRequiredError(data, requiredProperty, type) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "bpmn-moddle": "^7.1.3",
         "bpmnlint": "^8.0.0",
-        "bpmnlint-plugin-camunda-compat": "^0.14.0",
+        "bpmnlint-plugin-camunda-compat": "^0.14.1",
         "bpmnlint-utils": "^1.0.2",
         "min-dash": "^4.0.0",
         "min-dom": "^4.0.1",
@@ -1047,9 +1047,9 @@
       }
     },
     "node_modules/bpmnlint-plugin-camunda-compat": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/bpmnlint-plugin-camunda-compat/-/bpmnlint-plugin-camunda-compat-0.14.0.tgz",
-      "integrity": "sha512-P7zCno4nwfFZ8NRG7kLuPQlHaisvcJR+vA1fKIoBetrH6brAHAxbr0UF2Y8BL4m2TwwDvF5/f1TEy1Fge59CZQ==",
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/bpmnlint-plugin-camunda-compat/-/bpmnlint-plugin-camunda-compat-0.14.1.tgz",
+      "integrity": "sha512-Xhs2TOcodNYB3RVlkX9jvjTSazJh0G75SeImPkWvuzK4iCLzu6HkYkmNDXGrw8jfO3IwjXxVL6kxpkVcEy+0tw==",
       "dependencies": {
         "@bpmn-io/feel-lint": "^0.1.0",
         "@bpmn-io/moddle-utils": "^0.1.0",
@@ -6566,9 +6566,9 @@
       }
     },
     "bpmnlint-plugin-camunda-compat": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/bpmnlint-plugin-camunda-compat/-/bpmnlint-plugin-camunda-compat-0.14.0.tgz",
-      "integrity": "sha512-P7zCno4nwfFZ8NRG7kLuPQlHaisvcJR+vA1fKIoBetrH6brAHAxbr0UF2Y8BL4m2TwwDvF5/f1TEy1Fge59CZQ==",
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/bpmnlint-plugin-camunda-compat/-/bpmnlint-plugin-camunda-compat-0.14.1.tgz",
+      "integrity": "sha512-Xhs2TOcodNYB3RVlkX9jvjTSazJh0G75SeImPkWvuzK4iCLzu6HkYkmNDXGrw8jfO3IwjXxVL6kxpkVcEy+0tw==",
       "requires": {
         "@bpmn-io/feel-lint": "^0.1.0",
         "@bpmn-io/moddle-utils": "^0.1.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "bpmn-moddle": "^7.1.3",
     "bpmnlint": "^8.0.0",
-    "bpmnlint-plugin-camunda-compat": "^0.14.0",
+    "bpmnlint-plugin-camunda-compat": "^0.14.1",
     "bpmnlint-utils": "^1.0.2",
     "min-dash": "^4.0.0",
     "min-dom": "^4.0.1",

--- a/test/spec/modeler/Linting.spec.js
+++ b/test/spec/modeler/Linting.spec.js
@@ -98,6 +98,9 @@ const linter = new Linter();
 describe('Linting', function() {
 
   beforeEach(bootstrapModeler(diagramXML, {
+    keyboard: {
+      bindTo: document
+    },
     additionalModules: [
       lintingModule,
       propertiesPanelModule,

--- a/test/spec/utils/properties-panel.spec.js
+++ b/test/spec/utils/properties-panel.spec.js
@@ -856,6 +856,184 @@ describe('utils/properties-panel', function() {
       expectErrorMessage(entryIds[ 0 ], 'Must be an expression, or an ISO 8601 interval.', report);
     });
 
+
+    describe('FEEL', async function() {
+      const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/feel');
+      const INVALID_FEEL = '===';
+
+      it('should return error for input mapping', async function() {
+
+        // given
+        const node = createElement('bpmn:ServiceTask', {
+          id: 'ServiceTask_1',
+          extensionElements: createElement('bpmn:ExtensionElements', {
+            values: [
+              createElement('zeebe:IoMapping', {
+                inputParameters: [
+                  createElement('zeebe:Input', {
+                    source: INVALID_FEEL
+                  })
+                ]
+              })
+            ]
+          })
+        });
+
+        const report = await getLintError(node, rule);
+
+        // when
+        const entryIds = getEntryIds(report);
+
+        // then
+        expect(entryIds).to.eql([ 'ServiceTask_1-input-0-source' ]);
+      });
+
+
+      it('should return error for output mapping', async function() {
+
+        // given
+        const node = createElement('bpmn:ServiceTask', {
+          id: 'ServiceTask_1',
+          extensionElements: createElement('bpmn:ExtensionElements', {
+            values: [
+              createElement('zeebe:IoMapping', {
+                outputParameters: [
+                  createElement('zeebe:Output', {
+                    source: INVALID_FEEL
+                  })
+                ]
+              })
+            ]
+          })
+        });
+
+        const report = await getLintError(node, rule);
+
+        // when
+        const entryIds = getEntryIds(report);
+
+        // then
+        expect(entryIds).to.eql([ 'ServiceTask_1-output-0-source' ]);
+      });
+
+
+      it('should return error for Task Headers', async function() {
+
+        // given
+        const node = createElement('bpmn:ServiceTask', {
+          id: 'ServiceTask_1',
+          extensionElements: createElement('bpmn:ExtensionElements', {
+            values: [
+              createElement('zeebe:TaskHeaders', {
+                values: [
+                  createElement('zeebe:Header', {
+                    value: INVALID_FEEL
+                  })
+                ]
+              })
+            ]
+          })
+        });
+
+        const report = await getLintError(node, rule);
+
+        // when
+        const entryIds = getEntryIds(report);
+
+        // then
+        expect(entryIds).to.eql([ 'ServiceTask_1-header-0-value' ]);
+      });
+
+
+      it('should return error for Extension Properties', async function() {
+
+        // given
+        const node = createElement('bpmn:ServiceTask', {
+          id: 'ServiceTask_1',
+          extensionElements: createElement('bpmn:ExtensionElements', {
+            values: [
+              createElement('zeebe:TaskHeaders', {
+                values: [
+                  createElement('zeebe:Property', {
+                    value: INVALID_FEEL
+                  })
+                ]
+              })
+            ]
+          })
+        });
+
+        const report = await getLintError(node, rule);
+
+        // when
+        const entryIds = getEntryIds(report);
+
+        // then
+        expect(entryIds).to.eql([ 'ServiceTask_1-extensionProperty-0-value' ]);
+      });
+
+
+      it('should return error for multi-instance properties', async function() {
+        const node = createElement('bpmn:ServiceTask', {
+          loopCharacteristics: createElement('bpmn:MultiInstanceLoopCharacteristics', {
+            extensionElements: createElement('bpmn:ExtensionElements', {
+              values: [
+                createElement('zeebe:LoopCharacteristics', {
+                  inputCollection: INVALID_FEEL
+                })
+              ]
+            })
+          })
+        });
+
+        const report = await getLintError(node, rule);
+
+        // when
+        const entryIds = getEntryIds(report);
+
+        // then
+        expect(entryIds).to.eql([ 'multiInstance-inputCollection' ]);
+
+      });
+
+
+      it('should return error for multi-instance completion condition', async function() {
+        const node = createElement('bpmn:ServiceTask', {
+          loopCharacteristics: createElement('bpmn:MultiInstanceLoopCharacteristics', {
+            completionCondition: createElement('bpmn:FormalExpression', {
+              body: INVALID_FEEL
+            })
+          })
+        });
+
+        const report = await getLintError(node, rule);
+
+        // when
+        const entryIds = getEntryIds(report);
+
+        // then
+        expect(entryIds).to.eql([ 'multiInstance-completionCondition' ]);
+      });
+
+
+      it('should return error for conditional flow', async function() {
+        const node = createElement('bpmn:SequenceFlow', {
+          conditionExpression: createElement('bpmn:FormalExpression', {
+            body: INVALID_FEEL
+          })
+        });
+
+        const report = await getLintError(node, rule);
+
+        // when
+        const entryIds = getEntryIds(report);
+
+        // then
+        expect(entryIds).to.eql([ 'conditionExpression' ]);
+      });
+
+    });
+
   });
 
 

--- a/test/spec/utils/properties-panel.spec.js
+++ b/test/spec/utils/properties-panel.spec.js
@@ -858,8 +858,11 @@ describe('utils/properties-panel', function() {
 
 
     describe('FEEL', async function() {
+
       const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/feel');
+
       const INVALID_FEEL = '===';
+
 
       it('should return error for input mapping', async function() {
 


### PR DESCRIPTION
Currently, the Lint error takes precendent over the local error. Follow-up to fix it: https://github.com/bpmn-io/properties-panel/issues/190

Makes sure that FEEL lint errors map to the correct Properties panel entry

![Recording 2022-11-04 at 10 46 52](https://user-images.githubusercontent.com/21984219/199943208-a7be2aca-a0a2-4173-9097-c7c499333643.gif)

---

Related to https://github.com/camunda/linting/issues/22