### PR TITLE
feat: enable `bpmnlint/no-bpmndi` for all profiles

### DIFF
--- a/lib/Linter.js
+++ b/lib/Linter.js
@@ -20,6 +20,8 @@ import { toSemverMinor } from './utils/version';
 
 import { getDocumentationUrl } from './utils/documentation';
 
+import defaultPlugins from './plugins';
+
 const NoopResolver = new StaticResolver({});
 
 /**
@@ -47,7 +49,7 @@ export class Linter {
     });
 
     this._modeler = modeler;
-    this._plugins = plugins;
+    this._plugins = [ ...defaultPlugins, ...plugins ];
   }
 
   async lint(contents) {

--- a/lib/plugins/bpmnLintPlugin.js
+++ b/lib/plugins/bpmnLintPlugin.js
@@ -1,0 +1,11 @@
+import StaticResolver from 'bpmnlint/lib/resolver/static-resolver';
+import rule from 'bpmnlint/rules/no-bpmndi';
+
+export default {
+  config: {
+    rules: {
+      'bpmnlint/no-bpmndi': 'warn'
+    }
+  },
+  resolver: new StaticResolver({ 'rule:bpmnlint/no-bpmndi': rule })
+};

--- a/lib/plugins/index.js
+++ b/lib/plugins/index.js
@@ -1,0 +1,5 @@
+import bpmnLintPlugin from './bpmnLintPlugin';
+
+export default [
+  bpmnLintPlugin
+];

--- a/test/spec/Linter.spec.js
+++ b/test/spec/Linter.spec.js
@@ -10,6 +10,7 @@ import {
 import { Linter } from '../..';
 
 import simpleXML from './simple.bpmn';
+import missingDiXML from './simple-no-di.bpmn';
 import noExecutionPlatformXML from './no-execution-platform.bpmn';
 import camundaCloud10XML from './camunda-cloud-1-0.bpmn';
 import camundaCloud10ErrorsXML from './camunda-cloud-1-0-errors.bpmn';
@@ -386,11 +387,30 @@ describe('Linter', function() {
     const BazPlugin = {
       config: {
         rules: {
-          'foo/superfluous-gateway': 'off'
+          'foo/superfluous-gateway': 'off',
+          'bpmnlint/no-bpmndi': 'off'
         }
       },
       resolver: new StaticResolver({})
     };
+
+
+    it('should have default plugins', async function() {
+
+      // given
+      const linter = new Linter();
+
+      const { root } = await createModdle(missingDiXML);
+
+      // when
+      const reports = await linter.lint(root);
+
+      // then
+      expect(reports).to.have.length(2);
+
+      expect(reports.find(({ message }) => message === 'Element is missing bpmndi')).to.exist;
+
+    });
 
 
     it('should add rules (rules)', async function() {
@@ -447,7 +467,7 @@ describe('Linter', function() {
         ]
       });
 
-      const { root } = await createModdle(simpleXML);
+      const { root } = await createModdle(missingDiXML);
 
       // when
       const reports = await linter.lint(root);
@@ -456,6 +476,7 @@ describe('Linter', function() {
       expect(reports).to.have.length(2);
 
       expect(reports.find(({ message }) => message === 'Gateway is superfluous. It only has one source and target.')).not.to.exist;
+      expect(reports.find(({ message }) => message === 'Element is missing bpmndi')).not.to.exist;
       expect(reports.find(({ message }) => message === 'Element is an implicit end')).to.exist;
     });
 

--- a/test/spec/simple-no-di.bpmn
+++ b/test/spec/simple-no-di.bpmn
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0bmzwre" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.13.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.0.0">
+  <bpmn:process id="Process_0l9kcp2" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>SequenceFlow_1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:exclusiveGateway id="ExclusiveGateway_1">
+      <bpmn:incoming>SequenceFlow_1</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_2</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="SequenceFlow_1" sourceRef="StartEvent_1" targetRef="ExclusiveGateway_1" />
+    <bpmn:serviceTask id="ServiceTask_1">
+      <bpmn:incoming>SequenceFlow_2</bpmn:incoming>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="SequenceFlow_2" sourceRef="ExclusiveGateway_1" targetRef="ServiceTask_1" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_0l9kcp2">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1gm8bch_di" bpmnElement="ExclusiveGateway_1" isMarkerVisible="true">
+        <dc:Bounds x="265" y="92" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1y1c2wn_di" bpmnElement="ServiceTask_1">
+        <dc:Bounds x="370" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0k4t2aq_di" bpmnElement="SequenceFlow_1">
+        <di:waypoint x="215" y="117" />
+        <di:waypoint x="265" y="117" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>


### PR DESCRIPTION
related to https://github.com/camunda/camunda-modeler/issues/4277

I decided to add it in `@camunda/linting` directly instead of adding the plugin to the camunda modeler, so the linting between desktop and web modeler stays consistent