### PR TITLE
Support `zeebe:VersionTag` and `zeebe:versionTag` errors

### DIFF
--- a/lib/compiled-config.js
+++ b/lib/compiled-config.js
@@ -59,6 +59,7 @@ const rules = {
   "camunda-compat/no-signal-event-sub-process": "error",
   "camunda-compat/no-task-schedule": "error",
   "camunda-compat/no-template": "error",
+  "camunda-compat/no-version-tag": "error",
   "camunda-compat/no-zeebe-properties": "error",
   "camunda-compat/no-zeebe-user-task": "error",
   "camunda-compat/priority-definition": "error",
@@ -207,54 +208,58 @@ import rule_29 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-templ
 
 cache['bpmnlint-plugin-camunda-compat/no-template'] = rule_29;
 
-import rule_30 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-zeebe-properties';
+import rule_30 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-version-tag';
 
-cache['bpmnlint-plugin-camunda-compat/no-zeebe-properties'] = rule_30;
+cache['bpmnlint-plugin-camunda-compat/no-version-tag'] = rule_30;
 
-import rule_31 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-zeebe-user-task';
+import rule_31 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-zeebe-properties';
 
-cache['bpmnlint-plugin-camunda-compat/no-zeebe-user-task'] = rule_31;
+cache['bpmnlint-plugin-camunda-compat/no-zeebe-properties'] = rule_31;
 
-import rule_32 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/priority-definition';
+import rule_32 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-zeebe-user-task';
 
-cache['bpmnlint-plugin-camunda-compat/priority-definition'] = rule_32;
+cache['bpmnlint-plugin-camunda-compat/no-zeebe-user-task'] = rule_32;
 
-import rule_33 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/secrets';
+import rule_33 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/priority-definition';
 
-cache['bpmnlint-plugin-camunda-compat/secrets'] = rule_33;
+cache['bpmnlint-plugin-camunda-compat/priority-definition'] = rule_33;
 
-import rule_34 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/sequence-flow-condition';
+import rule_34 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/secrets';
 
-cache['bpmnlint-plugin-camunda-compat/sequence-flow-condition'] = rule_34;
+cache['bpmnlint-plugin-camunda-compat/secrets'] = rule_34;
 
-import rule_35 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/signal-reference';
+import rule_35 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/sequence-flow-condition';
 
-cache['bpmnlint-plugin-camunda-compat/signal-reference'] = rule_35;
+cache['bpmnlint-plugin-camunda-compat/sequence-flow-condition'] = rule_35;
 
-import rule_36 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/start-event-form';
+import rule_36 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/signal-reference';
 
-cache['bpmnlint-plugin-camunda-compat/start-event-form'] = rule_36;
+cache['bpmnlint-plugin-camunda-compat/signal-reference'] = rule_36;
 
-import rule_37 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/subscription';
+import rule_37 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/start-event-form';
 
-cache['bpmnlint-plugin-camunda-compat/subscription'] = rule_37;
+cache['bpmnlint-plugin-camunda-compat/start-event-form'] = rule_37;
 
-import rule_38 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/task-schedule';
+import rule_38 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/subscription';
 
-cache['bpmnlint-plugin-camunda-compat/task-schedule'] = rule_38;
+cache['bpmnlint-plugin-camunda-compat/subscription'] = rule_38;
 
-import rule_39 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/timer';
+import rule_39 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/task-schedule';
 
-cache['bpmnlint-plugin-camunda-compat/timer'] = rule_39;
+cache['bpmnlint-plugin-camunda-compat/task-schedule'] = rule_39;
 
-import rule_40 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/user-task-definition';
+import rule_40 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/timer';
 
-cache['bpmnlint-plugin-camunda-compat/user-task-definition'] = rule_40;
+cache['bpmnlint-plugin-camunda-compat/timer'] = rule_40;
 
-import rule_41 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/user-task-form';
+import rule_41 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/user-task-definition';
 
-cache['bpmnlint-plugin-camunda-compat/user-task-form'] = rule_41;
+cache['bpmnlint-plugin-camunda-compat/user-task-definition'] = rule_41;
 
-import rule_42 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/wait-for-completion';
+import rule_42 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/user-task-form';
 
-cache['bpmnlint-plugin-camunda-compat/wait-for-completion'] = rule_42;
+cache['bpmnlint-plugin-camunda-compat/user-task-form'] = rule_42;
+
+import rule_43 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/wait-for-completion';
+
+cache['bpmnlint-plugin-camunda-compat/wait-for-completion'] = rule_43;

--- a/lib/utils/error-messages.js
+++ b/lib/utils/error-messages.js
@@ -336,6 +336,10 @@ function getExtensionElementNotAllowedErrorMessage(report, executionPlatform, ex
     return getSupportedMessage(`${ getIndefiniteArticle(typeString) } <${ typeString }> with <Execution listeners>`, executionPlatform, executionPlatformVersion, allowedVersion);
   }
 
+  if (is(node, 'bpmn:Process') && is(extensionElement, 'zeebe:VersionTag')) {
+    return getSupportedMessage(`${ getIndefiniteArticle(typeString) } <${ typeString }> with <Version tag>`, executionPlatform, executionPlatformVersion, allowedVersion);
+  }
+
   return message;
 }
 
@@ -438,7 +442,7 @@ function getPropertyNotAllowedErrorMessage(report, executionPlatform, executionP
   }
 
   if (is(node, 'zeebe:AssignmentDefinition') && property === 'candidateUsers') {
-    return getSupportedMessage(`${ getIndefiniteArticle(typeString) } <${ typeString }> with defined <Candidate users>`, executionPlatform, executionPlatformVersion, allowedVersion);
+    return getSupportedMessage(`${ getIndefiniteArticle(typeString) } <${ typeString }> with <Candidate users>`, executionPlatform, executionPlatformVersion, allowedVersion);
   }
 
   if (is(node, 'bpmn:SequenceFlow') && property === 'conditionExpression') {
@@ -451,6 +455,14 @@ function getPropertyNotAllowedErrorMessage(report, executionPlatform, executionP
 
   if (is(node, 'zeebe:FormDefinition') && property === 'formId') {
     return getSupportedMessage(`${ getIndefiniteArticle(typeString) } <${ typeString }> with <Form type: Camunda form (linked)>`, executionPlatform, executionPlatformVersion, allowedVersion);
+  }
+
+  if (isAny(node, [
+    'zeebe:CalledDecision',
+    'zeebe:CalledElement',
+    'zeebe:FormDefinition'
+  ]) && property === 'versionTag') {
+    return getSupportedMessage(`${ getIndefiniteArticle(typeString) } <${ typeString }> with <Version tag>`, executionPlatform, executionPlatformVersion, allowedVersion);
   }
 
   return message;
@@ -723,7 +735,15 @@ function getPropertyValueNotAllowedErrorMessage(report, executionPlatform, execu
     'zeebe:CalledElement',
     'zeebe:FormDefinition'
   ]) && property === 'bindingType') {
-    return getSupportedMessage(`${ getIndefiniteArticle(typeString) } <${ typeString }> with <Binding: deployment>`, executionPlatform, executionPlatformVersion, allowedVersion);
+    const bindingType = node.get('bindingType');
+
+    let bindingTypeString = bindingType;
+
+    if (bindingType === 'versionTag') {
+      bindingTypeString = 'version tag';
+    }
+
+    return getSupportedMessage(`${ getIndefiniteArticle(typeString) } <${ typeString }> with <Binding: ${ bindingTypeString }>`, executionPlatform, executionPlatformVersion, allowedVersion);
   }
 
   return message;

--- a/lib/utils/properties-panel.js
+++ b/lib/utils/properties-panel.js
@@ -344,6 +344,10 @@ export function getEntryIds(report) {
     return [ 'bindingType' ];
   }
 
+  if (isPropertyError(data, 'versionTag') || isExtensionElementNotAllowedError(data, 'zeebe:VersionTag')) {
+    return [ 'versionTag' ];
+  }
+
   return [];
 }
 
@@ -574,6 +578,10 @@ export function getErrorMessage(id, report) {
   }
 
   if (id === 'bindingType') {
+    return getNotSupportedMessage('', allowedVersion);
+  }
+
+  if (id === 'versionTag') {
     return getNotSupportedMessage('', allowedVersion);
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@bpmn-io/diagram-js-ui": "^0.2.3",
         "bpmn-moddle": "^9.0.1",
         "bpmnlint": "^10.3.0",
-        "bpmnlint-plugin-camunda-compat": "^2.24.0",
+        "bpmnlint-plugin-camunda-compat": "^2.25.0",
         "bpmnlint-utils": "^1.0.2",
         "camunda-bpmn-moddle": "^7.0.1",
         "clsx": "^2.0.0",
@@ -20,13 +20,13 @@
         "min-dom": "^5.1.1",
         "modeler-moddle": "^0.2.0",
         "semver-compare": "^1.0.0",
-        "zeebe-bpmn-moddle": "^1.5.1"
+        "zeebe-bpmn-moddle": "^1.6.0"
       },
       "devDependencies": {
-        "bpmn-js": "^17.9.0",
-        "bpmn-js-element-templates": "^1.16.0",
-        "bpmn-js-properties-panel": "^5.22.0",
-        "camunda-bpmn-js-behaviors": "^1.5.0",
+        "bpmn-js": "^17.9.2",
+        "bpmn-js-element-templates": "^2.2.0",
+        "bpmn-js-properties-panel": "^5.23.0",
+        "camunda-bpmn-js-behaviors": "^1.6.1",
         "chai": "^4.4.1",
         "cross-env": "^7.0.3",
         "eslint": "^8.57.0",
@@ -1412,9 +1412,9 @@
       }
     },
     "node_modules/bpmn-js": {
-      "version": "17.9.0",
-      "resolved": "https://registry.npmjs.org/bpmn-js/-/bpmn-js-17.9.0.tgz",
-      "integrity": "sha512-JmbyLWtaa04qZWtyjLcXBWsg+87SuYL2kY7+8wxa7uo6YDdWAoBXOSrGbfsp26ofvSa38LgNOYn7vBl3uABbUw==",
+      "version": "17.9.2",
+      "resolved": "https://registry.npmjs.org/bpmn-js/-/bpmn-js-17.9.2.tgz",
+      "integrity": "sha512-j8exjnIK9h5GR7nqgKE01cj6bfrz5FqH1vE31lOxxg20cJxTRRa99jOBSN5JlH8gxIpTDskv+DAp08ZNwm7ZqQ==",
       "dev": true,
       "dependencies": {
         "bpmn-moddle": "^8.1.0",
@@ -1431,22 +1431,21 @@
       }
     },
     "node_modules/bpmn-js-element-templates": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/bpmn-js-element-templates/-/bpmn-js-element-templates-1.16.0.tgz",
-      "integrity": "sha512-m556VTAgKun4wLGBfX26dAYJ+j+UkMKeyIHILuRtq1c0lCV++0AuUCBSWGL7hv5Aw96oAEkH2zIOLWc9Qg/gyw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/bpmn-js-element-templates/-/bpmn-js-element-templates-2.2.0.tgz",
+      "integrity": "sha512-oFsr7VVLXadlx3HdOGc0fUoqMta5k79UNY1xORaiuQh1Z1bD+1lAFqyQbJxhqA4tnQ+XstOh3ZzbuPm4AvHogA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@bpmn-io/element-templates-validator": "^2.1.0",
         "@bpmn-io/extract-process-variables": "^0.8.0",
-        "bpmnlint": "^10.0.0",
+        "bpmnlint": "^10.3.0",
         "classnames": "^2.3.1",
         "ids": "^1.0.0",
         "min-dash": "^4.0.0",
         "min-dom": "^4.0.3",
         "preact-markup": "^2.1.1",
         "semver-compare": "^1.0.0",
-        "uuid": "^9.0.1"
+        "uuid": "^10.0.0"
       },
       "engines": {
         "node": "*"
@@ -1482,9 +1481,9 @@
       }
     },
     "node_modules/bpmn-js-properties-panel": {
-      "version": "5.22.0",
-      "resolved": "https://registry.npmjs.org/bpmn-js-properties-panel/-/bpmn-js-properties-panel-5.22.0.tgz",
-      "integrity": "sha512-U8fI4nYrFFWKjwD4sDh5VOc8pM5YCYYnWYjJabCPTZOPa8rBTrgKUjIK9boINc350TRTRrOm+0x175bQHPu0OQ==",
+      "version": "5.23.0",
+      "resolved": "https://registry.npmjs.org/bpmn-js-properties-panel/-/bpmn-js-properties-panel-5.23.0.tgz",
+      "integrity": "sha512-4B27LM8oV14A2QWRvazV17h4NxbkNERcqU+AGJmxKImMlLhu9893MWR+pCdTQCTphBdBkuD8ksWm+1wVCedJ7g==",
       "dev": true,
       "dependencies": {
         "@bpmn-io/extract-process-variables": "^0.8.0",
@@ -1626,9 +1625,9 @@
       }
     },
     "node_modules/bpmnlint-plugin-camunda-compat": {
-      "version": "2.24.0",
-      "resolved": "https://registry.npmjs.org/bpmnlint-plugin-camunda-compat/-/bpmnlint-plugin-camunda-compat-2.24.0.tgz",
-      "integrity": "sha512-2ehX5zv8Kj8GKwO7Bu+F8TciltFoLnKCtW1W0427TPj1EVJW5oilUDCP9DKQHQLM0Qa+y50LmlKI/mNE0DOKHw==",
+      "version": "2.25.0",
+      "resolved": "https://registry.npmjs.org/bpmnlint-plugin-camunda-compat/-/bpmnlint-plugin-camunda-compat-2.25.0.tgz",
+      "integrity": "sha512-A0t9j3/AcH0tVXLqVyhLYm6o8bJ2CSduni7pDWO1MaDHC/kh6/TzLhSde9ceZnWzsqs3VZRRMAO2xaAI8AqvHw==",
       "dependencies": {
         "@bpmn-io/feel-lint": "^1.2.0",
         "@bpmn-io/moddle-utils": "^0.2.1",
@@ -1826,9 +1825,9 @@
       }
     },
     "node_modules/camunda-bpmn-js-behaviors": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/camunda-bpmn-js-behaviors/-/camunda-bpmn-js-behaviors-1.5.0.tgz",
-      "integrity": "sha512-LHExkeC+ZallNMirN9pcm3y43ifUS5465mFIRsTUlitU1apgGS/L52NS0tsPXXQvCgNdEMk2bjs/kwiHhBLdSw==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/camunda-bpmn-js-behaviors/-/camunda-bpmn-js-behaviors-1.6.1.tgz",
+      "integrity": "sha512-nvfFmL2wrCi5IApt4NcYcpRHJx4nPS8AHSUq9ckyq9FiDeIwASafsvaEYY0r+FeobqUY1deYNYsKjhSYd4N0kQ==",
       "dev": true,
       "dependencies": {
         "ids": "^1.0.0",
@@ -6349,9 +6348,9 @@
       }
     },
     "node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
       "dev": true,
       "funding": [
         "https://github.com/sponsors/broofa",
@@ -6620,9 +6619,9 @@
       }
     },
     "node_modules/zeebe-bpmn-moddle": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/zeebe-bpmn-moddle/-/zeebe-bpmn-moddle-1.5.1.tgz",
-      "integrity": "sha512-20dqDop32YdjqyVLZB3Vhh8oq+VKVcmOPNGRUkW6m1kJOtkR/abZSPdqiMtjY310tkagMS56ocZB2yW8itMOHQ=="
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/zeebe-bpmn-moddle/-/zeebe-bpmn-moddle-1.6.0.tgz",
+      "integrity": "sha512-vjPeJoLQs7UkC5m27K0CyZkQMEAI8GsISU6TcfD2n/SzqkhJ6tubvcIabLRAhreaiuHY26MjtSVXw1LRVgd7Iw=="
     },
     "node_modules/zod": {
       "version": "3.23.8",
@@ -7779,9 +7778,9 @@
       }
     },
     "bpmn-js": {
-      "version": "17.9.0",
-      "resolved": "https://registry.npmjs.org/bpmn-js/-/bpmn-js-17.9.0.tgz",
-      "integrity": "sha512-JmbyLWtaa04qZWtyjLcXBWsg+87SuYL2kY7+8wxa7uo6YDdWAoBXOSrGbfsp26ofvSa38LgNOYn7vBl3uABbUw==",
+      "version": "17.9.2",
+      "resolved": "https://registry.npmjs.org/bpmn-js/-/bpmn-js-17.9.2.tgz",
+      "integrity": "sha512-j8exjnIK9h5GR7nqgKE01cj6bfrz5FqH1vE31lOxxg20cJxTRRa99jOBSN5JlH8gxIpTDskv+DAp08ZNwm7ZqQ==",
       "dev": true,
       "requires": {
         "bpmn-moddle": "^8.1.0",
@@ -7851,21 +7850,21 @@
       }
     },
     "bpmn-js-element-templates": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/bpmn-js-element-templates/-/bpmn-js-element-templates-1.16.0.tgz",
-      "integrity": "sha512-m556VTAgKun4wLGBfX26dAYJ+j+UkMKeyIHILuRtq1c0lCV++0AuUCBSWGL7hv5Aw96oAEkH2zIOLWc9Qg/gyw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/bpmn-js-element-templates/-/bpmn-js-element-templates-2.2.0.tgz",
+      "integrity": "sha512-oFsr7VVLXadlx3HdOGc0fUoqMta5k79UNY1xORaiuQh1Z1bD+1lAFqyQbJxhqA4tnQ+XstOh3ZzbuPm4AvHogA==",
       "dev": true,
       "requires": {
         "@bpmn-io/element-templates-validator": "^2.1.0",
         "@bpmn-io/extract-process-variables": "^0.8.0",
-        "bpmnlint": "^10.0.0",
+        "bpmnlint": "^10.3.0",
         "classnames": "^2.3.1",
         "ids": "^1.0.0",
         "min-dash": "^4.0.0",
         "min-dom": "^4.0.3",
         "preact-markup": "^2.1.1",
         "semver-compare": "^1.0.0",
-        "uuid": "^9.0.1"
+        "uuid": "^10.0.0"
       },
       "dependencies": {
         "domify": {
@@ -7888,9 +7887,9 @@
       }
     },
     "bpmn-js-properties-panel": {
-      "version": "5.22.0",
-      "resolved": "https://registry.npmjs.org/bpmn-js-properties-panel/-/bpmn-js-properties-panel-5.22.0.tgz",
-      "integrity": "sha512-U8fI4nYrFFWKjwD4sDh5VOc8pM5YCYYnWYjJabCPTZOPa8rBTrgKUjIK9boINc350TRTRrOm+0x175bQHPu0OQ==",
+      "version": "5.23.0",
+      "resolved": "https://registry.npmjs.org/bpmn-js-properties-panel/-/bpmn-js-properties-panel-5.23.0.tgz",
+      "integrity": "sha512-4B27LM8oV14A2QWRvazV17h4NxbkNERcqU+AGJmxKImMlLhu9893MWR+pCdTQCTphBdBkuD8ksWm+1wVCedJ7g==",
       "dev": true,
       "requires": {
         "@bpmn-io/extract-process-variables": "^0.8.0",
@@ -7982,9 +7981,9 @@
       }
     },
     "bpmnlint-plugin-camunda-compat": {
-      "version": "2.24.0",
-      "resolved": "https://registry.npmjs.org/bpmnlint-plugin-camunda-compat/-/bpmnlint-plugin-camunda-compat-2.24.0.tgz",
-      "integrity": "sha512-2ehX5zv8Kj8GKwO7Bu+F8TciltFoLnKCtW1W0427TPj1EVJW5oilUDCP9DKQHQLM0Qa+y50LmlKI/mNE0DOKHw==",
+      "version": "2.25.0",
+      "resolved": "https://registry.npmjs.org/bpmnlint-plugin-camunda-compat/-/bpmnlint-plugin-camunda-compat-2.25.0.tgz",
+      "integrity": "sha512-A0t9j3/AcH0tVXLqVyhLYm6o8bJ2CSduni7pDWO1MaDHC/kh6/TzLhSde9ceZnWzsqs3VZRRMAO2xaAI8AqvHw==",
       "requires": {
         "@bpmn-io/feel-lint": "^1.2.0",
         "@bpmn-io/moddle-utils": "^0.2.1",
@@ -8086,9 +8085,9 @@
       "dev": true
     },
     "camunda-bpmn-js-behaviors": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/camunda-bpmn-js-behaviors/-/camunda-bpmn-js-behaviors-1.5.0.tgz",
-      "integrity": "sha512-LHExkeC+ZallNMirN9pcm3y43ifUS5465mFIRsTUlitU1apgGS/L52NS0tsPXXQvCgNdEMk2bjs/kwiHhBLdSw==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/camunda-bpmn-js-behaviors/-/camunda-bpmn-js-behaviors-1.6.1.tgz",
+      "integrity": "sha512-nvfFmL2wrCi5IApt4NcYcpRHJx4nPS8AHSUq9ckyq9FiDeIwASafsvaEYY0r+FeobqUY1deYNYsKjhSYd4N0kQ==",
       "dev": true,
       "requires": {
         "ids": "^1.0.0",
@@ -11437,9 +11436,9 @@
       "dev": true
     },
     "uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
       "dev": true
     },
     "vary": {
@@ -11630,9 +11629,9 @@
       "dev": true
     },
     "zeebe-bpmn-moddle": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/zeebe-bpmn-moddle/-/zeebe-bpmn-moddle-1.5.1.tgz",
-      "integrity": "sha512-20dqDop32YdjqyVLZB3Vhh8oq+VKVcmOPNGRUkW6m1kJOtkR/abZSPdqiMtjY310tkagMS56ocZB2yW8itMOHQ=="
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/zeebe-bpmn-moddle/-/zeebe-bpmn-moddle-1.6.0.tgz",
+      "integrity": "sha512-vjPeJoLQs7UkC5m27K0CyZkQMEAI8GsISU6TcfD2n/SzqkhJ6tubvcIabLRAhreaiuHY26MjtSVXw1LRVgd7Iw=="
     },
     "zod": {
       "version": "3.23.8",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@bpmn-io/diagram-js-ui": "^0.2.3",
     "bpmn-moddle": "^9.0.1",
     "bpmnlint": "^10.3.0",
-    "bpmnlint-plugin-camunda-compat": "^2.24.0",
+    "bpmnlint-plugin-camunda-compat": "^2.25.0",
     "bpmnlint-utils": "^1.0.2",
     "camunda-bpmn-moddle": "^7.0.1",
     "clsx": "^2.0.0",
@@ -40,13 +40,13 @@
     "min-dom": "^5.1.1",
     "modeler-moddle": "^0.2.0",
     "semver-compare": "^1.0.0",
-    "zeebe-bpmn-moddle": "^1.5.1"
+    "zeebe-bpmn-moddle": "^1.6.0"
   },
   "devDependencies": {
-    "bpmn-js": "^17.9.0",
-    "bpmn-js-element-templates": "^1.16.0",
-    "bpmn-js-properties-panel": "^5.22.0",
-    "camunda-bpmn-js-behaviors": "^1.5.0",
+    "bpmn-js": "^17.9.2",
+    "bpmn-js-element-templates": "^2.2.0",
+    "bpmn-js-properties-panel": "^5.23.0",
+    "camunda-bpmn-js-behaviors": "^1.6.1",
     "chai": "^4.4.1",
     "cross-env": "^7.0.3",
     "eslint": "^8.57.0",

--- a/test/spec/utils/error-messages.spec.js
+++ b/test/spec/utils/error-messages.spec.js
@@ -500,6 +500,33 @@ describe('utils/error-messages', function() {
           // then
           expect(errorMessage).to.equal('A <Service Task> with <Execution listeners> is only supported by Camunda 8.6 or newer');
         });
+
+
+        it('should adjust (zeebe:VersionTag)', async function() {
+
+          // given
+          const executionPlatformVersion = '8.5';
+
+          const node = createElement('bpmn:Process', {
+            isExecutable: true,
+            extensionElements: createElement('bpmn:ExtensionElements', {
+              values: [
+                createElement('zeebe:VersionTag')
+              ]
+            })
+          });
+
+          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-version-tag');
+
+          const report = await getLintError(node, rule, { version: executionPlatformVersion });
+
+          // when
+          const errorMessage = getErrorMessage(report, 'Camunda Cloud', executionPlatformVersion);
+
+          // then
+          expect(errorMessage).to.equal('A <Process> with <Version tag> is only supported by Camunda 8.6 or newer');
+        });
+
       });
 
 
@@ -777,7 +804,7 @@ describe('utils/error-messages', function() {
           const errorMessage = getErrorMessage(report, 'Camunda Cloud', '1.0');
 
           // then
-          expect(errorMessage).to.equal('A <User Task> with defined <Candidate users> is only supported by Camunda 8.2 or newer');
+          expect(errorMessage).to.equal('A <User Task> with <Candidate users> is only supported by Camunda 8.2 or newer');
         });
 
 
@@ -834,6 +861,85 @@ describe('utils/error-messages', function() {
 
           // then
           expect(errorMessage).to.equal('A <Timer Intermediate Catch Event> with <Date> is only supported by Camunda 8.3 or newer');
+        });
+
+
+        describe('version tag', function() {
+
+          it('should adjust (business rule task)', async function() {
+
+            // given
+            const node = createElement('bpmn:BusinessRuleTask', {
+              extensionElements: createElement('bpmn:ExtensionElements', {
+                values: [
+                  createElement('zeebe:CalledDecision', {
+                    versionTag: 'v1.0.0'
+                  })
+                ]
+              })
+            });
+
+            const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-version-tag');
+
+            const report = await getLintError(node, rule);
+
+            // when
+            const errorMessage = getErrorMessage(report, 'Camunda Cloud', '1.0', 'desktop');
+
+            // then
+            expect(errorMessage).to.equal('A <Business Rule Task> with <Version tag> is only supported by Camunda 8.6 or newer');
+          });
+
+
+          it('should adjust (call activity)', async function() {
+
+            // given
+            const node = createElement('bpmn:CallActivity', {
+              extensionElements: createElement('bpmn:ExtensionElements', {
+                values: [
+                  createElement('zeebe:CalledElement', {
+                    versionTag: 'v1.0.0'
+                  })
+                ]
+              })
+            });
+
+            const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-version-tag');
+
+            const report = await getLintError(node, rule);
+
+            // when
+            const errorMessage = getErrorMessage(report, 'Camunda Cloud', '1.0', 'desktop');
+
+            // then
+            expect(errorMessage).to.equal('A <Call Activity> with <Version tag> is only supported by Camunda 8.6 or newer');
+          });
+
+
+          it('should adjust (user task)', async function() {
+
+            // given
+            const node = createElement('bpmn:UserTask', {
+              extensionElements: createElement('bpmn:ExtensionElements', {
+                values: [
+                  createElement('zeebe:FormDefinition', {
+                    versionTag: 'v1.0.0'
+                  })
+                ]
+              })
+            });
+
+            const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-version-tag');
+
+            const report = await getLintError(node, rule);
+
+            // when
+            const errorMessage = getErrorMessage(report, 'Camunda Cloud', '1.0', 'desktop');
+
+            // then
+            expect(errorMessage).to.equal('A <User Task> with <Version tag> is only supported by Camunda 8.6 or newer');
+          });
+
         });
 
       });
@@ -1917,7 +2023,7 @@ describe('utils/error-messages', function() {
         });
 
 
-        it('should adjust (binding type set to false)', async function() {
+        it('should adjust (binding type set to deployment)', async function() {
 
           // given
           const node = createElement('bpmn:CallActivity', {
@@ -1939,6 +2045,85 @@ describe('utils/error-messages', function() {
 
           // then
           expect(errorMessage).to.equal('A <Call Activity> with <Binding: deployment> is only supported by Camunda 8.6 or newer');
+        });
+
+
+        describe('binding type set to version tag', function() {
+
+          it('should adjust (business rule task)', async function() {
+
+            // given
+            const node = createElement('bpmn:BusinessRuleTask', {
+              extensionElements: createElement('bpmn:ExtensionElements', {
+                values: [
+                  createElement('zeebe:CalledDecision', {
+                    bindingType: 'versionTag'
+                  })
+                ]
+              })
+            });
+
+            const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-binding-type');
+
+            const report = await getLintError(node, rule);
+
+            // when
+            const errorMessage = getErrorMessage(report, 'Camunda Cloud', '1.0');
+
+            // then
+            expect(errorMessage).to.equal('A <Business Rule Task> with <Binding: version tag> is only supported by Camunda 8.6 or newer');
+          });
+
+
+          it('should adjust (call activity)', async function() {
+
+            // given
+            const node = createElement('bpmn:CallActivity', {
+              extensionElements: createElement('bpmn:ExtensionElements', {
+                values: [
+                  createElement('zeebe:CalledElement', {
+                    bindingType: 'versionTag'
+                  })
+                ]
+              })
+            });
+
+            const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-binding-type');
+
+            const report = await getLintError(node, rule);
+
+            // when
+            const errorMessage = getErrorMessage(report, 'Camunda Cloud', '1.0');
+
+            // then
+            expect(errorMessage).to.equal('A <Call Activity> with <Binding: version tag> is only supported by Camunda 8.6 or newer');
+          });
+
+
+          it('should adjust (user task)', async function() {
+
+            // given
+            const node = createElement('bpmn:UserTask', {
+              extensionElements: createElement('bpmn:ExtensionElements', {
+                values: [
+                  createElement('zeebe:FormDefinition', {
+                    bindingType: 'versionTag'
+                  })
+                ]
+              })
+            });
+
+            const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-binding-type');
+
+            const report = await getLintError(node, rule);
+
+            // when
+            const errorMessage = getErrorMessage(report, 'Camunda Cloud', '1.0');
+
+            // then
+            expect(errorMessage).to.equal('A <User Task> with <Binding: version tag> is only supported by Camunda 8.6 or newer');
+          });
+
         });
 
       });

--- a/test/spec/utils/lint-helper.js
+++ b/test/spec/utils/lint-helper.js
@@ -1,6 +1,6 @@
 import Linter from 'bpmnlint/lib/linter';
 
-async function lintNode(node, rule, config = {},) {
+async function lintNode(node, rule, config = {}) {
   const linter = new Linter({
     resolver: {
       resolveRule: () => Promise.resolve(rule)

--- a/test/spec/utils/properties-panel.spec.js
+++ b/test/spec/utils/properties-panel.spec.js
@@ -1938,7 +1938,7 @@ describe('utils/properties-panel', function() {
       });
 
 
-      it('should support `waitForCompletion`', async function() {
+      it('intermediate throw event - Wait for completion', async function() {
 
         // given
         const node = createElement('bpmn:IntermediateThrowEvent', {
@@ -1963,7 +1963,7 @@ describe('utils/properties-panel', function() {
       });
 
 
-      describe('execution listener', async function() {
+      describe('Execution listeners', async function() {
 
         it('should mark type as required', async function() {
 
@@ -2039,6 +2039,177 @@ describe('utils/properties-panel', function() {
         });
 
       });
+
+
+      describe('Binding', function() {
+
+        it('business rule task', async function() {
+
+          // given
+          const node = createElement('bpmn:BusinessRuleTask', {
+            extensionElements: createElement('bpmn:ExtensionElements', {
+              values: [
+                createElement('zeebe:CalledDecision', {
+                  bindingType: 'deployment'
+                })
+              ]
+            })
+          });
+
+          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-binding-type');
+
+          const report = await getLintError(node, rule);
+
+          // when
+          const entryIds = getEntryIds(report);
+
+          // then
+          expect(entryIds).to.eql([ 'bindingType' ]);
+
+          expectErrorMessage(entryIds[ 0 ], 'Only supported by Camunda 8.6 or newer.', report);
+        });
+
+
+        it('call activity', async function() {
+
+          // given
+          const node = createElement('bpmn:CallActivity', {
+            extensionElements: createElement('bpmn:ExtensionElements', {
+              values: [
+                createElement('zeebe:CalledElement', {
+                  bindingType: 'deployment'
+                })
+              ]
+            })
+          });
+
+          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-binding-type');
+
+          const report = await getLintError(node, rule);
+
+          // when
+          const entryIds = getEntryIds(report);
+
+          // then
+          expect(entryIds).to.eql([ 'bindingType' ]);
+
+          expectErrorMessage(entryIds[ 0 ], 'Only supported by Camunda 8.6 or newer.', report);
+        });
+
+
+        it('user task', async function() {
+
+          // given
+          const node = createElement('bpmn:UserTask', {
+            extensionElements: createElement('bpmn:ExtensionElements', {
+              values: [
+                createElement('zeebe:FormDefinition', {
+                  bindingType: 'deployment'
+                })
+              ]
+            })
+          });
+
+          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-binding-type');
+
+          const report = await getLintError(node, rule);
+
+          // when
+          const entryIds = getEntryIds(report);
+
+          // then
+          expect(entryIds).to.eql([ 'bindingType' ]);
+
+          expectErrorMessage(entryIds[ 0 ], 'Only supported by Camunda 8.6 or newer.', report);
+        });
+
+      });
+
+
+      describe('Version tag', function() {
+
+        it('business rule task', async function() {
+
+          // given
+          const node = createElement('bpmn:BusinessRuleTask', {
+            extensionElements: createElement('bpmn:ExtensionElements', {
+              values: [
+                createElement('zeebe:CalledDecision', {
+                  versionTag: 'v1.0.0'
+                })
+              ]
+            })
+          });
+
+          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-version-tag');
+
+          const report = await getLintError(node, rule);
+
+          // when
+          const entryIds = getEntryIds(report);
+
+          // then
+          expect(entryIds).to.eql([ 'versionTag' ]);
+
+          expectErrorMessage(entryIds[ 0 ], 'Only supported by Camunda 8.6 or newer.', report);
+        });
+
+
+        it('call activity', async function() {
+
+          // given
+          const node = createElement('bpmn:CallActivity', {
+            extensionElements: createElement('bpmn:ExtensionElements', {
+              values: [
+                createElement('zeebe:CalledElement', {
+                  versionTag: 'v1.0.0'
+                })
+              ]
+            })
+          });
+
+          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-version-tag');
+
+          const report = await getLintError(node, rule);
+
+          // when
+          const entryIds = getEntryIds(report);
+
+          // then
+          expect(entryIds).to.eql([ 'versionTag' ]);
+
+          expectErrorMessage(entryIds[ 0 ], 'Only supported by Camunda 8.6 or newer.', report);
+        });
+
+
+        it('user task', async function() {
+
+          // given
+          const node = createElement('bpmn:UserTask', {
+            extensionElements: createElement('bpmn:ExtensionElements', {
+              values: [
+                createElement('zeebe:FormDefinition', {
+                  versionTag: 'v1.0.0'
+                })
+              ]
+            })
+          });
+
+          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-version-tag');
+
+          const report = await getLintError(node, rule);
+
+          // when
+          const entryIds = getEntryIds(report);
+
+          // then
+          expect(entryIds).to.eql([ 'versionTag' ]);
+
+          expectErrorMessage(entryIds[ 0 ], 'Only supported by Camunda 8.6 or newer.', report);
+        });
+
+      });
+
     });
 
 


### PR DESCRIPTION
### `zeebe:VersionTag` not supported error

![image](https://github.com/user-attachments/assets/cf151d8f-563a-4de0-bc7b-cb50e5ccb516)

### `zeebe:versionTag` not supported error

![image](https://github.com/user-attachments/assets/2e17a51f-49ff-4bfe-b01e-9cf2a1aeec71)

Related to https://github.com/camunda/camunda-modeler/issues/4480