### PR TITLE
Allow Blank Error Catch Event in Camunda 8.2

### DIFF
--- a/lib/utils/error-messages.js
+++ b/lib/utils/error-messages.js
@@ -96,7 +96,7 @@ export function getErrorMessage(report, executionPlatform, executionPlatformVers
   }
 
   if (type === ERROR_TYPES.PROPERTY_REQUIRED) {
-    return getPropertyRequiredErrorMessage(report);
+    return getPropertyRequiredErrorMessage(report, executionPlatform, executionPlatformVersion);
   }
 
   if (type === ERROR_TYPES.PROPERTY_VALUE_DUPLICATED) {
@@ -329,13 +329,14 @@ function getPropertyNotAllowedErrorMessage(report, executionPlatform, executionP
 }
 
 
-function getPropertyRequiredErrorMessage(report) {
+function getPropertyRequiredErrorMessage(report, executionPlatform, executionPlatformVersion) {
   const {
     data,
     message
   } = report;
 
   const {
+    allowedVersion,
     node,
     parentNode,
     requiredProperty
@@ -368,7 +369,13 @@ function getPropertyRequiredErrorMessage(report) {
   }
 
   if (is(node, 'bpmn:Error') && requiredProperty === 'errorCode') {
-    return `${ getIndefiniteArticle(typeString) } <${ typeString }> with <Error Reference> must have a defined <Error code>`;
+
+    if (parentNode && is(parentNode, 'bpmn:CatchEvent')) {
+      return getSupportedMessage(`${ getIndefiniteArticle(typeString) } <${ typeString }> without defined <Error code>`, executionPlatform, executionPlatformVersion, allowedVersion);
+    } else if (parentNode && is(parentNode, 'bpmn:ThrowEvent')) {
+      return `${ getIndefiniteArticle(typeString) } <${ typeString }> with <Error Reference> must have a defined <Error code>`;
+    }
+
   }
 
   if (is(node, 'bpmn:Escalation') && requiredProperty === 'escalationCode') {
@@ -392,7 +399,13 @@ function getPropertyRequiredErrorMessage(report) {
   }
 
   if (requiredProperty === 'errorRef') {
-    return `${ getIndefiniteArticle(typeString) } <${ typeString }> must have a defined <Error Reference>`;
+
+    if (parentNode && is(parentNode, 'bpmn:CatchEvent')) {
+      return getSupportedMessage(`${ getIndefiniteArticle(typeString) } <${ typeString }> without defined <Error Reference>`, executionPlatform, executionPlatformVersion, allowedVersion);
+    } else if (parentNode && is(parentNode, 'bpmn:ThrowEvent')) {
+      return `${ getIndefiniteArticle(typeString) } <${ typeString }> must have a defined <Error Reference>`;
+    }
+
   }
 
   if (requiredProperty === 'messageRef') {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "bpmn-moddle": "^8.0.0",
         "bpmnlint": "^8.0.0",
-        "bpmnlint-plugin-camunda-compat": "^0.21.0",
+        "bpmnlint-plugin-camunda-compat": "^0.22.0",
         "bpmnlint-utils": "^1.0.2",
         "min-dash": "^4.0.0",
         "min-dom": "^4.1.0",
@@ -1687,9 +1687,9 @@
       }
     },
     "node_modules/bpmnlint-plugin-camunda-compat": {
-      "version": "0.21.0",
-      "resolved": "https://registry.npmjs.org/bpmnlint-plugin-camunda-compat/-/bpmnlint-plugin-camunda-compat-0.21.0.tgz",
-      "integrity": "sha512-7Itn3ryigOJwRflL+FbvLSPuHSllb+WyiPHpPs7zO8OKlb0F59336AnB5dNe4uOOleDTG3z9msUyboCS7Asv6w==",
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/bpmnlint-plugin-camunda-compat/-/bpmnlint-plugin-camunda-compat-0.22.0.tgz",
+      "integrity": "sha512-1J0gxud/60Yq/Q/jCm3aR5xsBoJq3+TjgD0lS0cnzqPswIHg6NbklHae5V/SJykAhKxl5CHEjtTJo2AXB+38dQ==",
       "dependencies": {
         "@bpmn-io/feel-lint": "^0.1.1",
         "@bpmn-io/moddle-utils": "^0.1.0",
@@ -7972,9 +7972,9 @@
       }
     },
     "bpmnlint-plugin-camunda-compat": {
-      "version": "0.21.0",
-      "resolved": "https://registry.npmjs.org/bpmnlint-plugin-camunda-compat/-/bpmnlint-plugin-camunda-compat-0.21.0.tgz",
-      "integrity": "sha512-7Itn3ryigOJwRflL+FbvLSPuHSllb+WyiPHpPs7zO8OKlb0F59336AnB5dNe4uOOleDTG3z9msUyboCS7Asv6w==",
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/bpmnlint-plugin-camunda-compat/-/bpmnlint-plugin-camunda-compat-0.22.0.tgz",
+      "integrity": "sha512-1J0gxud/60Yq/Q/jCm3aR5xsBoJq3+TjgD0lS0cnzqPswIHg6NbklHae5V/SJykAhKxl5CHEjtTJo2AXB+38dQ==",
       "requires": {
         "@bpmn-io/feel-lint": "^0.1.1",
         "@bpmn-io/moddle-utils": "^0.1.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "bpmn-moddle": "^8.0.0",
     "bpmnlint": "^8.0.0",
-    "bpmnlint-plugin-camunda-compat": "^0.21.0",
+    "bpmnlint-plugin-camunda-compat": "^0.22.0",
     "bpmnlint-utils": "^1.0.2",
     "min-dash": "^4.0.0",
     "min-dom": "^4.1.0",

--- a/test/spec/utils/error-messages.spec.js
+++ b/test/spec/utils/error-messages.spec.js
@@ -658,7 +658,32 @@ describe('utils/error-messages', function() {
       });
 
 
-      it('should adjust (error code)', async function() {
+      it('should adjust (error code, catch event)', async function() {
+
+        // given
+        const executionPlatformVersion = '8.1';
+
+        const node = createElement('bpmn:BoundaryEvent', {
+          eventDefinitions: [
+            createElement('bpmn:ErrorEventDefinition', {
+              errorRef: createElement('bpmn:Error')
+            })
+          ]
+        });
+
+        const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/error-reference');
+
+        const report = await getLintError(node, rule, { version: executionPlatformVersion });
+
+        // when
+        const errorMessage = getErrorMessage(report, 'Camunda Cloud', executionPlatformVersion);
+
+        // then
+        expect(errorMessage).to.equal('An <Error Boundary Event> without defined <Error code> is only supported by Camunda 8.2 or newer');
+      });
+
+
+      it('should adjust (error code, throw event)', async function() {
 
         // given
         const node = createElement('bpmn:EndEvent', {
@@ -671,7 +696,7 @@ describe('utils/error-messages', function() {
 
         const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/error-reference');
 
-        const report = await getLintError(node, rule);
+        const report = await getLintError(node, rule, { version: '8.1' });
 
         // when
         const errorMessage = getErrorMessage(report);
@@ -805,7 +830,30 @@ describe('utils/error-messages', function() {
       });
 
 
-      it('should adjust (error ref)', async function() {
+      it('should adjust (error ref, catch event)', async function() {
+
+        // given
+        const executionPlatformVersion = '8.1';
+
+        const node = createElement('bpmn:BoundaryEvent', {
+          eventDefinitions: [
+            createElement('bpmn:ErrorEventDefinition')
+          ]
+        });
+
+        const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/error-reference');
+
+        const report = await getLintError(node, rule, { version: executionPlatformVersion });
+
+        // when
+        const errorMessage = getErrorMessage(report, 'Camunda Cloud', executionPlatformVersion);
+
+        // then
+        expect(errorMessage).to.equal('An <Error Boundary Event> without defined <Error Reference> is only supported by Camunda 8.2 or newer');
+      });
+
+
+      it('should adjust (error ref, throw event)', async function() {
 
         // given
         const node = createElement('bpmn:EndEvent', {
@@ -816,7 +864,7 @@ describe('utils/error-messages', function() {
 
         const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/error-reference');
 
-        const report = await getLintError(node, rule);
+        const report = await getLintError(node, rule, { version: '8.1' });
 
         // when
         const errorMessage = getErrorMessage(report);
@@ -1294,6 +1342,7 @@ describe('utils/error-messages', function() {
         // then
         expect(errorMessage).to.equal('Escalation code used in a catch event must be a static value');
       });
+
     });
 
 

--- a/test/spec/utils/properties-panel.spec.js
+++ b/test/spec/utils/properties-panel.spec.js
@@ -142,7 +142,7 @@ describe('utils/properties-panel', function() {
 
       const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/error-reference');
 
-      const report = await getLintError(node, rule);
+      const report = await getLintError(node, rule, { version: '8.1' });
 
       // when
       const entryIds = getEntryIds(report);
@@ -321,7 +321,7 @@ describe('utils/properties-panel', function() {
 
       const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/error-reference');
 
-      const report = await getLintError(node, rule);
+      const report = await getLintError(node, rule, { version: '8.1' });
 
       // when
       const entryIds = getEntryIds(report);


### PR DESCRIPTION
Requires https://github.com/camunda/bpmnlint-plugin-camunda-compat/pull/81

![image](https://user-images.githubusercontent.com/7633572/221897589-d15a1cb5-1863-47be-bf4e-eb227d9ed579.png)

----

Related to https://github.com/camunda/camunda-modeler/issues/3362
