### PR TITLE
Housekeeping

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,2 @@
 node_modules
+lib/compiled-config.js

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,11 +1,11 @@
 {
   "extends": "plugin:bpmn-io/browser",
-  "globals": {
-    "require": false
+  "parserOptions": {
+    "ecmaVersion": "latest"
   },
   "overrides": [
     {
-      "files": "karma.conf.js",
+      "files": ["karma.conf.js", "tasks/*.js"],
       "extends": "plugin:bpmn-io/node"
     }
   ]

--- a/lib/Linter.js
+++ b/lib/Linter.js
@@ -72,6 +72,8 @@ export class Linter {
 
           return {
             ...report,
+            executionPlatform,
+            executionPlatformVersion,
             message: getErrorMessage(
               report,
               executionPlatform,

--- a/lib/Linter.js
+++ b/lib/Linter.js
@@ -7,6 +7,8 @@ import Resolver from './Resolver';
 
 import { isString } from 'min-dash';
 
+import { resolver as RulesResolver } from './compiled-config';
+
 import modelerModdle from 'modeler-moddle/resources/modeler.json';
 import zeebeModdle from 'zeebe-bpmn-moddle/resources/zeebe.json';
 
@@ -118,10 +120,23 @@ export class Linter {
   }
 
   async _createResolver(configName) {
-    const cache = await createCache(configName);
+    const { configs } = await import('bpmnlint-plugin-camunda-compat');
+
+    let { [ configName ]: config } = configs;
+
+    if (!config) {
+      config = {
+        rules: {}
+      };
+    }
+
+    const ConfigResolver = new StaticResolver({
+      [ `config:bpmnlint-plugin-camunda-compat/${ configName }` ]: config
+    });
 
     return new Resolver([
-      new StaticResolver(cache),
+      ConfigResolver,
+      RulesResolver,
       ...this._plugins.map(({ resolver }) => resolver)
     ]);
   }
@@ -136,36 +151,4 @@ function getConfigName(executionPlatform, executionPlatformVersion) {
 
 function toLowerCase(string) {
   return string.toLowerCase();
-}
-
-async function createCache(configName) {
-  let config = require('bpmnlint-plugin-camunda-compat').configs[ configName ];
-
-  if (!config) {
-    config = {
-      rules: {}
-    };
-  }
-
-  const rules = await requireRules(config);
-
-  return {
-    [ `config:bpmnlint-plugin-camunda-compat/${ configName }` ]: config,
-    ...rules
-  };
-}
-
-function requireRules({ rules }) {
-  let requiredRules = {};
-
-  for (let ruleName of Object.keys(rules)) {
-    const requiredRule = require(`bpmnlint-plugin-camunda-compat/rules/${ ruleName }`);
-
-    requiredRules = {
-      ...requiredRules,
-      [ `rule:bpmnlint-plugin-camunda-compat/${ ruleName }` ]: requiredRule
-    };
-  }
-
-  return requiredRules;
 }

--- a/lib/compiled-config.js
+++ b/lib/compiled-config.js
@@ -1,0 +1,180 @@
+
+const cache = {};
+
+/**
+ * A resolver that caches rules and configuration as part of the bundle,
+ * making them accessible in the browser.
+ *
+ * @param {Object} cache
+ */
+function Resolver() {}
+
+Resolver.prototype.resolveRule = function(pkg, ruleName) {
+
+  const rule = cache[pkg + '/' + ruleName];
+
+  if (!rule) {
+    throw new Error('cannot resolve rule <' + pkg + '/' + ruleName + '>: not bundled');
+  }
+
+  return rule;
+};
+
+Resolver.prototype.resolveConfig = function(pkg, configName) {
+  throw new Error(
+    'cannot resolve config <' + configName + '> in <' + pkg +'>: not bundled'
+  );
+};
+
+const resolver = new Resolver();
+
+const rules = {
+  "camunda-compat/element-type": "error",
+  "camunda-compat/called-element": "error",
+  "camunda-compat/collapsed-subprocess": "error",
+  "camunda-compat/duplicate-task-headers": "error",
+  "camunda-compat/error-reference": "error",
+  "camunda-compat/escalation-reference": "error",
+  "camunda-compat/event-based-gateway-target": "error",
+  "camunda-compat/executable-process": "error",
+  "camunda-compat/feel": "error",
+  "camunda-compat/history-time-to-live": "error",
+  "camunda-compat/implementation": "error",
+  "camunda-compat/inclusive-gateway": "error",
+  "camunda-compat/loop-characteristics": "error",
+  "camunda-compat/message-reference": "error",
+  "camunda-compat/no-candidate-users": "error",
+  "camunda-compat/no-expression": "error",
+  "camunda-compat/no-multiple-none-start-events": "error",
+  "camunda-compat/no-signal-event-sub-process": "error",
+  "camunda-compat/no-task-schedule": "error",
+  "camunda-compat/no-template": "error",
+  "camunda-compat/no-zeebe-properties": "error",
+  "camunda-compat/sequence-flow-condition": "error",
+  "camunda-compat/signal-reference": "error",
+  "camunda-compat/subscription": "error",
+  "camunda-compat/task-schedule": "error",
+  "camunda-compat/timer": "error",
+  "camunda-compat/user-task-form": "error"
+};
+
+const config = {
+  rules: rules
+};
+
+const bundle = {
+  resolver: resolver,
+  config: config
+};
+
+export { resolver, config };
+
+export default bundle;
+
+import rule_0 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/element-type';
+
+cache['bpmnlint-plugin-camunda-compat/element-type'] = rule_0;
+
+import rule_1 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/called-element';
+
+cache['bpmnlint-plugin-camunda-compat/called-element'] = rule_1;
+
+import rule_2 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/collapsed-subprocess';
+
+cache['bpmnlint-plugin-camunda-compat/collapsed-subprocess'] = rule_2;
+
+import rule_3 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/duplicate-task-headers';
+
+cache['bpmnlint-plugin-camunda-compat/duplicate-task-headers'] = rule_3;
+
+import rule_4 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/error-reference';
+
+cache['bpmnlint-plugin-camunda-compat/error-reference'] = rule_4;
+
+import rule_5 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/escalation-reference';
+
+cache['bpmnlint-plugin-camunda-compat/escalation-reference'] = rule_5;
+
+import rule_6 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/event-based-gateway-target';
+
+cache['bpmnlint-plugin-camunda-compat/event-based-gateway-target'] = rule_6;
+
+import rule_7 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/executable-process';
+
+cache['bpmnlint-plugin-camunda-compat/executable-process'] = rule_7;
+
+import rule_8 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/feel';
+
+cache['bpmnlint-plugin-camunda-compat/feel'] = rule_8;
+
+import rule_9 from 'bpmnlint-plugin-camunda-compat/rules/camunda-platform/history-time-to-live';
+
+cache['bpmnlint-plugin-camunda-compat/history-time-to-live'] = rule_9;
+
+import rule_10 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/implementation';
+
+cache['bpmnlint-plugin-camunda-compat/implementation'] = rule_10;
+
+import rule_11 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/inclusive-gateway';
+
+cache['bpmnlint-plugin-camunda-compat/inclusive-gateway'] = rule_11;
+
+import rule_12 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/loop-characteristics';
+
+cache['bpmnlint-plugin-camunda-compat/loop-characteristics'] = rule_12;
+
+import rule_13 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/message-reference';
+
+cache['bpmnlint-plugin-camunda-compat/message-reference'] = rule_13;
+
+import rule_14 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-candidate-users';
+
+cache['bpmnlint-plugin-camunda-compat/no-candidate-users'] = rule_14;
+
+import rule_15 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-expression';
+
+cache['bpmnlint-plugin-camunda-compat/no-expression'] = rule_15;
+
+import rule_16 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-multiple-none-start-events';
+
+cache['bpmnlint-plugin-camunda-compat/no-multiple-none-start-events'] = rule_16;
+
+import rule_17 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-signal-event-sub-process';
+
+cache['bpmnlint-plugin-camunda-compat/no-signal-event-sub-process'] = rule_17;
+
+import rule_18 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-task-schedule';
+
+cache['bpmnlint-plugin-camunda-compat/no-task-schedule'] = rule_18;
+
+import rule_19 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-template';
+
+cache['bpmnlint-plugin-camunda-compat/no-template'] = rule_19;
+
+import rule_20 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-zeebe-properties';
+
+cache['bpmnlint-plugin-camunda-compat/no-zeebe-properties'] = rule_20;
+
+import rule_21 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/sequence-flow-condition';
+
+cache['bpmnlint-plugin-camunda-compat/sequence-flow-condition'] = rule_21;
+
+import rule_22 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/signal-reference';
+
+cache['bpmnlint-plugin-camunda-compat/signal-reference'] = rule_22;
+
+import rule_23 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/subscription';
+
+cache['bpmnlint-plugin-camunda-compat/subscription'] = rule_23;
+
+import rule_24 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/task-schedule';
+
+cache['bpmnlint-plugin-camunda-compat/task-schedule'] = rule_24;
+
+import rule_25 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/timer';
+
+cache['bpmnlint-plugin-camunda-compat/timer'] = rule_25;
+
+import rule_26 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/user-task-form';
+
+cache['bpmnlint-plugin-camunda-compat/user-task-form'] = rule_26;

--- a/lib/utils/error-messages.js
+++ b/lib/utils/error-messages.js
@@ -9,7 +9,10 @@ import {
 
 import { getTypeString } from './types';
 
-import { toSemverMinor } from './version';
+import {
+  greaterOrEqual,
+  toSemverMinor
+} from './version';
 
 const TIMER_PROPERTIES = [
   'timeCycle',
@@ -122,7 +125,7 @@ export function getErrorMessage(report, executionPlatform, executionPlatformVers
   }
 
   if (type === ERROR_TYPES.EXPRESSION_VALUE_NOT_ALLOWED) {
-    return getExpressionValueNotAllowedErrorMessage(report);
+    return getExpressionValueNotAllowedErrorMessage(report, executionPlatform, executionPlatformVersion);
   }
 
   if (type === ERROR_TYPES.EXPRESSION_NOT_ALLOWED) {
@@ -507,7 +510,7 @@ function getExpressionRequiredErrorMessage(report) {
   return message;
 }
 
-function getExpressionValueNotAllowedErrorMessage(report) {
+function getExpressionValueNotAllowedErrorMessage(report, executionPlatform, executionPlatformVersion) {
   const {
     data,
     message
@@ -522,7 +525,11 @@ function getExpressionValueNotAllowedErrorMessage(report) {
   const typeString = getTypeString(parentNode || node);
 
   if (is(node, 'bpmn:FormalExpression') && property === 'timeCycle') {
-    return `${ getIndefiniteArticle(typeString) } <${ typeString }> <Time cycle> must be an expression, an ISO 8601 repeating interval, or a cron expression (cron requires Camunda Platform 8.1 or newer)`;
+    if (!greaterOrEqual(executionPlatformVersion, '8.1')) {
+      return `${ getIndefiniteArticle(typeString) } <${ typeString }> <Time cycle> must be an expression, an ISO 8601 repeating interval, or a cron expression (cron only supported by Camunda Platform 8.1 or newer)`;
+    } else {
+      return `${ getIndefiniteArticle(typeString) } <${ typeString }> <Time cycle> must be an expression, an ISO 8601 repeating interval, or a cron expression`;
+    }
   }
 
   if (is(node, 'bpmn:FormalExpression') && property === 'timeDate') {

--- a/lib/utils/properties-panel.js
+++ b/lib/utils/properties-panel.js
@@ -4,6 +4,8 @@ import { is } from 'bpmnlint-utils';
 
 import { ERROR_TYPES } from 'bpmnlint-plugin-camunda-compat/rules/utils/error-types';
 
+import { greaterOrEqual } from './version';
+
 const TIMER_PROPERTIES = [
   'timeDate',
   'timeDuration',
@@ -268,7 +270,10 @@ export function getEntryIds(report) {
 }
 
 export function getErrorMessage(id, report) {
-  const { data = {} } = report;
+  const {
+    data = {},
+    executionPlatformVersion
+  } = report;
 
   // do not override FEEL message
   if (data.type === ERROR_TYPES.FEEL_EXPRESSION_INVALID) {
@@ -397,7 +402,11 @@ export function getErrorMessage(id, report) {
     const { property } = data;
 
     if (property === 'timeCycle') {
-      return 'Must be an expression, an ISO 8601 repeating interval, or a cron expression (cron requires Camunda Platform 8.1 or newer).';
+      if (!greaterOrEqual(executionPlatformVersion, '8.1')) {
+        return 'Must be an expression, an ISO 8601 repeating interval, or a cron expression (cron only supported by Camunda Platform 8.1 or newer).';
+      }
+
+      return 'Must be an expression, an ISO 8601 repeating interval, or a cron expression.';
     }
 
     if (property === 'timeDate') {

--- a/lib/utils/version.js
+++ b/lib/utils/version.js
@@ -1,3 +1,9 @@
+import cmp from 'semver-compare';
+
+export function greaterOrEqual(a, b) {
+  return cmp(a, b) !== -1;
+}
+
 export function toSemverMinor(executionPlatformVersion) {
   return executionPlatformVersion.split('.').slice(0, 2).join('.');
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "min-dash": "^4.0.0",
         "min-dom": "^4.1.0",
         "modeler-moddle": "^0.2.0",
+        "semver-compare": "^1.0.0",
         "zeebe-bpmn-moddle": "^0.18.0"
       },
       "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
       "license": "MIT",
       "dependencies": {
         "bpmn-moddle": "^8.0.0",
-        "bpmnlint": "^9.0.0",
-        "bpmnlint-plugin-camunda-compat": "^1.4.0",
+        "bpmnlint": "^9.2.0",
+        "bpmnlint-plugin-camunda-compat": "^2.1.0",
         "bpmnlint-utils": "^1.0.2",
         "min-dash": "^4.0.0",
         "min-dom": "^4.1.0",
@@ -1209,9 +1209,9 @@
       }
     },
     "node_modules/bpmnlint": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/bpmnlint/-/bpmnlint-9.0.0.tgz",
-      "integrity": "sha512-U1YF5tNymGd2rBjKBVEkLuGPYssrqarZgEttMwxF7avEBDdJg7cryAsjKSeYhmDP5U8qV2iFBX/AVUMw00WuTg==",
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/bpmnlint/-/bpmnlint-9.2.0.tgz",
+      "integrity": "sha512-GJVe6t0lSUTqKH1FeM9ueqop+zZh7Ag4QsWhiHrpU4Zt6XmGIXNfxwLrX8JvqNzxJIdhpF+YRT7rY2qQQhvYBg==",
       "dependencies": {
         "@bpmn-io/moddle-utils": "^0.2.0",
         "ansi-colors": "^4.1.3",
@@ -1232,9 +1232,9 @@
       }
     },
     "node_modules/bpmnlint-plugin-camunda-compat": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/bpmnlint-plugin-camunda-compat/-/bpmnlint-plugin-camunda-compat-1.4.0.tgz",
-      "integrity": "sha512-2ziFfIU/mGX3w4QQR77yLY07FMKmwTyN9X7b5u9zL3Hf9pbkimV/anYHgPOrXXmBEVzc7b8lW0vqHdOaMROQpQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/bpmnlint-plugin-camunda-compat/-/bpmnlint-plugin-camunda-compat-2.1.0.tgz",
+      "integrity": "sha512-7gwNcth/MAa6XhkvZiS5+VNtbPgzgG34XyJZOpX7Wh6pCcH4u1goRX9jvebGfljoPlXxBXM02uutiwzzrzfshg==",
       "dependencies": {
         "@bpmn-io/feel-lint": "^0.1.1",
         "@bpmn-io/moddle-utils": "^0.1.0",
@@ -6924,9 +6924,9 @@
       }
     },
     "bpmnlint": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/bpmnlint/-/bpmnlint-9.0.0.tgz",
-      "integrity": "sha512-U1YF5tNymGd2rBjKBVEkLuGPYssrqarZgEttMwxF7avEBDdJg7cryAsjKSeYhmDP5U8qV2iFBX/AVUMw00WuTg==",
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/bpmnlint/-/bpmnlint-9.2.0.tgz",
+      "integrity": "sha512-GJVe6t0lSUTqKH1FeM9ueqop+zZh7Ag4QsWhiHrpU4Zt6XmGIXNfxwLrX8JvqNzxJIdhpF+YRT7rY2qQQhvYBg==",
       "requires": {
         "@bpmn-io/moddle-utils": "^0.2.0",
         "ansi-colors": "^4.1.3",
@@ -6951,9 +6951,9 @@
       }
     },
     "bpmnlint-plugin-camunda-compat": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/bpmnlint-plugin-camunda-compat/-/bpmnlint-plugin-camunda-compat-1.4.0.tgz",
-      "integrity": "sha512-2ziFfIU/mGX3w4QQR77yLY07FMKmwTyN9X7b5u9zL3Hf9pbkimV/anYHgPOrXXmBEVzc7b8lW0vqHdOaMROQpQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/bpmnlint-plugin-camunda-compat/-/bpmnlint-plugin-camunda-compat-2.1.0.tgz",
+      "integrity": "sha512-7gwNcth/MAa6XhkvZiS5+VNtbPgzgG34XyJZOpX7Wh6pCcH4u1goRX9jvebGfljoPlXxBXM02uutiwzzrzfshg==",
       "requires": {
         "@bpmn-io/feel-lint": "^0.1.1",
         "@bpmn-io/moddle-utils": "^0.1.0",

--- a/package.json
+++ b/package.json
@@ -28,8 +28,8 @@
   "license": "MIT",
   "dependencies": {
     "bpmn-moddle": "^8.0.0",
-    "bpmnlint": "^9.0.0",
-    "bpmnlint-plugin-camunda-compat": "^1.4.0",
+    "bpmnlint": "^9.2.0",
+    "bpmnlint-plugin-camunda-compat": "^2.1.0",
     "bpmnlint-utils": "^1.0.2",
     "min-dash": "^4.0.0",
     "min-dom": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -10,8 +10,10 @@
     "start": "npm run start:cloud",
     "start:platform": "cross-env SINGLE_START=platform npm run test:watch",
     "start:cloud": "cross-env SINGLE_START=cloud npm run test:watch",
-    "test": "karma start",
-    "test:watch": "npm test -- --auto-watch --no-single-run"
+    "test": "npm run compile-config && karma start",
+    "test:watch": "npm test -- --auto-watch --no-single-run",
+    "compile-config": "node tasks/compile-config.js",
+    "prepublish": "npm run compile-config"
   },
   "keywords": [
     "bpmnlint",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "min-dash": "^4.0.0",
     "min-dom": "^4.1.0",
     "modeler-moddle": "^0.2.0",
+    "semver-compare": "^1.0.0",
     "zeebe-bpmn-moddle": "^0.18.0"
   },
   "devDependencies": {

--- a/tasks/compile-config.js
+++ b/tasks/compile-config.js
@@ -1,0 +1,9 @@
+const fs = require('fs');
+
+const compileConfig = require('bpmnlint/lib/support/compile-config');
+
+const config = {
+  extends: 'plugin:camunda-compat/all'
+};
+
+compileConfig(config).then(code => fs.writeFileSync('lib/compiled-config.js', code));

--- a/test/spec/Linter.spec.js
+++ b/test/spec/Linter.spec.js
@@ -253,11 +253,11 @@ describe('Linter', function() {
     const FooPlugin = {
       config: {
         rules: {
-          'foo/fake-join': 'error'
+          'foo/superfluous-gateway': 'error'
         }
       },
       resolver: new StaticResolver({
-        'rule:bpmnlint-plugin-foo/fake-join': require('bpmnlint/rules/fake-join')
+        'rule:bpmnlint-plugin-foo/superfluous-gateway': require('bpmnlint/rules/superfluous-gateway')
       })
     };
 
@@ -265,24 +265,24 @@ describe('Linter', function() {
       config: {
         extends: 'plugin:foo/recommended',
         rules: {
-          'bar/single-blank-start-event': 'error'
+          'bar/no-implicit-end': 'error'
         }
       },
       resolver: new StaticResolver({
         'config:bpmnlint-plugin-foo/recommended': {
           rules: {
-            'foo/fake-join': 'error'
+            'foo/superfluous-gateway': 'error'
           }
         },
-        'rule:bpmnlint-plugin-foo/fake-join': require('bpmnlint/rules/fake-join'),
-        'rule:bpmnlint-plugin-bar/single-blank-start-event': require('bpmnlint/rules/single-blank-start-event')
+        'rule:bpmnlint-plugin-foo/superfluous-gateway': require('bpmnlint/rules/superfluous-gateway'),
+        'rule:bpmnlint-plugin-bar/no-implicit-end': require('bpmnlint/rules/no-implicit-end')
       })
     };
 
     const BazPlugin = {
       config: {
         rules: {
-          'foo/fake-join': 'off'
+          'foo/superfluous-gateway': 'off'
         }
       },
       resolver: new StaticResolver({})
@@ -306,7 +306,7 @@ describe('Linter', function() {
       // then
       expect(reports).to.have.length(2);
 
-      expect(reports.find(({ message }) => message === 'Incoming flows do not join')).to.exist;
+      expect(reports.find(({ message }) => message === 'Gateway is superfluous. It only has one source and target.')).to.exist;
     });
 
 
@@ -327,8 +327,8 @@ describe('Linter', function() {
       // then
       expect(reports).to.have.length(3);
 
-      expect(reports.find(({ message }) => message === 'Incoming flows do not join')).to.exist;
-      expect(reports.find(({ message }) => message === 'Process has multiple blank start events')).to.exist;
+      expect(reports.find(({ message }) => message === 'Gateway is superfluous. It only has one source and target.')).to.exist;
+      expect(reports.find(({ message }) => message === 'Element is an implicit end')).to.exist;
     });
 
 
@@ -351,8 +351,8 @@ describe('Linter', function() {
       // then
       expect(reports).to.have.length(2);
 
-      expect(reports.find(({ message }) => message === 'Incoming flows do not join')).not.to.exist;
-      expect(reports.find(({ message }) => message === 'Process has multiple blank start events')).to.exist;
+      expect(reports.find(({ message }) => message === 'Gateway is superfluous. It only has one source and target.')).not.to.exist;
+      expect(reports.find(({ message }) => message === 'Element is an implicit end')).to.exist;
     });
 
   });

--- a/test/spec/simple.bpmn
+++ b/test/spec/simple.bpmn
@@ -1,50 +1,37 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0bmzwre" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.3.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.0.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0bmzwre" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.13.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.0.0">
   <bpmn:process id="Process_0l9kcp2" isExecutable="true">
     <bpmn:startEvent id="StartEvent_1">
       <bpmn:outgoing>SequenceFlow_1</bpmn:outgoing>
     </bpmn:startEvent>
-    <bpmn:sequenceFlow id="SequenceFlow_1" sourceRef="StartEvent_1" targetRef="ServiceTask_1" />
-    <bpmn:endEvent id="EndEvent_1">
-      <bpmn:incoming>SequenceFlow_3</bpmn:incoming>
-    </bpmn:endEvent>
-    <bpmn:sequenceFlow id="SequenceFlow_3" sourceRef="ServiceTask_1" targetRef="EndEvent_1" />
-    <bpmn:startEvent id="StartEvent_2">
-      <bpmn:outgoing>SequenceFlow_2</bpmn:outgoing>
-    </bpmn:startEvent>
-    <bpmn:sequenceFlow id="SequenceFlow_2" sourceRef="StartEvent_2" targetRef="ServiceTask_1" />
-    <bpmn:serviceTask id="ServiceTask_1">
+    <bpmn:exclusiveGateway id="ExclusiveGateway_1">
       <bpmn:incoming>SequenceFlow_1</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_2</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="SequenceFlow_1" sourceRef="StartEvent_1" targetRef="ExclusiveGateway_1" />
+    <bpmn:serviceTask id="ServiceTask_1">
       <bpmn:incoming>SequenceFlow_2</bpmn:incoming>
-      <bpmn:outgoing>SequenceFlow_3</bpmn:outgoing>
     </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="SequenceFlow_2" sourceRef="ExclusiveGateway_1" targetRef="ServiceTask_1" />
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_0l9kcp2">
       <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
         <dc:Bounds x="179" y="99" width="36" height="36" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_132li60_di" bpmnElement="EndEvent_1">
-        <dc:Bounds x="432" y="99" width="36" height="36" />
+      <bpmndi:BPMNShape id="Gateway_1gm8bch_di" bpmnElement="ExclusiveGateway_1" isMarkerVisible="true">
+        <dc:Bounds x="265" y="92" width="50" height="50" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1nb2u4i_di" bpmnElement="StartEvent_2">
-        <dc:Bounds x="179" y="212" width="36" height="36" />
+      <bpmndi:BPMNShape id="Activity_1y1c2wn_di" bpmnElement="ServiceTask_1">
+        <dc:Bounds x="370" y="77" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_04o4n6j_di" bpmnElement="ServiceTask_1">
-        <dc:Bounds x="270" y="77" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="Flow_0sc49do_di" bpmnElement="SequenceFlow_1">
+      <bpmndi:BPMNEdge id="Flow_0k4t2aq_di" bpmnElement="SequenceFlow_1">
         <di:waypoint x="215" y="117" />
-        <di:waypoint x="270" y="117" />
+        <di:waypoint x="265" y="117" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0fsup22_di" bpmnElement="SequenceFlow_3">
+      <bpmndi:BPMNEdge id="Flow_1lhvake_di" bpmnElement="SequenceFlow_2">
+        <di:waypoint x="315" y="117" />
         <di:waypoint x="370" y="117" />
-        <di:waypoint x="432" y="117" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0xstfkg_di" bpmnElement="SequenceFlow_2">
-        <di:waypoint x="215" y="230" />
-        <di:waypoint x="320" y="230" />
-        <di:waypoint x="320" y="157" />
       </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/test/spec/utils/error-messages.spec.js
+++ b/test/spec/utils/error-messages.spec.js
@@ -55,7 +55,7 @@ describe('utils/error-messages', function() {
             triggeredByEvent: true
           });
 
-          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/no-signal-event-sub-process');
+          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-signal-event-sub-process');
 
           const report = await getLintError(node, rule);
 
@@ -78,7 +78,7 @@ describe('utils/error-messages', function() {
 
           const node = createElement('bpmn:Task');
 
-          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/element-type');
+          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/element-type');
 
           const report = await getLintError(node, rule, { version: executionPlatformVersion });
 
@@ -97,7 +97,7 @@ describe('utils/error-messages', function() {
 
           const node = createElement('bpmn:ComplexGateway');
 
-          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/element-type');
+          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/element-type');
 
           const report = await getLintError(node, rule, { version: executionPlatformVersion });
 
@@ -116,7 +116,7 @@ describe('utils/error-messages', function() {
 
           const node = createElement('bpmn:IntermediateCatchEvent');
 
-          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/element-type');
+          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/element-type');
 
           const report = await getLintError(node, rule, { version: executionPlatformVersion });
 
@@ -135,7 +135,7 @@ describe('utils/error-messages', function() {
 
           const node = createElement('bpmn:IntermediateThrowEvent');
 
-          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/element-type');
+          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/element-type');
 
           const report = await getLintError(node, rule, { version: executionPlatformVersion });
 
@@ -158,7 +158,7 @@ describe('utils/error-messages', function() {
             ]
           });
 
-          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/element-type');
+          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/element-type');
 
           const report = await getLintError(node, rule, { version: executionPlatformVersion });
 
@@ -177,7 +177,7 @@ describe('utils/error-messages', function() {
 
           const node = createElement('bpmn:BusinessRuleTask');
 
-          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/element-type');
+          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/element-type');
 
           const report = await getLintError(node, rule, { version: executionPlatformVersion });
 
@@ -200,7 +200,7 @@ describe('utils/error-messages', function() {
             ]
           });
 
-          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/element-type');
+          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/element-type');
 
           const report = await getLintError(node, rule, { version: executionPlatformVersion });
 
@@ -224,7 +224,7 @@ describe('utils/error-messages', function() {
             isExpanded: false
           });
 
-          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/collapsed-subprocess');
+          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/collapsed-subprocess');
 
           const report = await getLintError(di, rule);
 
@@ -244,7 +244,7 @@ describe('utils/error-messages', function() {
             isExpanded: false
           });
 
-          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/collapsed-subprocess');
+          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/collapsed-subprocess');
 
           const report = await getLintError(di, rule);
 
@@ -273,7 +273,7 @@ describe('utils/error-messages', function() {
             })
           });
 
-          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/implementation');
+          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/implementation');
 
           const report = await getLintError(node, rule, { version: executionPlatformVersion });
 
@@ -298,7 +298,7 @@ describe('utils/error-messages', function() {
             })
           });
 
-          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/no-zeebe-properties');
+          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-zeebe-properties');
 
           const report = await getLintError(node, rule);
 
@@ -323,7 +323,7 @@ describe('utils/error-messages', function() {
             })
           });
 
-          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/implementation');
+          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/implementation');
 
           const report = await getLintError(node, rule, { version: executionPlatformVersion });
 
@@ -350,7 +350,7 @@ describe('utils/error-messages', function() {
             })
           });
 
-          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/no-task-schedule');
+          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-task-schedule');
 
           const report = await getLintError(node, rule, { version: executionPlatformVersion });
 
@@ -371,7 +371,7 @@ describe('utils/error-messages', function() {
           // given
           const node = createElement('bpmn:CallActivity');
 
-          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/called-element');
+          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/called-element');
 
           const report = await getLintError(node, rule);
 
@@ -390,7 +390,7 @@ describe('utils/error-messages', function() {
             loopCharacteristics: createElement('bpmn:MultiInstanceLoopCharacteristics')
           });
 
-          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/loop-characteristics');
+          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/loop-characteristics');
 
           const report = await getLintError(node, rule);
 
@@ -409,7 +409,7 @@ describe('utils/error-messages', function() {
             messageRef: createElement('bpmn:Message')
           });
 
-          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/subscription');
+          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/subscription');
 
           const report = await getLintError(node, rule);
 
@@ -426,7 +426,7 @@ describe('utils/error-messages', function() {
           // given
           const node = createElement('bpmn:ServiceTask');
 
-          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/implementation');
+          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/implementation');
 
           const report = await getLintError(node, rule, { version: '1.0' });
 
@@ -443,7 +443,7 @@ describe('utils/error-messages', function() {
           // given
           const node = createElement('bpmn:BusinessRuleTask');
 
-          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/implementation');
+          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/implementation');
 
           const report = await getLintError(node, rule, { version: '1.3' });
 
@@ -460,7 +460,7 @@ describe('utils/error-messages', function() {
           // given
           const node = createElement('bpmn:ScriptTask');
 
-          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/implementation');
+          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/implementation');
 
           const report = await getLintError(node, rule, { version: '8.2' });
 
@@ -492,7 +492,7 @@ describe('utils/error-messages', function() {
             })
           });
 
-          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/loop-characteristics');
+          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/loop-characteristics');
 
           const report = await getLintError(node, rule);
 
@@ -520,7 +520,7 @@ describe('utils/error-messages', function() {
             })
           });
 
-          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/loop-characteristics');
+          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/loop-characteristics');
 
           const report = await getLintError(node, rule);
 
@@ -545,7 +545,7 @@ describe('utils/error-messages', function() {
               modelerTemplate: 'foo'
             });
 
-            const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/no-template');
+            const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-template');
 
             const report = await getLintError(node, rule);
 
@@ -564,7 +564,7 @@ describe('utils/error-messages', function() {
               modelerTemplate: 'foo'
             });
 
-            const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/no-template');
+            const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-template');
 
             const report = await getLintError(node, rule);
 
@@ -588,7 +588,7 @@ describe('utils/error-messages', function() {
             ]
           });
 
-          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/inclusive-gateway');
+          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/inclusive-gateway');
 
           const report = await getLintError(node, rule);
 
@@ -613,7 +613,7 @@ describe('utils/error-messages', function() {
             })
           });
 
-          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/no-candidate-users');
+          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-candidate-users');
 
           const report = await getLintError(node, rule);
 
@@ -642,7 +642,7 @@ describe('utils/error-messages', function() {
 
           endEvent.incoming = [ sequenceFlow ];
 
-          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/sequence-flow-condition');
+          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/sequence-flow-condition');
 
           const report = await getLintError(sequenceFlow, rule);
 
@@ -669,7 +669,7 @@ describe('utils/error-messages', function() {
 
           createElement('bpmn:Process', { flowElements: [ node ] });
 
-          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/timer');
+          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/timer');
 
           const report = await getLintError(node, rule, { version: executionPlatformVersion });
 
@@ -698,7 +698,7 @@ describe('utils/error-messages', function() {
             })
           });
 
-          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/implementation');
+          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/implementation');
 
           const report = await getLintError(node, rule, { version: '1.3' });
 
@@ -723,7 +723,7 @@ describe('utils/error-messages', function() {
             })
           });
 
-          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/implementation');
+          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/implementation');
 
           const report = await getLintError(node, rule, { version: '1.3' });
 
@@ -746,7 +746,7 @@ describe('utils/error-messages', function() {
             })
           });
 
-          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/implementation');
+          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/implementation');
 
           const report = await getLintError(node, rule, { version: '1.3' });
 
@@ -769,7 +769,7 @@ describe('utils/error-messages', function() {
             })
           });
 
-          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/called-element');
+          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/called-element');
 
           const report = await getLintError(node, rule);
 
@@ -794,7 +794,7 @@ describe('utils/error-messages', function() {
             ]
           });
 
-          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/error-reference');
+          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/error-reference');
 
           const report = await getLintError(node, rule, { version: executionPlatformVersion });
 
@@ -817,7 +817,7 @@ describe('utils/error-messages', function() {
             ]
           });
 
-          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/error-reference');
+          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/error-reference');
 
           const report = await getLintError(node, rule, { version: '8.1' });
 
@@ -840,7 +840,7 @@ describe('utils/error-messages', function() {
             ]
           });
 
-          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/escalation-reference');
+          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/escalation-reference');
 
           const report = await getLintError(node, rule);
 
@@ -865,7 +865,7 @@ describe('utils/error-messages', function() {
             })
           });
 
-          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/loop-characteristics');
+          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/loop-characteristics');
 
           const report = await getLintError(node, rule);
 
@@ -888,7 +888,7 @@ describe('utils/error-messages', function() {
             ]
           });
 
-          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/message-reference');
+          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/message-reference');
 
           const report = await getLintError(node, rule);
 
@@ -911,7 +911,7 @@ describe('utils/error-messages', function() {
             ]
           });
 
-          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/signal-reference');
+          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/signal-reference');
 
           const report = await getLintError(node, rule);
 
@@ -941,7 +941,7 @@ describe('utils/error-messages', function() {
             ]
           });
 
-          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/subscription');
+          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/subscription');
 
           const report = await getLintError(node, rule);
 
@@ -964,7 +964,7 @@ describe('utils/error-messages', function() {
             })
           });
 
-          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/implementation');
+          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/implementation');
 
           const report = await getLintError(node, rule, { version: '1.0' });
 
@@ -987,7 +987,7 @@ describe('utils/error-messages', function() {
             ]
           });
 
-          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/error-reference');
+          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/error-reference');
 
           const report = await getLintError(node, rule, { version: executionPlatformVersion });
 
@@ -1008,7 +1008,7 @@ describe('utils/error-messages', function() {
             ]
           });
 
-          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/error-reference');
+          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/error-reference');
 
           const report = await getLintError(node, rule, { version: '8.1' });
 
@@ -1029,7 +1029,7 @@ describe('utils/error-messages', function() {
             ]
           });
 
-          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/message-reference');
+          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/message-reference');
 
           const report = await getLintError(node, rule);
 
@@ -1050,7 +1050,7 @@ describe('utils/error-messages', function() {
             ]
           });
 
-          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/signal-reference');
+          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/signal-reference');
 
           const report = await getLintError(node, rule);
 
@@ -1073,7 +1073,7 @@ describe('utils/error-messages', function() {
             })
           });
 
-          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/user-task-form');
+          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/user-task-form');
 
           const report = await getLintError(node, rule);
 
@@ -1111,7 +1111,7 @@ describe('utils/error-messages', function() {
 
           const node = process.get('flowElements')[ 0 ];
 
-          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/user-task-form');
+          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/user-task-form');
 
           const report = await getLintError(node, rule);
 
@@ -1133,7 +1133,7 @@ describe('utils/error-messages', function() {
             ]
           });
 
-          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/sequence-flow-condition');
+          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/sequence-flow-condition');
 
           const reports = await getLintErrors(node, rule);
 
@@ -1163,7 +1163,7 @@ describe('utils/error-messages', function() {
             ]
           });
 
-          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/timer');
+          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/timer');
 
           const report = await getLintError(node, rule, { version: executionPlatformVersion });
 
@@ -1190,7 +1190,7 @@ describe('utils/error-messages', function() {
             ]
           });
 
-          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/timer');
+          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/timer');
 
           const report = await getLintError(node, rule, { version: executionPlatformVersion });
 
@@ -1215,7 +1215,7 @@ describe('utils/error-messages', function() {
             })
           });
 
-          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/implementation');
+          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/implementation');
 
           const report = await getLintError(node, rule, { version: '8.2' });
 
@@ -1240,7 +1240,7 @@ describe('utils/error-messages', function() {
             })
           });
 
-          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/implementation');
+          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/implementation');
 
           const report = await getLintError(node, rule, { version: '8.2' });
 
@@ -1263,7 +1263,7 @@ describe('utils/error-messages', function() {
             })
           });
 
-          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/implementation');
+          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/implementation');
 
           const report = await getLintError(node, rule, { version: '8.2' });
 
@@ -1294,7 +1294,7 @@ describe('utils/error-messages', function() {
             ]
           });
 
-          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/timer');
+          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/timer');
 
           const report = await getLintError(node, rule, { version: executionPlatformVersion });
 
@@ -1321,7 +1321,7 @@ describe('utils/error-messages', function() {
 
           createElement('bpmn:Process', { flowElements: [ node ] });
 
-          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/timer');
+          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/timer');
 
           const report = await getLintError(node, rule, { version: executionPlatformVersion });
 
@@ -1348,7 +1348,7 @@ describe('utils/error-messages', function() {
             ]
           });
 
-          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/timer');
+          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/timer');
 
           const report = await getLintError(node, rule, { version: executionPlatformVersion });
 
@@ -1375,7 +1375,7 @@ describe('utils/error-messages', function() {
             })
           });
 
-          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/task-schedule');
+          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/task-schedule');
 
           const report = await getLintError(node, rule, { version: executionPlatformVersion });
 
@@ -1402,7 +1402,7 @@ describe('utils/error-messages', function() {
             })
           });
 
-          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/task-schedule');
+          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/task-schedule');
 
           const report = await getLintError(node, rule, { version: executionPlatformVersion });
 
@@ -1434,7 +1434,7 @@ describe('utils/error-messages', function() {
             })
           });
 
-          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/duplicate-task-headers');
+          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/duplicate-task-headers');
 
           const report = await getLintError(node, rule);
 
@@ -1462,7 +1462,7 @@ describe('utils/error-messages', function() {
             ]
           });
 
-          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/executable-process');
+          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/executable-process');
 
           const report = await getLintError(node, rule);
 
@@ -1492,7 +1492,7 @@ describe('utils/error-messages', function() {
             ]
           });
 
-          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/no-expression');
+          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-expression');
 
           const report = await getLintError(node, rule, { version: '8.2' });
 
@@ -1517,7 +1517,7 @@ describe('utils/error-messages', function() {
             ]
           });
 
-          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/no-expression');
+          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-expression');
 
           const report = await getLintError(node, rule, { version: '8.1' });
 
@@ -1543,7 +1543,7 @@ describe('utils/error-messages', function() {
             ]
           });
 
-          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/no-expression');
+          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-expression');
 
           const report = await getLintError(node, rule, { version: '8.2' });
 
@@ -1575,7 +1575,7 @@ describe('utils/error-messages', function() {
 
           receiveTask.incoming = [ sequenceFlow ];
 
-          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/event-based-gateway-target');
+          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/event-based-gateway-target');
 
           const report = await getLintError(receiveTask, rule);
 
@@ -1617,7 +1617,7 @@ describe('utils/error-messages', function() {
           ]
         });
 
-        const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/executable-process');
+        const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/executable-process');
 
         const reports = await getLintErrors(node, rule);
 
@@ -1642,7 +1642,7 @@ describe('utils/error-messages', function() {
           // given
           const node = createElementCamundaPlatform('bpmn:Process');
 
-          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/history-time-to-live');
+          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-platform/history-time-to-live');
 
           const report = await getLintError(node, rule, { version: '7.19' });
 

--- a/test/spec/utils/error-messages.spec.js
+++ b/test/spec/utils/error-messages.spec.js
@@ -1279,30 +1279,61 @@ describe('utils/error-messages', function() {
 
       describe('expression value not allowed', function() {
 
-        it('should adjust (time cycle)', async function() {
+        describe('should adjust (time cycle)', async function() {
 
-          // given
-          const executionPlatformVersion = '1.0';
+          it('< Camunda 8.1', async function() {
 
-          const node = createElement('bpmn:BoundaryEvent', {
-            attachedToRef: createElement('bpmn:Task'),
-            cancelActivity: false,
-            eventDefinitions: [
-              createElement('bpmn:TimerEventDefinition', {
-                timeCycle: createElement('bpmn:FormalExpression', { body: 'invalid' })
-              })
-            ]
+            // given
+            const executionPlatformVersion = '1.0';
+
+            const node = createElement('bpmn:BoundaryEvent', {
+              attachedToRef: createElement('bpmn:Task'),
+              cancelActivity: false,
+              eventDefinitions: [
+                createElement('bpmn:TimerEventDefinition', {
+                  timeCycle: createElement('bpmn:FormalExpression', { body: 'invalid' })
+                })
+              ]
+            });
+
+            const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/timer');
+
+            const report = await getLintError(node, rule, { version: executionPlatformVersion });
+
+            // when
+            const errorMessage = getErrorMessage(report, 'Camunda Cloud', executionPlatformVersion);
+
+            // then
+            expect(errorMessage).to.equal('A <Timer Boundary Event> <Time cycle> must be an expression, an ISO 8601 repeating interval, or a cron expression (cron only supported by Camunda Platform 8.1 or newer)');
           });
 
-          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/timer');
 
-          const report = await getLintError(node, rule, { version: executionPlatformVersion });
+          it('=> Camunda 8.1', async function() {
 
-          // when
-          const errorMessage = getErrorMessage(report);
+            // given
+            const executionPlatformVersion = '8.1';
 
-          // then
-          expect(errorMessage).to.equal('A <Timer Boundary Event> <Time cycle> must be an expression, an ISO 8601 repeating interval, or a cron expression (cron requires Camunda Platform 8.1 or newer)');
+            const node = createElement('bpmn:BoundaryEvent', {
+              attachedToRef: createElement('bpmn:Task'),
+              cancelActivity: false,
+              eventDefinitions: [
+                createElement('bpmn:TimerEventDefinition', {
+                  timeCycle: createElement('bpmn:FormalExpression', { body: 'invalid' })
+                })
+              ]
+            });
+
+            const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/timer');
+
+            const report = await getLintError(node, rule, { version: executionPlatformVersion });
+
+            // when
+            const errorMessage = getErrorMessage(report, 'Camunda Cloud', executionPlatformVersion);
+
+            // then
+            expect(errorMessage).to.equal('A <Timer Boundary Event> <Time cycle> must be an expression, an ISO 8601 repeating interval, or a cron expression');
+          });
+
         });
 
 

--- a/test/spec/utils/lint-helper.js
+++ b/test/spec/utils/lint-helper.js
@@ -2,16 +2,26 @@ import { expect } from 'chai';
 
 import Linter from 'bpmnlint/lib/linter';
 
-async function lintNode(node, rule, config = {}) {
+async function lintNode(node, rule, config = {},) {
   const linter = new Linter({
     resolver: {
       resolveRule: () => Promise.resolve(rule)
     }
   });
 
-  return linter.lint(node, {
+  const allReports = await linter.lint(node, {
     rules: { 'ruleName': [ 2, config ] }
   });
+
+  Object.values(allReports).forEach(reports => {
+    reports.forEach(report => {
+      if (config.version) {
+        report.executionPlatformVersion = config.version;
+      }
+    });
+  });
+
+  return allReports;
 }
 
 /**

--- a/test/spec/utils/properties-panel.spec.js
+++ b/test/spec/utils/properties-panel.spec.js
@@ -69,7 +69,7 @@ describe('utils/properties-panel', function() {
           ]
         });
 
-        const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/executable-process');
+        const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/executable-process');
 
         const report = await getLintError(node, rule);
 
@@ -111,7 +111,7 @@ describe('utils/properties-panel', function() {
           ]
         });
 
-        const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/executable-process');
+        const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/executable-process');
 
         const reports = await getLintErrors(node, rule);
 
@@ -132,7 +132,7 @@ describe('utils/properties-panel', function() {
         // given
         const node = createElement('bpmn:BusinessRuleTask');
 
-        const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/implementation');
+        const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/implementation');
 
         const report = await getLintError(node, rule, { version: '1.3' });
 
@@ -151,7 +151,7 @@ describe('utils/properties-panel', function() {
         // given
         const node = createElement('bpmn:ScriptTask');
 
-        const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/implementation');
+        const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/implementation');
 
         const report = await getLintError(node, rule, { version: '8.2' });
 
@@ -174,7 +174,7 @@ describe('utils/properties-panel', function() {
           ]
         });
 
-        const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/error-reference');
+        const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/error-reference');
 
         const report = await getLintError(node, rule, { version: '8.1' });
 
@@ -197,7 +197,7 @@ describe('utils/properties-panel', function() {
           ]
         });
 
-        const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/escalation-reference');
+        const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/escalation-reference');
 
         const report = await getLintError(node, rule);
 
@@ -220,7 +220,7 @@ describe('utils/properties-panel', function() {
           ]
         });
 
-        const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/message-reference');
+        const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/message-reference');
 
         const report = await getLintError(node, rule);
 
@@ -243,7 +243,7 @@ describe('utils/properties-panel', function() {
           ]
         });
 
-        const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/signal-reference');
+        const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/signal-reference');
 
         const report = await getLintError(node, rule);
 
@@ -270,7 +270,7 @@ describe('utils/properties-panel', function() {
           })
         });
 
-        const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/implementation');
+        const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/implementation');
 
         const report = await getLintError(node, rule, { version: '1.3' });
 
@@ -297,7 +297,7 @@ describe('utils/properties-panel', function() {
           })
         });
 
-        const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/implementation');
+        const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/implementation');
 
         const report = await getLintError(node, rule, { version: '1.3' });
 
@@ -324,7 +324,7 @@ describe('utils/properties-panel', function() {
           })
         });
 
-        const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/implementation');
+        const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/implementation');
 
         const report = await getLintError(node, rule, { version: '8.2' });
 
@@ -351,7 +351,7 @@ describe('utils/properties-panel', function() {
           })
         });
 
-        const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/implementation');
+        const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/implementation');
 
         const report = await getLintError(node, rule, { version: '8.2' });
 
@@ -376,7 +376,7 @@ describe('utils/properties-panel', function() {
           ]
         });
 
-        const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/error-reference');
+        const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/error-reference');
 
         const report = await getLintError(node, rule, { version: '8.1' });
 
@@ -401,7 +401,7 @@ describe('utils/properties-panel', function() {
           ]
         });
 
-        const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/no-expression');
+        const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-expression');
 
         const report = await getLintError(node, rule, { version: '8.1' });
 
@@ -426,7 +426,7 @@ describe('utils/properties-panel', function() {
           ]
         });
 
-        const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/no-expression');
+        const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-expression');
 
         const report = await getLintError(node, rule, { version: '8.2' });
 
@@ -451,7 +451,7 @@ describe('utils/properties-panel', function() {
           ]
         });
 
-        const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/escalation-reference');
+        const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/escalation-reference');
 
         const report = await getLintError(node, rule);
 
@@ -476,7 +476,7 @@ describe('utils/properties-panel', function() {
           ]
         });
 
-        const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/no-expression');
+        const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-expression');
 
         const report = await getLintError(node, rule, { version: '8.2' });
 
@@ -501,7 +501,7 @@ describe('utils/properties-panel', function() {
           ]
         });
 
-        const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/message-reference');
+        const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/message-reference');
 
         const report = await getLintError(node, rule);
 
@@ -524,7 +524,7 @@ describe('utils/properties-panel', function() {
             loopCharacteristics: createElement('bpmn:MultiInstanceLoopCharacteristics')
           });
 
-          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/loop-characteristics');
+          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/loop-characteristics');
 
           const report = await getLintError(node, rule);
 
@@ -551,7 +551,7 @@ describe('utils/properties-panel', function() {
             })
           });
 
-          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/loop-characteristics');
+          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/loop-characteristics');
 
           const report = await getLintError(node, rule);
 
@@ -583,7 +583,7 @@ describe('utils/properties-panel', function() {
           })
         });
 
-        const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/loop-characteristics');
+        const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/loop-characteristics');
 
         const report = await getLintError(node, rule);
 
@@ -613,7 +613,7 @@ describe('utils/properties-panel', function() {
           })
         });
 
-        const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/loop-characteristics');
+        const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/loop-characteristics');
 
         const report = await getLintError(node, rule);
 
@@ -634,7 +634,7 @@ describe('utils/properties-panel', function() {
           // given
           const node = createElement('bpmn:CallActivity');
 
-          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/called-element');
+          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/called-element');
 
           const report = await getLintError(node, rule);
 
@@ -659,7 +659,7 @@ describe('utils/properties-panel', function() {
             })
           });
 
-          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/called-element');
+          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/called-element');
 
           const report = await getLintError(node, rule);
 
@@ -682,7 +682,7 @@ describe('utils/properties-panel', function() {
           // given
           const node = createElement('bpmn:ServiceTask');
 
-          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/implementation');
+          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/implementation');
 
           const report = await getLintError(node, rule, { version: '1.0' });
 
@@ -707,7 +707,7 @@ describe('utils/properties-panel', function() {
             })
           });
 
-          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/implementation');
+          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/implementation');
 
           const report = await getLintError(node, rule, { version: '1.0' });
 
@@ -732,7 +732,7 @@ describe('utils/properties-panel', function() {
             messageRef: createElement('bpmn:Message')
           });
 
-          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/subscription');
+          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/subscription');
 
           const report = await getLintError(node, rule);
 
@@ -759,7 +759,7 @@ describe('utils/properties-panel', function() {
             })
           });
 
-          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/subscription');
+          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/subscription');
 
           const report = await getLintError(node, rule);
 
@@ -786,7 +786,7 @@ describe('utils/properties-panel', function() {
           })
         });
 
-        const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/user-task-form');
+        const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/user-task-form');
 
         const report = await getLintError(node, rule);
 
@@ -826,7 +826,7 @@ describe('utils/properties-panel', function() {
 
         const node = process.get('flowElements')[ 0 ];
 
-        const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/user-task-form');
+        const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/user-task-form');
 
         const report = await getLintError(node, rule);
 
@@ -857,7 +857,7 @@ describe('utils/properties-panel', function() {
           })
         });
 
-        const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/duplicate-task-headers');
+        const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/duplicate-task-headers');
 
         const report = await getLintError(node, rule);
 
@@ -891,7 +891,7 @@ describe('utils/properties-panel', function() {
           })
         });
 
-        const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/no-zeebe-properties');
+        const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-zeebe-properties');
 
         const report = await getLintError(node, rule);
 
@@ -922,7 +922,7 @@ describe('utils/properties-panel', function() {
           ]
         });
 
-        const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/sequence-flow-condition');
+        const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/sequence-flow-condition');
 
         const reports = await getLintErrors(node, rule);
 
@@ -951,7 +951,7 @@ describe('utils/properties-panel', function() {
             ]
           });
 
-          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/timer');
+          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/timer');
 
           const report = await getLintError(node, rule, { version: '1.0' });
 
@@ -976,7 +976,7 @@ describe('utils/properties-panel', function() {
             ]
           });
 
-          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/timer');
+          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/timer');
 
           const report = await getLintError(node, rule, { version: '1.0' });
 
@@ -1003,7 +1003,7 @@ describe('utils/properties-panel', function() {
             ]
           });
 
-          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/timer');
+          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/timer');
 
           const report = await getLintError(node, rule, { version: '1.0' });
 
@@ -1030,7 +1030,7 @@ describe('utils/properties-panel', function() {
 
           createElement('bpmn:Process', { flowElements: [ node ] });
 
-          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/timer');
+          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/timer');
 
           const report = await getLintError(node, rule, { version: '1.0' });
 
@@ -1057,7 +1057,7 @@ describe('utils/properties-panel', function() {
             ]
           });
 
-          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/timer');
+          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/timer');
 
           const report = await getLintError(node, rule, { version: '1.0' });
 
@@ -1080,13 +1080,13 @@ describe('utils/properties-panel', function() {
             eventDefinitions: [
               createElement('bpmn:TimerEventDefinition', {
                 timeCycle: createElement('bpmn:FormalExpression', {
-                  body: 'INVALID'
+                  body: '0 0 9-17 * * MON-FRI'
                 })
               })
             ]
           });
 
-          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/timer');
+          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/timer');
 
           const report = await getLintError(node, rule, { version: '1.0' });
 
@@ -1115,7 +1115,7 @@ describe('utils/properties-panel', function() {
 
           createElement('bpmn:Process', { flowElements: [ node ] });
 
-          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/timer');
+          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/timer');
 
           const report = await getLintError(node, rule, { version: '1.0' });
 
@@ -1144,7 +1144,7 @@ describe('utils/properties-panel', function() {
             ]
           });
 
-          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/timer');
+          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/timer');
 
           const report = await getLintError(node, rule, { version: '1.0' });
 
@@ -1162,7 +1162,7 @@ describe('utils/properties-panel', function() {
 
       describe('FEEL', async function() {
 
-        const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/feel');
+        const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/feel');
 
         const INVALID_FEEL = '===';
 
@@ -1354,7 +1354,7 @@ describe('utils/properties-panel', function() {
           })
         });
 
-        const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/no-candidate-users');
+        const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-candidate-users');
 
         const report = await getLintError(node, rule);
 
@@ -1383,7 +1383,7 @@ describe('utils/properties-panel', function() {
             })
           });
 
-          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/task-schedule');
+          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/task-schedule');
 
           const report = await getLintError(node, rule);
 
@@ -1410,7 +1410,7 @@ describe('utils/properties-panel', function() {
             })
           });
 
-          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/task-schedule');
+          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/task-schedule');
 
           const report = await getLintError(node, rule);
 
@@ -1437,7 +1437,7 @@ describe('utils/properties-panel', function() {
             })
           });
 
-          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/no-task-schedule');
+          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-task-schedule');
 
           const report = await getLintError(node, rule);
 
@@ -1464,7 +1464,7 @@ describe('utils/properties-panel', function() {
             })
           });
 
-          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/no-task-schedule');
+          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-task-schedule');
 
           const report = await getLintError(node, rule);
 
@@ -1547,7 +1547,7 @@ describe('utils/properties-panel', function() {
         // given
         const node = createElementCamundaPlatform('bpmn:Process', { isExecutable: true });
 
-        const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/history-time-to-live');
+        const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-platform/history-time-to-live');
 
         const report = await getLintError(node, rule, { platform: 'camunda-platform', version: '7.19' });
 

--- a/test/spec/utils/properties-panel.spec.js
+++ b/test/spec/utils/properties-panel.spec.js
@@ -1479,25 +1479,6 @@ describe('utils/properties-panel', function() {
 
       });
 
-
-      it('Process - History TTL', async function() {
-
-        // given
-        const node = createElement('bpmn:Process');
-
-        const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/history-time-to-live');
-
-        const report = await getLintError(node, rule);
-
-        // when
-        const entryIds = getEntryIds(report);
-
-        // then
-        expect(entryIds).to.eql([ 'historyTimeToLive' ]);
-
-        expectErrorMessage(entryIds[ 0 ], 'Time to live must be defined.', report);
-      });
-
     });
 
 


### PR DESCRIPTION
* migrate to bpmnlint@9 and bpmnlint-plugin-camunda-compat@2
* show version hint for time cycle expression only if version older

![brave_ohIEp2cJSK](https://github.com/camunda/linting/assets/7633572/6d3d5fbb-6e4e-4dc8-9cbc-d5d2a3316bc1)

---

Requires https://github.com/bpmn-io/bpmnlint/pull/113
Requires https://github.com/camunda/bpmnlint-plugin-camunda-compat/pull/108
Related to https://github.com/camunda/camunda-modeler/issues/3709