### PR TITLE
fix: use stable annotation size

### DIFF
--- a/assets/linting.css
+++ b/assets/linting.css
@@ -7,23 +7,22 @@
   --cl-color-success: #52b415;
 }
 
+.cl-icon, .cl-icon * {
+  box-sizing: border-box;
+}
+
 .cl-icon {
   --icon-color: white;
   --icon-bg-color: #333;
   background: var(--icon-bg-color);
   color: var(--icon-color);
   border-radius: 100%;
-  height: .75em;
-  width: .75em;
+  height: 20px;
+  width: 20px;
   border: solid 4px var(--icon-bg-color);
   display: flex;
   align-items: center;
   justify-content: center;
-  box-sizing: content-box;
-}
-
-.cl-icon * {
-  box-sizing: content-box;
 }
 
 .cl-icon-error {

--- a/lib/modeler/LintingAnnotations.js
+++ b/lib/modeler/LintingAnnotations.js
@@ -90,7 +90,7 @@ function getAnnotationPosition(element) {
   }
 
   return {
-    bottom: 13,
+    bottom: 14,
     left: -6
   };
 }


### PR DESCRIPTION
Required by https://github.com/camunda/camunda-modeler/issues/3762

----

As stable as it gets :see_no_evil: 

![capture rwzOin_optimized](https://github.com/camunda/linting/assets/58601/18ee6446-5bee-4256-b139-cfe4b5692e70)
