### PR TITLE
feat: allow custom entryIds

### DIFF
--- a/lib/utils/properties-panel.js
+++ b/lib/utils/properties-panel.js
@@ -48,8 +48,13 @@ export function getEntryIds(report) {
   const {
     data = {},
     id,
-    path
+    path,
+    entryIds
   } = report;
+
+  if (entryIds) {
+    return entryIds;
+  }
 
   if (isPropertyError(data, 'isExecutable')) {
     return [ 'isExecutable' ];
@@ -257,7 +262,7 @@ export function getEntryIds(report) {
 }
 
 export function getErrorMessage(id, report) {
-  const { data } = report;
+  const { data = {} } = report;
 
   // do not override FEEL message
   if (data.type === ERROR_TYPES.FEEL_EXPRESSION_INVALID) {

--- a/test/spec/utils/properties-panel.spec.js
+++ b/test/spec/utils/properties-panel.spec.js
@@ -29,6 +29,27 @@ describe('utils/properties-panel', function() {
 
     describe('#getEntryId and #getErrorMessage', function() {
 
+      it('should keep original entryIds', async function() {
+
+        // given
+        const node = createElement('bpmn:Process');
+
+        const rule = () => ({
+          check: (node, reporter) => {
+            reporter.report(node.id, 'My Custom Message' , { entryIds: [ 'myCustomEntry' ] });
+          }
+        });
+
+        const report = await getLintError(node, rule);
+
+        // when
+        const entryIds = getEntryIds(report);
+
+        // then
+        expect(entryIds).to.eql([ 'myCustomEntry' ]);
+      });
+
+
       it('executable-process - Executable (process)', async function() {
 
         // given


### PR DESCRIPTION
related to https://github.com/camunda/camunda-modeler/issues/3357

The entry is used to select the input field in the properties panel. We want to be able to provide this information in the lint rule, as this might not be a static value (e.g. for element templates)