### PR TITLE
Scale annotations

### DIFF
--- a/lib/modeler/LintingAnnotations.js
+++ b/lib/modeler/LintingAnnotations.js
@@ -54,8 +54,8 @@ export default class LintingAnnotations {
       const overlayId = this._overlays.add(element, 'linting', {
         position,
         html,
-        show: {
-          minZoom: 0.5
+        scale: {
+          min: .7
         }
       });
 


### PR DESCRIPTION
Related to https://github.com/camunda/modeler-design/issues/184 we want to ensure error annotations cannot hide, but remain visible on all zoom levels.

![capture VSzBOK_optimized](https://github.com/camunda/linting/assets/58601/52ed4cde-e58e-430b-9e1a-d737d8f9ddc2)
