### PR TITLE
Prepare v3.11 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to [@camunda/linting](https://github.com/camunda/linting) ar
 
 ___Note:__ Yet to be released changes appear here._
 
+## 3.11.0
+
+* `FEAT`: allow `formKey` and `formId` starting with v8.3 when linting start event forms ([#149](https://github.com/camunda/bpmnlint-plugin-camunda-compat/pull/149))
+* `FIX`: differentiate between desktop and web modeler when linting user task forms ([#149](https://github.com/camunda/bpmnlint-plugin-camunda-compat/pull/149))
+* `DEPS`: update to `bpmnlint-plugin-camunda-compat@2.12.0`
+
 ## 3.10.0
 
 * `FEAT`: add 8.4 and 7.21 config ([#143](https://github.com/camunda/bpmnlint-plugin-camunda-compat/pull/143))

--- a/lib/compiled-config.js
+++ b/lib/compiled-config.js
@@ -57,7 +57,7 @@ const rules = {
   "camunda-compat/secrets": "error",
   "camunda-compat/sequence-flow-condition": "error",
   "camunda-compat/signal-reference": "error",
-  "camunda-compat/start-form": "error",
+  "camunda-compat/start-event-form": "error",
   "camunda-compat/subscription": "error",
   "camunda-compat/task-schedule": "error",
   "camunda-compat/timer": "error",
@@ -189,9 +189,9 @@ import rule_27 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/signal-r
 
 cache['bpmnlint-plugin-camunda-compat/signal-reference'] = rule_27;
 
-import rule_28 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/start-form';
+import rule_28 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/start-event-form';
 
-cache['bpmnlint-plugin-camunda-compat/start-form'] = rule_28;
+cache['bpmnlint-plugin-camunda-compat/start-event-form'] = rule_28;
 
 import rule_29 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/subscription';
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@bpmn-io/diagram-js-ui": "^0.2.2",
         "bpmn-moddle": "^8.0.0",
         "bpmnlint": "^9.2.0",
-        "bpmnlint-plugin-camunda-compat": "^2.11.1",
+        "bpmnlint-plugin-camunda-compat": "^2.12.0",
         "bpmnlint-utils": "^1.0.2",
         "camunda-bpmn-moddle": "^7.0.1",
         "clsx": "^2.0.0",
@@ -1320,9 +1320,9 @@
       }
     },
     "node_modules/bpmnlint-plugin-camunda-compat": {
-      "version": "2.11.1",
-      "resolved": "https://registry.npmjs.org/bpmnlint-plugin-camunda-compat/-/bpmnlint-plugin-camunda-compat-2.11.1.tgz",
-      "integrity": "sha512-3t48yy5UC0730W7kQ45w/dxQ8p8CafMb5zpGUSp64NAXFZg4YjGEsMMup93uSdiGXbpXJsmLL02J6sJRNvbWMg==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/bpmnlint-plugin-camunda-compat/-/bpmnlint-plugin-camunda-compat-2.12.0.tgz",
+      "integrity": "sha512-di9+QPUO0VdaKiZuRMdHwXBKTw906GjQWK024x3w+zQks5LEHZqdNZsLxJ2rr4s4Q+WD9vQ4guUsnb5stPENag==",
       "dependencies": {
         "@bpmn-io/feel-lint": "^1.0.0",
         "@bpmn-io/moddle-utils": "^0.2.1",
@@ -7190,9 +7190,9 @@
       }
     },
     "bpmnlint-plugin-camunda-compat": {
-      "version": "2.11.1",
-      "resolved": "https://registry.npmjs.org/bpmnlint-plugin-camunda-compat/-/bpmnlint-plugin-camunda-compat-2.11.1.tgz",
-      "integrity": "sha512-3t48yy5UC0730W7kQ45w/dxQ8p8CafMb5zpGUSp64NAXFZg4YjGEsMMup93uSdiGXbpXJsmLL02J6sJRNvbWMg==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/bpmnlint-plugin-camunda-compat/-/bpmnlint-plugin-camunda-compat-2.12.0.tgz",
+      "integrity": "sha512-di9+QPUO0VdaKiZuRMdHwXBKTw906GjQWK024x3w+zQks5LEHZqdNZsLxJ2rr4s4Q+WD9vQ4guUsnb5stPENag==",
       "requires": {
         "@bpmn-io/feel-lint": "^1.0.0",
         "@bpmn-io/moddle-utils": "^0.2.1",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@bpmn-io/diagram-js-ui": "^0.2.2",
     "bpmn-moddle": "^8.0.0",
     "bpmnlint": "^9.2.0",
-    "bpmnlint-plugin-camunda-compat": "^2.11.1",
+    "bpmnlint-plugin-camunda-compat": "^2.12.0",
     "bpmnlint-utils": "^1.0.2",
     "camunda-bpmn-moddle": "^7.0.1",
     "clsx": "^2.0.0",

--- a/test/spec/utils/error-messages.spec.js
+++ b/test/spec/utils/error-messages.spec.js
@@ -414,7 +414,7 @@ describe('utils/error-messages', function() {
             })
           });
 
-          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/start-form');
+          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/start-event-form');
 
           const report = await getLintError(node, rule, { version: executionPlatformVersion });
 

--- a/test/spec/utils/properties-panel.spec.js
+++ b/test/spec/utils/properties-panel.spec.js
@@ -774,7 +774,7 @@ describe('utils/properties-panel', function() {
       });
 
 
-      it('start-form - Form', async function() {
+      it('start-event-form - Form', async function() {
 
         // given
         const node = createElement('bpmn:StartEvent', {
@@ -785,7 +785,7 @@ describe('utils/properties-panel', function() {
           })
         });
 
-        const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/start-form');
+        const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/start-event-form');
 
         const report = await getLintError(node, rule, { version: '1.0' });
 


### PR DESCRIPTION
# Changes

* `FEAT`: allow `formKey` and `formId` starting with v8.3 when linting start event forms ([#149](https://github.com/camunda/bpmnlint-plugin-camunda-compat/pull/149))
* `FIX`: differentiate between desktop and web modeler when linting user task forms ([#149](https://github.com/camunda/bpmnlint-plugin-camunda-compat/pull/149))
* `DEPS`: update to `bpmnlint-plugin-camunda-compat@2.12.0`

---

Related to https://github.com/camunda/bpmnlint-plugin-camunda-compat/issues/147