### PR TITLE
fix(Linter): correctly parse C7 XML 

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ const modeler = new Modeler({
 
 // configure to be used with desktop or web modeler
 const linter = new Linter({
-  modeler: 'web',
-  type: 'cloud' // cloud or platform diagrams, defaults to `cloud`
+  modeler: 'web', // `desktop` or `web` modeler, defaults to `desktop`
+  type: 'cloud' // `cloud` or `platform` diagrams, defaults to `cloud`
 });
 
 // lint by passing definitions

--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ const modeler = new Modeler({
 
 // configure to be used with desktop or web modeler
 const linter = new Linter({
-  modeler: 'web'
+  modeler: 'web',
+  type: 'cloud' // cloud or platform diagrams, defaults to `cloud`
 });
 
 // lint by passing definitions

--- a/lib/Linter.js
+++ b/lib/Linter.js
@@ -20,6 +20,12 @@ import { toSemverMinor } from './utils/version';
 
 import { getDocumentationUrl } from './utils/documentation';
 
+/**
+ * @param {Object} [options]
+ * @param {string} [options.modeler='desktop']
+ * @param {Array<Object>} [options.plugins=[]]
+ * @param {string} [options.type='cloud']
+ */
 export class Linter {
   constructor(options = {}) {
     const {

--- a/lib/Linter.js
+++ b/lib/Linter.js
@@ -11,6 +11,7 @@ import { resolver as RulesResolver } from './compiled-config';
 
 import modelerModdle from 'modeler-moddle/resources/modeler.json';
 import zeebeModdle from 'zeebe-bpmn-moddle/resources/zeebe.json';
+import camundaModdle from 'camunda-bpmn-moddle/resources/camunda.json';
 
 import { getErrorMessage } from './utils/error-messages';
 import { getEntryIds } from './utils/properties-panel';
@@ -19,17 +20,23 @@ import { toSemverMinor } from './utils/version';
 
 import { getDocumentationUrl } from './utils/documentation';
 
-const moddle = new BpmnModdle({
-  modeler: modelerModdle,
-  zeebe: zeebeModdle
-});
-
 export class Linter {
   constructor(options = {}) {
     const {
       modeler = 'desktop',
-      plugins = []
+      plugins = [],
+      type = 'cloud'
     } = options;
+
+    this._moddle = new BpmnModdle({
+      modeler: modelerModdle,
+
+      // Zeebe and Camunda moddle extensions can't be used together
+      // cf. https://github.com/camunda/camunda-modeler/issues/3853#issuecomment-1731145100
+      ...(type === 'cloud' ?
+        { zeebe: zeebeModdle } :
+        { camunda: camundaModdle })
+    });
 
     this._modeler = modeler;
     this._plugins = plugins;
@@ -39,7 +46,7 @@ export class Linter {
     let rootElement;
 
     if (isString(contents)) {
-      ({ rootElement } = await moddle.fromXML(contents));
+      ({ rootElement } = await this._moddle.fromXML(contents));
     } else {
       rootElement = contents;
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "bpmnlint": "^9.2.0",
         "bpmnlint-plugin-camunda-compat": "^2.7.1",
         "bpmnlint-utils": "^1.0.2",
+        "camunda-bpmn-moddle": "^7.0.1",
         "clsx": "^2.0.0",
         "min-dash": "^4.0.0",
         "min-dom": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "bpmnlint": "^9.2.0",
     "bpmnlint-plugin-camunda-compat": "^2.7.1",
     "bpmnlint-utils": "^1.0.2",
+    "camunda-bpmn-moddle": "^7.0.1",
     "clsx": "^2.0.0",
     "min-dash": "^4.0.0",
     "min-dom": "^4.1.0",

--- a/test/spec/Linter.spec.js
+++ b/test/spec/Linter.spec.js
@@ -151,6 +151,10 @@ describe('Linter', function() {
 
     describe('camunda-cloud', function() {
 
+      beforeEach(function() {
+        linter = new Linter({ type: 'cloud' });
+      });
+
       const versions = [
         [ '1.0', camundaCloud10XML, camundaCloud10ErrorsXML ],
         [ '1.1', camundaCloud11XML, camundaCloud11ErrorsXML ],
@@ -165,7 +169,7 @@ describe('Linter', function() {
 
         describe(`Camunda Cloud ${ version }`, function() {
 
-          describe('no errors', function() {
+          describe('from moddle', function() {
 
             it('should not have errors', async function() {
 
@@ -179,10 +183,6 @@ describe('Linter', function() {
               expect(reports).to.be.empty;
             });
 
-          });
-
-
-          describe('errors', function() {
 
             it('should have errors', async function() {
 
@@ -198,6 +198,30 @@ describe('Linter', function() {
 
           });
 
+
+          describe('from XML', function() {
+
+            it('should not have errors', async function() {
+
+              // when
+              const reports = await linter.lint(xml);
+
+              // then
+              expect(reports).to.be.empty;
+            });
+
+
+            it('should have errors', async function() {
+
+              // when
+              const reports = await linter.lint(errorsXML);
+
+              // then
+              expect(reports).not.to.be.empty;
+            });
+
+          });
+
         });
 
       });
@@ -206,6 +230,10 @@ describe('Linter', function() {
 
 
     describe('camunda-platform', function() {
+
+      beforeEach(function() {
+        linter = new Linter({ type: 'platform' });
+      });
 
       const versions = [
         [ '7.19', camundaPlatform719XML, camundaPlatform719ErrorsXML ],
@@ -229,29 +257,57 @@ describe('Linter', function() {
 
         describe(`Camunda Platform ${ version }`, function() {
 
-          it('should not have errors', async function() {
+          describe('from moddle', function() {
 
-            // given
-            const { root } = await createModdleCamundaPlatform(xml);
+            it('should not have errors', async function() {
 
-            // when
-            const reports = await linter.lint(root);
+              // given
+              const { root } = await createModdleCamundaPlatform(xml);
 
-            // then
-            expect(reports).to.be.empty;
+              // when
+              const reports = await linter.lint(root);
+
+              // then
+              expect(reports).to.be.empty;
+            });
+
+
+            it('should have errors', async function() {
+
+              // given
+              const { root } = await createModdleCamundaPlatform(errorsXML);
+
+              // when
+              const reports = await linter.lint(root);
+
+              // then
+              expect(reports).not.to.be.empty;
+            });
+
           });
 
 
-          it('should have errors', async function() {
+          describe('from xml', function() {
 
-            // given
-            const { root } = await createModdleCamundaPlatform(errorsXML);
+            it('should not have errors', async function() {
 
-            // when
-            const reports = await linter.lint(root);
+              // when
+              const reports = await linter.lint(xml);
 
-            // then
-            expect(reports).not.to.be.empty;
+              // then
+              expect(reports).to.be.empty;
+            });
+
+
+            it('should have errors', async function() {
+
+              // when
+              const reports = await linter.lint(errorsXML);
+
+              // then
+              expect(reports).not.to.be.empty;
+            });
+
           });
 
         });


### PR DESCRIPTION
this requires a new configuration option `type = platform` to be set

Integration into the modeler looks like this: https://github.com/camunda/camunda-modeler/pull/3878

related to https://github.com/camunda/camunda-modeler/issues/3853
