### PR TITLE
fix: make `modeler-moddle` a production dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to [@camunda/linting](https://github.com/camunda/linting) ar
 
 ___Note:__ Yet to be released changes appear here._
 
+* `FIX`: make `modeler-moddle` a production dependency
+
 ## 1.2.0
 
 * `FEAT`: add `event-based-gateway-target` rule ([#96](https://github.com/camunda/bpmnlint-plugin-camunda-compat/pull/96))

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "bpmnlint-utils": "^1.0.2",
         "min-dash": "^4.0.0",
         "min-dom": "^4.1.0",
+        "modeler-moddle": "^0.2.0",
         "zeebe-bpmn-moddle": "^0.18.0"
       },
       "devDependencies": {
@@ -34,7 +35,6 @@
         "karma-webpack": "^5.0.0",
         "mocha": "^10.2.0",
         "mocha-test-container-support": "^0.2.0",
-        "modeler-moddle": "^0.2.0",
         "puppeteer": "^19.5.2",
         "sinon": "^15.0.1",
         "sinon-chai": "^3.7.0",
@@ -4645,8 +4645,7 @@
     "node_modules/modeler-moddle": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/modeler-moddle/-/modeler-moddle-0.2.0.tgz",
-      "integrity": "sha512-l8OUpvX94m3spe+RBwWFQ0bGvPBZ3FBCiSY3yNtDk52j0YRj+cnVOxTMQvVM+i6k1T326IfqYM3F9HJfPZtXRw==",
-      "dev": true
+      "integrity": "sha512-l8OUpvX94m3spe+RBwWFQ0bGvPBZ3FBCiSY3yNtDk52j0YRj+cnVOxTMQvVM+i6k1T326IfqYM3F9HJfPZtXRw=="
     },
     "node_modules/mri": {
       "version": "1.2.0",
@@ -10190,8 +10189,7 @@
     "modeler-moddle": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/modeler-moddle/-/modeler-moddle-0.2.0.tgz",
-      "integrity": "sha512-l8OUpvX94m3spe+RBwWFQ0bGvPBZ3FBCiSY3yNtDk52j0YRj+cnVOxTMQvVM+i6k1T326IfqYM3F9HJfPZtXRw==",
-      "dev": true
+      "integrity": "sha512-l8OUpvX94m3spe+RBwWFQ0bGvPBZ3FBCiSY3yNtDk52j0YRj+cnVOxTMQvVM+i6k1T326IfqYM3F9HJfPZtXRw=="
     },
     "mri": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "bpmnlint-utils": "^1.0.2",
     "min-dash": "^4.0.0",
     "min-dom": "^4.1.0",
+    "modeler-moddle": "^0.2.0",
     "zeebe-bpmn-moddle": "^0.18.0"
   },
   "devDependencies": {
@@ -52,7 +53,6 @@
     "karma-webpack": "^5.0.0",
     "mocha": "^10.2.0",
     "mocha-test-container-support": "^0.2.0",
-    "modeler-moddle": "^0.2.0",
     "puppeteer": "^19.5.2",
     "sinon": "^15.0.1",
     "sinon-chai": "^3.7.0",


### PR DESCRIPTION
it is used here: https://github.com/camunda/linting/blob/main/lib/Linter.js#L10 and you can't use the lib if you don't already have the dependency installed as a peer dependency 