### PR TITLE
feat: update `no-version-tag` rule and add `version-tag` rule

### DIFF
--- a/lib/compiled-config.js
+++ b/lib/compiled-config.js
@@ -72,6 +72,7 @@ const rules = {
   "camunda-compat/timer": "error",
   "camunda-compat/user-task-definition": "warn",
   "camunda-compat/user-task-form": "error",
+  "camunda-compat/version-tag": "error",
   "camunda-compat/wait-for-completion": "error"
 };
 
@@ -260,6 +261,10 @@ import rule_42 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/user-tas
 
 cache['bpmnlint-plugin-camunda-compat/user-task-form'] = rule_42;
 
-import rule_43 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/wait-for-completion';
+import rule_43 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/version-tag';
 
-cache['bpmnlint-plugin-camunda-compat/wait-for-completion'] = rule_43;
+cache['bpmnlint-plugin-camunda-compat/version-tag'] = rule_43;
+
+import rule_44 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/wait-for-completion';
+
+cache['bpmnlint-plugin-camunda-compat/wait-for-completion'] = rule_44;

--- a/lib/utils/error-messages.js
+++ b/lib/utils/error-messages.js
@@ -457,14 +457,6 @@ function getPropertyNotAllowedErrorMessage(report, executionPlatform, executionP
     return getSupportedMessage(`${ getIndefiniteArticle(typeString) } <${ typeString }> with <Form type: Camunda form (linked)>`, executionPlatform, executionPlatformVersion, allowedVersion);
   }
 
-  if (isAny(node, [
-    'zeebe:CalledDecision',
-    'zeebe:CalledElement',
-    'zeebe:FormDefinition'
-  ]) && property === 'versionTag') {
-    return getSupportedMessage(`${ getIndefiniteArticle(typeString) } <${ typeString }> with <Version tag>`, executionPlatform, executionPlatformVersion, allowedVersion);
-  }
-
   return message;
 }
 
@@ -600,6 +592,14 @@ function getPropertyRequiredErrorMessage(report, executionPlatform, executionPla
 
   if (is(node, 'bpmn:LinkEventDefinition') && requiredProperty === 'name') {
     return `${ getIndefiniteArticle(typeString) } <${ typeString }> must have a defined <Name>`;
+  }
+
+  if (isAny(node, [
+    'zeebe:CalledDecision',
+    'zeebe:CalledElement',
+    'zeebe:FormDefinition'
+  ]) && requiredProperty === 'versionTag') {
+    return `${ getIndefiniteArticle(typeString) } <${ typeString }> with <Binding: version tag> must have a defined <Version tag>`;
   }
 
   return message;

--- a/lib/utils/properties-panel.js
+++ b/lib/utils/properties-panel.js
@@ -579,7 +579,11 @@ export function getErrorMessage(id, report) {
   }
 
   if (id === 'versionTag') {
-    return getNotSupportedMessage('', allowedVersion);
+    if (type === ERROR_TYPES.EXTENSION_ELEMENT_NOT_ALLOWED) {
+      return getNotSupportedMessage('', allowedVersion);
+    } else {
+      return 'Version tag must be defined.';
+    }
   }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@bpmn-io/diagram-js-ui": "^0.2.3",
         "bpmn-moddle": "^9.0.1",
         "bpmnlint": "^10.3.0",
-        "bpmnlint-plugin-camunda-compat": "^2.25.0",
+        "bpmnlint-plugin-camunda-compat": "^2.26.0",
         "bpmnlint-utils": "^1.0.2",
         "camunda-bpmn-moddle": "^7.0.1",
         "clsx": "^2.0.0",
@@ -1591,9 +1591,9 @@
       }
     },
     "node_modules/bpmnlint-plugin-camunda-compat": {
-      "version": "2.25.0",
-      "resolved": "https://registry.npmjs.org/bpmnlint-plugin-camunda-compat/-/bpmnlint-plugin-camunda-compat-2.25.0.tgz",
-      "integrity": "sha512-A0t9j3/AcH0tVXLqVyhLYm6o8bJ2CSduni7pDWO1MaDHC/kh6/TzLhSde9ceZnWzsqs3VZRRMAO2xaAI8AqvHw==",
+      "version": "2.26.0",
+      "resolved": "https://registry.npmjs.org/bpmnlint-plugin-camunda-compat/-/bpmnlint-plugin-camunda-compat-2.26.0.tgz",
+      "integrity": "sha512-Xwtb50xaxIOZ/tgVEbGLLWDFR4EOmCyWjIaIjskjHfLqBzZlektDeG8SoqrLij6aH75qFUf7iqk/se0RwnT2iw==",
       "dependencies": {
         "@bpmn-io/feel-lint": "^1.2.0",
         "@bpmn-io/moddle-utils": "^0.2.1",
@@ -7868,9 +7868,9 @@
       }
     },
     "bpmnlint-plugin-camunda-compat": {
-      "version": "2.25.0",
-      "resolved": "https://registry.npmjs.org/bpmnlint-plugin-camunda-compat/-/bpmnlint-plugin-camunda-compat-2.25.0.tgz",
-      "integrity": "sha512-A0t9j3/AcH0tVXLqVyhLYm6o8bJ2CSduni7pDWO1MaDHC/kh6/TzLhSde9ceZnWzsqs3VZRRMAO2xaAI8AqvHw==",
+      "version": "2.26.0",
+      "resolved": "https://registry.npmjs.org/bpmnlint-plugin-camunda-compat/-/bpmnlint-plugin-camunda-compat-2.26.0.tgz",
+      "integrity": "sha512-Xwtb50xaxIOZ/tgVEbGLLWDFR4EOmCyWjIaIjskjHfLqBzZlektDeG8SoqrLij6aH75qFUf7iqk/se0RwnT2iw==",
       "requires": {
         "@bpmn-io/feel-lint": "^1.2.0",
         "@bpmn-io/moddle-utils": "^0.2.1",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@bpmn-io/diagram-js-ui": "^0.2.3",
     "bpmn-moddle": "^9.0.1",
     "bpmnlint": "^10.3.0",
-    "bpmnlint-plugin-camunda-compat": "^2.25.0",
+    "bpmnlint-plugin-camunda-compat": "^2.26.0",
     "bpmnlint-utils": "^1.0.2",
     "camunda-bpmn-moddle": "^7.0.1",
     "clsx": "^2.0.0",

--- a/test/spec/utils/error-messages.spec.js
+++ b/test/spec/utils/error-messages.spec.js
@@ -863,85 +863,6 @@ describe('utils/error-messages', function() {
           expect(errorMessage).to.equal('A <Timer Intermediate Catch Event> with <Date> is only supported by Camunda 8.3 or newer');
         });
 
-
-        describe('version tag', function() {
-
-          it('should adjust (business rule task)', async function() {
-
-            // given
-            const node = createElement('bpmn:BusinessRuleTask', {
-              extensionElements: createElement('bpmn:ExtensionElements', {
-                values: [
-                  createElement('zeebe:CalledDecision', {
-                    versionTag: 'v1.0.0'
-                  })
-                ]
-              })
-            });
-
-            const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-version-tag');
-
-            const report = await getLintError(node, rule);
-
-            // when
-            const errorMessage = getErrorMessage(report, 'Camunda Cloud', '1.0', 'desktop');
-
-            // then
-            expect(errorMessage).to.equal('A <Business Rule Task> with <Version tag> is only supported by Camunda 8.6 or newer');
-          });
-
-
-          it('should adjust (call activity)', async function() {
-
-            // given
-            const node = createElement('bpmn:CallActivity', {
-              extensionElements: createElement('bpmn:ExtensionElements', {
-                values: [
-                  createElement('zeebe:CalledElement', {
-                    versionTag: 'v1.0.0'
-                  })
-                ]
-              })
-            });
-
-            const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-version-tag');
-
-            const report = await getLintError(node, rule);
-
-            // when
-            const errorMessage = getErrorMessage(report, 'Camunda Cloud', '1.0', 'desktop');
-
-            // then
-            expect(errorMessage).to.equal('A <Call Activity> with <Version tag> is only supported by Camunda 8.6 or newer');
-          });
-
-
-          it('should adjust (user task)', async function() {
-
-            // given
-            const node = createElement('bpmn:UserTask', {
-              extensionElements: createElement('bpmn:ExtensionElements', {
-                values: [
-                  createElement('zeebe:FormDefinition', {
-                    versionTag: 'v1.0.0'
-                  })
-                ]
-              })
-            });
-
-            const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-version-tag');
-
-            const report = await getLintError(node, rule);
-
-            // when
-            const errorMessage = getErrorMessage(report, 'Camunda Cloud', '1.0', 'desktop');
-
-            // then
-            expect(errorMessage).to.equal('A <User Task> with <Version tag> is only supported by Camunda 8.6 or newer');
-          });
-
-        });
-
       });
 
 
@@ -1711,6 +1632,88 @@ describe('utils/error-messages', function() {
 
           // then
           expect(errorMessage).to.equal('An <Execution Listener> must have a defined <Type>');
+        });
+
+
+        describe('version tag', function() {
+
+          it('should adjust (business rule task)', async function() {
+
+            // given
+            const node = createElement('bpmn:BusinessRuleTask', {
+              extensionElements: createElement('bpmn:ExtensionElements', {
+                values: [
+                  createElement('zeebe:CalledDecision', {
+                    bindingType: 'versionTag',
+                    versionTag: ''
+                  })
+                ]
+              })
+            });
+
+            const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/version-tag');
+
+            const report = await getLintError(node, rule);
+
+            // when
+            const errorMessage = getErrorMessage(report, 'Camunda Cloud', '8.6', 'desktop');
+
+            // then
+            expect(errorMessage).to.equal('A <Business Rule Task> with <Binding: version tag> must have a defined <Version tag>');
+          });
+
+
+          it('should adjust (call activity)', async function() {
+
+            // given
+            const node = createElement('bpmn:CallActivity', {
+              extensionElements: createElement('bpmn:ExtensionElements', {
+                values: [
+                  createElement('zeebe:CalledElement', {
+                    bindingType: 'versionTag',
+                    versionTag: ''
+                  })
+                ]
+              })
+            });
+
+            const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/version-tag');
+
+            const report = await getLintError(node, rule);
+
+            // when
+            const errorMessage = getErrorMessage(report, 'Camunda Cloud', '8.6', 'desktop');
+
+            // then
+            expect(errorMessage).to.equal('A <Call Activity> with <Binding: version tag> must have a defined <Version tag>');
+          });
+
+
+          it('should adjust (user task)', async function() {
+
+            // given
+            const node = createElement('bpmn:UserTask', {
+              extensionElements: createElement('bpmn:ExtensionElements', {
+                values: [
+                  createElement('zeebe:FormDefinition', {
+                    bindingType: 'versionTag',
+                    versionTag: ''
+                  })
+                ]
+              })
+            });
+
+            const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/version-tag');
+
+            const report = await getLintError(node, rule);
+
+            // when
+            const errorMessage = getErrorMessage(report, 'Camunda Cloud', '8.6', 'desktop');
+
+            // then
+            expect(errorMessage).to.equal('A <User Task> with <Binding: version tag> must have a defined <Version tag>');
+          });
+
         });
 
       });

--- a/test/spec/utils/properties-panel.spec.js
+++ b/test/spec/utils/properties-panel.spec.js
@@ -2160,15 +2160,16 @@ describe('utils/properties-panel', function() {
             extensionElements: createElement('bpmn:ExtensionElements', {
               values: [
                 createElement('zeebe:CalledDecision', {
-                  versionTag: 'v1.0.0'
+                  bindingType: 'versionTag',
+                  versionTag: ''
                 })
               ]
             })
           });
 
-          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-version-tag');
+          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/version-tag');
 
-          const report = await getLintError(node, rule);
+          const report = await getLintError(node, rule, { version: '8.6' });
 
           // when
           const entryIds = getEntryIds(report);
@@ -2176,7 +2177,7 @@ describe('utils/properties-panel', function() {
           // then
           expect(entryIds).to.eql([ 'versionTag' ]);
 
-          expectErrorMessage(entryIds[ 0 ], 'Only supported by Camunda 8.6 or newer.', report);
+          expectErrorMessage(entryIds[ 0 ], 'Version tag must be defined.', report);
         });
 
 
@@ -2187,15 +2188,16 @@ describe('utils/properties-panel', function() {
             extensionElements: createElement('bpmn:ExtensionElements', {
               values: [
                 createElement('zeebe:CalledElement', {
-                  versionTag: 'v1.0.0'
+                  bindingType: 'versionTag',
+                  versionTag: ''
                 })
               ]
             })
           });
 
-          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-version-tag');
+          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/version-tag');
 
-          const report = await getLintError(node, rule);
+          const report = await getLintError(node, rule, { version: '8.6' });
 
           // when
           const entryIds = getEntryIds(report);
@@ -2203,7 +2205,7 @@ describe('utils/properties-panel', function() {
           // then
           expect(entryIds).to.eql([ 'versionTag' ]);
 
-          expectErrorMessage(entryIds[ 0 ], 'Only supported by Camunda 8.6 or newer.', report);
+          expectErrorMessage(entryIds[ 0 ], 'Version tag must be defined.', report);
         });
 
 
@@ -2214,15 +2216,16 @@ describe('utils/properties-panel', function() {
             extensionElements: createElement('bpmn:ExtensionElements', {
               values: [
                 createElement('zeebe:FormDefinition', {
-                  versionTag: 'v1.0.0'
+                  bindingType: 'versionTag',
+                  versionTag: ''
                 })
               ]
             })
           });
 
-          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-version-tag');
+          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/version-tag');
 
-          const report = await getLintError(node, rule);
+          const report = await getLintError(node, rule, { version: '8.6' });
 
           // when
           const entryIds = getEntryIds(report);
@@ -2230,7 +2233,7 @@ describe('utils/properties-panel', function() {
           // then
           expect(entryIds).to.eql([ 'versionTag' ]);
 
-          expectErrorMessage(entryIds[ 0 ], 'Only supported by Camunda 8.6 or newer.', report);
+          expectErrorMessage(entryIds[ 0 ], 'Version tag must be defined.', report);
         });
 
       });


### PR DESCRIPTION
Integrates fix for https://github.com/camunda/camunda-modeler/issues/4519 and handles the changed lint errors.

![brave_Z4pi3wR9ZS](https://github.com/user-attachments/assets/8ad90aa3-4e1b-4998-88d9-a33f446b46f2)

---

Related to https://github.com/camunda/camunda-modeler/issues/4519
Requires https://github.com/camunda/bpmnlint-plugin-camunda-compat/pull/174