### PR TITLE
Ship `bpmnlint-plugin-camunda-compat@1.3` Rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to [@camunda/linting](https://github.com/camunda/linting) ar
 
 ___Note:__ Yet to be released changes appear here._
 
+## 1.3.0
+
+* `FEAT`: allow time date for timer intermediate catch and boundary event in Camunda 8.3 ([98](https://github.com/camunda/bpmnlint-plugin-camunda-compat/pull/98))
+
 ## 1.2.1
 
 * `FIX`: make `modeler-moddle` a production dependency

--- a/lib/utils/error-messages.js
+++ b/lib/utils/error-messages.js
@@ -469,10 +469,6 @@ function getPropertyRequiredErrorMessage(report, executionPlatform, executionPla
     return `${ getIndefiniteArticle(typeString) } <${ typeString }> must have a defined <Timer type>`;
   }
 
-  if (is(node, 'bpmn:TimerEventDefinition') && requiredProperty === 'timeDuration') {
-    return `${ getIndefiniteArticle(typeString) } <${ typeString }> must have a defined <Timer duration>`;
-  }
-
   if (is(node, 'bpmn:Process') && requiredProperty === 'historyTimeToLive') {
     return `${ getIndefiniteArticle(typeString) } <${ typeString }> must have a defined <History time to live>`;
   }

--- a/lib/utils/properties-panel.js
+++ b/lib/utils/properties-panel.js
@@ -191,13 +191,13 @@ export function getEntryIds(report) {
   if (isExpressionRequiredError(data, 'timeCycle', 'bpmn:FormalExpression')
     || isExpressionRequiredError(data, 'timeDate', 'bpmn:FormalExpression')
     || isExpressionRequiredError(data, 'timeDuration', 'bpmn:FormalExpression')) {
-    return hasOnlyDurationTimer(data.parentNode) ? [ 'timerEventDefinitionDurationValue' ] : [ 'timerEventDefinitionValue' ];
+    return [ 'timerEventDefinitionValue' ];
   }
 
   if (isExpressionValueNotAllowedError(data, 'timeCycle', 'bpmn:FormalExpression')
     || isExpressionValueNotAllowedError(data, 'timeDate', 'bpmn:FormalExpression')
     || isExpressionValueNotAllowedError(data, 'timeDuration', 'bpmn:FormalExpression')) {
-    return hasOnlyDurationTimer(data.parentNode) ? [ 'timerEventDefinitionDurationValue' ] : [ 'timerEventDefinitionValue' ];
+    return [ 'timerEventDefinitionValue' ];
   }
 
   const LIST_PROPERTIES = [
@@ -370,11 +370,6 @@ export function getErrorMessage(id, report) {
     return 'Condition expression must be defined.';
   }
 
-  if (id === 'timerEventDefinitionDurationValue') {
-    return data.type === ERROR_TYPES.EXPRESSION_REQUIRED ?
-      'Duration must be defined.' : 'Must be an expression, or an ISO 8601 interval.';
-  }
-
   if (id === 'timerEventDefinitionValue') {
     if (data.type === ERROR_TYPES.EXPRESSION_REQUIRED) {
       return 'Value must be defined.';
@@ -482,12 +477,4 @@ function isExpressionValueNotAllowedError(data, propertyName, type) {
 
 function getBusinessObject(element) {
   return element.businessObject || element;
-}
-
-function hasOnlyDurationTimer(node) {
-  return is(node, 'bpmn:IntermediateCatchEvent') || isInterruptingBoundaryEvent(node);
-}
-
-function isInterruptingBoundaryEvent(event) {
-  return is(event, 'bpmn:BoundaryEvent') && event.get('cancelActivity') !== false;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "bpmn-moddle": "^8.0.0",
         "bpmnlint": "^8.0.0",
-        "bpmnlint-plugin-camunda-compat": "^1.2.0",
+        "bpmnlint-plugin-camunda-compat": "^1.3.1",
         "bpmnlint-utils": "^1.0.2",
         "min-dash": "^4.0.0",
         "min-dom": "^4.1.0",
@@ -1688,9 +1688,9 @@
       }
     },
     "node_modules/bpmnlint-plugin-camunda-compat": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/bpmnlint-plugin-camunda-compat/-/bpmnlint-plugin-camunda-compat-1.2.0.tgz",
-      "integrity": "sha512-yIzBPpJqIpN2tDDkE5kcw4o8dSblEfLczaB4yeCCtjAEEfctDL66vzSgR3XHIOo/gAQGOcvmrbW/3y/PkgEa1g==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/bpmnlint-plugin-camunda-compat/-/bpmnlint-plugin-camunda-compat-1.3.1.tgz",
+      "integrity": "sha512-nH+bmplVZ92d+26/GFKi4HQ1dD6xxjhRAwRGBMRuQc1hNtdsp/dv9MhShSyMCD1ZWays4d59dhNXHWorAy8aCg==",
       "dependencies": {
         "@bpmn-io/feel-lint": "^0.1.1",
         "@bpmn-io/moddle-utils": "^0.1.0",
@@ -7970,9 +7970,9 @@
       }
     },
     "bpmnlint-plugin-camunda-compat": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/bpmnlint-plugin-camunda-compat/-/bpmnlint-plugin-camunda-compat-1.2.0.tgz",
-      "integrity": "sha512-yIzBPpJqIpN2tDDkE5kcw4o8dSblEfLczaB4yeCCtjAEEfctDL66vzSgR3XHIOo/gAQGOcvmrbW/3y/PkgEa1g==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/bpmnlint-plugin-camunda-compat/-/bpmnlint-plugin-camunda-compat-1.3.1.tgz",
+      "integrity": "sha512-nH+bmplVZ92d+26/GFKi4HQ1dD6xxjhRAwRGBMRuQc1hNtdsp/dv9MhShSyMCD1ZWays4d59dhNXHWorAy8aCg==",
       "requires": {
         "@bpmn-io/feel-lint": "^0.1.1",
         "@bpmn-io/moddle-utils": "^0.1.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "bpmn-moddle": "^8.0.0",
     "bpmnlint": "^8.0.0",
-    "bpmnlint-plugin-camunda-compat": "^1.2.0",
+    "bpmnlint-plugin-camunda-compat": "^1.3.1",
     "bpmnlint-utils": "^1.0.2",
     "min-dash": "^4.0.0",
     "min-dom": "^4.1.0",

--- a/test/spec/utils/error-messages.spec.js
+++ b/test/spec/utils/error-messages.spec.js
@@ -1126,6 +1126,8 @@ describe('utils/error-messages', function() {
         it('should adjust (timer type)', async function() {
 
           // given
+          const executionPlatformVersion = '1.0';
+
           const node = createElement('bpmn:BoundaryEvent', {
             attachedToRef: createElement('bpmn:Task'),
             cancelActivity: false,
@@ -1136,7 +1138,7 @@ describe('utils/error-messages', function() {
 
           const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/timer');
 
-          const report = await getLintError(node, rule);
+          const report = await getLintError(node, rule, { version: executionPlatformVersion });
 
           // when
           const errorMessage = getErrorMessage(report);
@@ -1146,31 +1148,11 @@ describe('utils/error-messages', function() {
         });
 
 
-        it('should adjust (timer duration)', async function() {
-
-          // given
-          const node = createElement('bpmn:BoundaryEvent', {
-            attachedToRef: createElement('bpmn:Task'),
-            eventDefinitions: [
-              createElement('bpmn:TimerEventDefinition')
-            ]
-          });
-
-          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/timer');
-
-          const report = await getLintError(node, rule);
-
-          // when
-          const errorMessage = getErrorMessage(report);
-
-          // then
-          expect(errorMessage).to.equal('A <Timer Boundary Event> must have a defined <Timer duration>');
-        });
-
-
         it('should adjust (time cycle)', async function() {
 
           // given
+          const executionPlatformVersion = '1.0';
+
           const node = createElement('bpmn:BoundaryEvent', {
             attachedToRef: createElement('bpmn:Task'),
             cancelActivity: false,
@@ -1183,7 +1165,7 @@ describe('utils/error-messages', function() {
 
           const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/timer');
 
-          const report = await getLintError(node, rule);
+          const report = await getLintError(node, rule, { version: executionPlatformVersion });
 
           // when
           const errorMessage = getErrorMessage(report);
@@ -1273,6 +1255,8 @@ describe('utils/error-messages', function() {
         it('should adjust (time cycle)', async function() {
 
           // given
+          const executionPlatformVersion = '1.0';
+
           const node = createElement('bpmn:BoundaryEvent', {
             attachedToRef: createElement('bpmn:Task'),
             cancelActivity: false,
@@ -1285,7 +1269,7 @@ describe('utils/error-messages', function() {
 
           const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/timer');
 
-          const report = await getLintError(node, rule);
+          const report = await getLintError(node, rule, { version: executionPlatformVersion });
 
           // when
           const errorMessage = getErrorMessage(report);
@@ -1298,6 +1282,8 @@ describe('utils/error-messages', function() {
         it('should adjust (time date)', async function() {
 
           // given
+          const executionPlatformVersion = '1.0';
+
           const node = createElement('bpmn:StartEvent', {
             eventDefinitions: [
               createElement('bpmn:TimerEventDefinition', {
@@ -1306,9 +1292,11 @@ describe('utils/error-messages', function() {
             ]
           });
 
+          createElement('bpmn:Process', { flowElements: [ node ] });
+
           const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/timer');
 
-          const report = await getLintError(node, rule);
+          const report = await getLintError(node, rule, { version: executionPlatformVersion });
 
           // when
           const errorMessage = getErrorMessage(report);
@@ -1321,6 +1309,8 @@ describe('utils/error-messages', function() {
         it('should adjust (time duration)', async function() {
 
           // given
+          const executionPlatformVersion = '1.0';
+
           const node = createElement('bpmn:BoundaryEvent', {
             attachedToRef: createElement('bpmn:Task'),
             cancelActivity: false,
@@ -1333,7 +1323,7 @@ describe('utils/error-messages', function() {
 
           const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/timer');
 
-          const report = await getLintError(node, rule);
+          const report = await getLintError(node, rule, { version: executionPlatformVersion });
 
           // when
           const errorMessage = getErrorMessage(report);

--- a/test/spec/utils/properties-panel.spec.js
+++ b/test/spec/utils/properties-panel.spec.js
@@ -922,7 +922,7 @@ describe('utils/properties-panel', function() {
 
         const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/timer');
 
-        const report = await getLintError(node, rule);
+        const report = await getLintError(node, rule, { version: '1.0' });
 
         // when
         const entryIds = getEntryIds(report);
@@ -931,58 +931,6 @@ describe('utils/properties-panel', function() {
         expect(entryIds).to.eql([ 'timerEventDefinitionType' ]);
 
         expectErrorMessage(entryIds[ 0 ], 'Type must be defined.', report);
-      });
-
-
-      it('timer (no duration value)', async function() {
-
-        // given
-        const node = createElement('bpmn:BoundaryEvent', {
-          attachedToRef: createElement('bpmn:Task'),
-          cancelActivity: false,
-          eventDefinitions: [
-            createElement('bpmn:TimerEventDefinition', {
-              timeDuration: createElement('bpmn:FormalExpression')
-            })
-          ]
-        });
-
-        const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/timer');
-
-        const report = await getLintError(node, rule);
-
-        // when
-        const entryIds = getEntryIds(report);
-
-        // then
-        expect(entryIds).to.eql([ 'timerEventDefinitionValue' ]);
-
-        expectErrorMessage(entryIds[ 0 ], 'Value must be defined.', report);
-      });
-
-
-      it('timer (no duration value - no timer selection)', async function() {
-
-        // given
-        const node = createElement('bpmn:IntermediateCatchEvent', {
-          eventDefinitions: [
-            createElement('bpmn:TimerEventDefinition', {
-              timeDuration: createElement('bpmn:FormalExpression')
-            })
-          ]
-        });
-
-        const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/timer');
-
-        const report = await getLintError(node, rule);
-
-        // when
-        const entryIds = getEntryIds(report);
-
-        // then
-        expect(entryIds).to.eql([ 'timerEventDefinitionDurationValue' ]);
-
-        expectErrorMessage(entryIds[ 0 ], 'Duration must be defined.', report);
       });
 
 
@@ -1001,7 +949,7 @@ describe('utils/properties-panel', function() {
 
         const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/timer');
 
-        const report = await getLintError(node, rule);
+        const report = await getLintError(node, rule, { version: '1.0' });
 
         // when
         const entryIds = getEntryIds(report);
@@ -1024,9 +972,38 @@ describe('utils/properties-panel', function() {
           ]
         });
 
+        createElement('bpmn:Process', { flowElements: [ node ] });
+
         const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/timer');
 
-        const report = await getLintError(node, rule);
+        const report = await getLintError(node, rule, { version: '1.0' });
+
+        // when
+        const entryIds = getEntryIds(report);
+
+        // then
+        expect(entryIds).to.eql([ 'timerEventDefinitionValue' ]);
+
+        expectErrorMessage(entryIds[ 0 ], 'Value must be defined.', report);
+      });
+
+
+      it('timer (no time duration value)', async function() {
+
+        // given
+        const node = createElement('bpmn:BoundaryEvent', {
+          attachedToRef: createElement('bpmn:Task'),
+          cancelActivity: false,
+          eventDefinitions: [
+            createElement('bpmn:TimerEventDefinition', {
+              timeDuration: createElement('bpmn:FormalExpression')
+            })
+          ]
+        });
+
+        const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/timer');
+
+        const report = await getLintError(node, rule, { version: '1.0' });
 
         // when
         const entryIds = getEntryIds(report);
@@ -1055,7 +1032,7 @@ describe('utils/properties-panel', function() {
 
         const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/timer');
 
-        const report = await getLintError(node, rule);
+        const report = await getLintError(node, rule, { version: '1.0' });
 
         // when
         const entryIds = getEntryIds(report);
@@ -1080,9 +1057,11 @@ describe('utils/properties-panel', function() {
           ]
         });
 
+        createElement('bpmn:Process', { flowElements: [ node ] });
+
         const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/timer');
 
-        const report = await getLintError(node, rule);
+        const report = await getLintError(node, rule, { version: '1.0' });
 
         // when
         const entryIds = getEntryIds(report);
@@ -1111,40 +1090,13 @@ describe('utils/properties-panel', function() {
 
         const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/timer');
 
-        const report = await getLintError(node, rule);
+        const report = await getLintError(node, rule, { version: '1.0' });
 
         // when
         const entryIds = getEntryIds(report);
 
         // then
         expect(entryIds).to.eql([ 'timerEventDefinitionValue' ]);
-
-        expectErrorMessage(entryIds[ 0 ], 'Must be an expression, or an ISO 8601 interval.', report);
-      });
-
-
-      it('timer (invalid time duration - no timer selection)', async function() {
-
-        // given
-        const node = createElement('bpmn:IntermediateCatchEvent', {
-          eventDefinitions: [
-            createElement('bpmn:TimerEventDefinition', {
-              timeDuration: createElement('bpmn:FormalExpression', {
-                body: 'INVALID'
-              })
-            })
-          ]
-        });
-
-        const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/timer');
-
-        const report = await getLintError(node, rule);
-
-        // when
-        const entryIds = getEntryIds(report);
-
-        // then
-        expect(entryIds).to.eql([ 'timerEventDefinitionDurationValue' ]);
 
         expectErrorMessage(entryIds[ 0 ], 'Must be an expression, or an ISO 8601 interval.', report);
       });


### PR DESCRIPTION
* update `bpmnlint-plugin-camunda-compat`
* remove legacy IDs (cf. https://github.com/bpmn-io/bpmn-js-properties-panel/pull/931)

---

Requires https://github.com/bpmn-io/bpmn-js-properties-panel/pull/931