### PR TITLE
Mark job worker-based user task managed by Camunda as deprecated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to [@camunda/linting](https://github.com/camunda/linting) ar
 
 ___Note:__ Yet to be released changes appear here._
 
+## 3.30.0
+
+* `FEAT`: rename "Zeebe user task" to "Camunda user task" ([#126](https://github.com/camunda/linting/pull/126))
+* `FEAT`: mark job worker-based user task managed by Camunda as deprecated ([#125](https://github.com/camunda/linting/pull/125))
+* `DEPS`: update to `bpmnlint-plugin-camunda-compat@2.29.0`
+
 ## 3.29.1
 
 * `FIX`: relax `task-listener` to not check implementation type ([camunda/bpmnlint-plugin-camunda-compat#182](https://github.com/camunda/bpmnlint-plugin-camunda-compat/pull/182))

--- a/lib/compiled-config.js
+++ b/lib/compiled-config.js
@@ -64,6 +64,7 @@ const rules = {
   "camunda-compat/no-zeebe-properties": "error",
   "camunda-compat/no-zeebe-user-task": "error",
   "camunda-compat/priority-definition": "error",
+  "camunda-compat/zeebe-user-task": "warn",
   "camunda-compat/secrets": "warn",
   "camunda-compat/sequence-flow-condition": "error",
   "camunda-compat/signal-reference": "error",
@@ -231,50 +232,54 @@ import rule_34 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/priority
 
 cache['bpmnlint-plugin-camunda-compat/priority-definition'] = rule_34;
 
-import rule_35 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/secrets';
+import rule_35 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/zeebe-user-task';
 
-cache['bpmnlint-plugin-camunda-compat/secrets'] = rule_35;
+cache['bpmnlint-plugin-camunda-compat/zeebe-user-task'] = rule_35;
 
-import rule_36 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/sequence-flow-condition';
+import rule_36 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/secrets';
 
-cache['bpmnlint-plugin-camunda-compat/sequence-flow-condition'] = rule_36;
+cache['bpmnlint-plugin-camunda-compat/secrets'] = rule_36;
 
-import rule_37 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/signal-reference';
+import rule_37 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/sequence-flow-condition';
 
-cache['bpmnlint-plugin-camunda-compat/signal-reference'] = rule_37;
+cache['bpmnlint-plugin-camunda-compat/sequence-flow-condition'] = rule_37;
 
-import rule_38 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/start-event-form';
+import rule_38 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/signal-reference';
 
-cache['bpmnlint-plugin-camunda-compat/start-event-form'] = rule_38;
+cache['bpmnlint-plugin-camunda-compat/signal-reference'] = rule_38;
 
-import rule_39 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/subscription';
+import rule_39 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/start-event-form';
 
-cache['bpmnlint-plugin-camunda-compat/subscription'] = rule_39;
+cache['bpmnlint-plugin-camunda-compat/start-event-form'] = rule_39;
 
-import rule_40 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/task-listener';
+import rule_40 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/subscription';
 
-cache['bpmnlint-plugin-camunda-compat/task-listener'] = rule_40;
+cache['bpmnlint-plugin-camunda-compat/subscription'] = rule_40;
 
-import rule_41 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/task-schedule';
+import rule_41 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/task-listener';
 
-cache['bpmnlint-plugin-camunda-compat/task-schedule'] = rule_41;
+cache['bpmnlint-plugin-camunda-compat/task-listener'] = rule_41;
 
-import rule_42 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/timer';
+import rule_42 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/task-schedule';
 
-cache['bpmnlint-plugin-camunda-compat/timer'] = rule_42;
+cache['bpmnlint-plugin-camunda-compat/task-schedule'] = rule_42;
 
-import rule_43 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/user-task-definition';
+import rule_43 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/timer';
 
-cache['bpmnlint-plugin-camunda-compat/user-task-definition'] = rule_43;
+cache['bpmnlint-plugin-camunda-compat/timer'] = rule_43;
 
-import rule_44 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/user-task-form';
+import rule_44 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/user-task-definition';
 
-cache['bpmnlint-plugin-camunda-compat/user-task-form'] = rule_44;
+cache['bpmnlint-plugin-camunda-compat/user-task-definition'] = rule_44;
 
-import rule_45 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/version-tag';
+import rule_45 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/user-task-form';
 
-cache['bpmnlint-plugin-camunda-compat/version-tag'] = rule_45;
+cache['bpmnlint-plugin-camunda-compat/user-task-form'] = rule_45;
 
-import rule_46 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/wait-for-completion';
+import rule_46 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/version-tag';
 
-cache['bpmnlint-plugin-camunda-compat/wait-for-completion'] = rule_46;
+cache['bpmnlint-plugin-camunda-compat/version-tag'] = rule_46;
+
+import rule_47 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/wait-for-completion';
+
+cache['bpmnlint-plugin-camunda-compat/wait-for-completion'] = rule_47;

--- a/lib/utils/documentation.js
+++ b/lib/utils/documentation.js
@@ -1,4 +1,5 @@
 const baseUrl = 'https://docs.camunda.io/docs/next/components/modeler/reference/modeling-guidance/rules';
+const userTaskMigrationUrl = 'https://docs.camunda.io/docs/next/apis-tools/migration-manuals/migrate-to-zeebe-user-tasks';
 
 export function getDocumentationUrl(rule) {
   if (rule === 'camunda-compat/called-element') {
@@ -27,6 +28,10 @@ export function getDocumentationUrl(rule) {
 
   if (rule === 'camunda-compat/history-time-to-live') {
     return getUrl('history-time-to-live');
+  }
+
+  if (rule === 'camunda-compat/zeebe-user-task') {
+    return userTaskMigrationUrl;
   }
 
   return null;

--- a/lib/utils/error-messages.js
+++ b/lib/utils/error-messages.js
@@ -390,7 +390,7 @@ function getExtensionElementRequiredErrorMessage(report, executionPlatform, exec
   }
 
   if (requiredExtensionElement === 'zeebe:UserTask') {
-    return `${ getIndefiniteArticle(typeString) } <${ typeString }> with <Implementation: Job worker> is deprecated on ${ getExecutionPlatformLabel(executionPlatform, executionPlatformVersion) }. Consider migrating to <Implementation: Camunda user task>.`;
+    return `${ getIndefiniteArticle(typeString) } <${ typeString }> with <Implementation: Job worker> managed by Camunda is deprecated. Consider migrating to <Implementation: Camunda user task>.`;
   }
 
   return message;

--- a/lib/utils/error-messages.js
+++ b/lib/utils/error-messages.js
@@ -102,7 +102,7 @@ export function getErrorMessage(report, executionPlatform, executionPlatformVers
   }
 
   if (type === ERROR_TYPES.EXTENSION_ELEMENT_REQUIRED) {
-    return getExtensionElementRequiredErrorMessage(report);
+    return getExtensionElementRequiredErrorMessage(report, executionPlatform, executionPlatformVersion);
   }
 
   if (type === ERROR_TYPES.PROPERTY_DEPENDENT_REQUIRED) {
@@ -347,7 +347,7 @@ function getExtensionElementNotAllowedErrorMessage(report, executionPlatform, ex
   return message;
 }
 
-function getExtensionElementRequiredErrorMessage(report) {
+function getExtensionElementRequiredErrorMessage(report, executionPlatform, executionPlatformVersion) {
   const {
     data,
     message
@@ -390,7 +390,7 @@ function getExtensionElementRequiredErrorMessage(report) {
   }
 
   if (requiredExtensionElement === 'zeebe:UserTask') {
-    return `${ getIndefiniteArticle(typeString) } <${ typeString }> must have <Implementation: Zeebe user task>`;
+    return `${ getIndefiniteArticle(typeString) } <${ typeString }> with <Implementation: Job worker> is deprecated on ${ getExecutionPlatformLabel(executionPlatform, executionPlatformVersion) }. Consider migrating to <Implementation: Zeebe user task>.`;
   }
 
   return message;

--- a/lib/utils/error-messages.js
+++ b/lib/utils/error-messages.js
@@ -313,7 +313,7 @@ function getExtensionElementNotAllowedErrorMessage(report, executionPlatform, ex
   }
 
   if (is(extensionElement, 'zeebe:UserTask')) {
-    return getSupportedMessage('A <User Task> with <Implementation: Zeebe user task>', executionPlatform, executionPlatformVersion, allowedVersion);
+    return getSupportedMessage('A <User Task> with <Implementation: Camunda user task>', executionPlatform, executionPlatformVersion, allowedVersion);
   }
 
   if (is(node, 'bpmn:ScriptTask') && is(extensionElement, 'zeebe:Script')) {
@@ -390,7 +390,7 @@ function getExtensionElementRequiredErrorMessage(report, executionPlatform, exec
   }
 
   if (requiredExtensionElement === 'zeebe:UserTask') {
-    return `${ getIndefiniteArticle(typeString) } <${ typeString }> with <Implementation: Job worker> is deprecated on ${ getExecutionPlatformLabel(executionPlatform, executionPlatformVersion) }. Consider migrating to <Implementation: Zeebe user task>.`;
+    return `${ getIndefiniteArticle(typeString) } <${ typeString }> with <Implementation: Job worker> is deprecated on ${ getExecutionPlatformLabel(executionPlatform, executionPlatformVersion) }. Consider migrating to <Implementation: Camunda user task>.`;
   }
 
   return message;
@@ -570,7 +570,7 @@ function getPropertyRequiredErrorMessage(report, executionPlatform, executionPla
     return `${ getIndefiniteArticle(typeString) } <${ typeString }> with <Form type: Custom form key> must have a defined <Form key>`;
   }
 
-  // Zeebe User Task
+  // Camunda User Task
   if (is(node, 'zeebe:FormDefinition') && isZeebeUserTask(parentNode)) {
     if (isEmptyString(node.get('externalReference'))) {
       return `${ getIndefiniteArticle(typeString) } <${ typeString }> with <Form type: External reference> must have a defined <External reference>`;

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@bpmn-io/diagram-js-ui": "^0.2.3",
         "bpmn-moddle": "^9.0.1",
         "bpmnlint": "^10.3.1",
-        "bpmnlint-plugin-camunda-compat": "^2.28.1",
+        "bpmnlint-plugin-camunda-compat": "^2.29.0",
         "bpmnlint-utils": "^1.0.2",
         "camunda-bpmn-moddle": "^7.0.1",
         "clsx": "^2.0.0",
@@ -1712,9 +1712,9 @@
       }
     },
     "node_modules/bpmnlint-plugin-camunda-compat": {
-      "version": "2.28.1",
-      "resolved": "https://registry.npmjs.org/bpmnlint-plugin-camunda-compat/-/bpmnlint-plugin-camunda-compat-2.28.1.tgz",
-      "integrity": "sha512-HBs5mqru2txC11g8wJALYd1xAbB24BL1LiXZyWWfWtdhh467FfELmibHZ0U+MUwv1QX2lACMQfVqb/A8HFV9wA==",
+      "version": "2.29.0",
+      "resolved": "https://registry.npmjs.org/bpmnlint-plugin-camunda-compat/-/bpmnlint-plugin-camunda-compat-2.29.0.tgz",
+      "integrity": "sha512-kSvdxAWWY8PV71IXqNqDTkYFmsTjSKFsN296cWk7HdM1Iyv+jYSli4nW0nOXtrVj6ZLfH1jfdDYJmv6n3NfXTQ==",
       "license": "MIT",
       "dependencies": {
         "@bpmn-io/feel-lint": "^1.2.0",
@@ -8703,9 +8703,9 @@
       }
     },
     "bpmnlint-plugin-camunda-compat": {
-      "version": "2.28.1",
-      "resolved": "https://registry.npmjs.org/bpmnlint-plugin-camunda-compat/-/bpmnlint-plugin-camunda-compat-2.28.1.tgz",
-      "integrity": "sha512-HBs5mqru2txC11g8wJALYd1xAbB24BL1LiXZyWWfWtdhh467FfELmibHZ0U+MUwv1QX2lACMQfVqb/A8HFV9wA==",
+      "version": "2.29.0",
+      "resolved": "https://registry.npmjs.org/bpmnlint-plugin-camunda-compat/-/bpmnlint-plugin-camunda-compat-2.29.0.tgz",
+      "integrity": "sha512-kSvdxAWWY8PV71IXqNqDTkYFmsTjSKFsN296cWk7HdM1Iyv+jYSli4nW0nOXtrVj6ZLfH1jfdDYJmv6n3NfXTQ==",
       "requires": {
         "@bpmn-io/feel-lint": "^1.2.0",
         "@bpmn-io/moddle-utils": "^0.2.1",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@bpmn-io/diagram-js-ui": "^0.2.3",
     "bpmn-moddle": "^9.0.1",
     "bpmnlint": "^10.3.1",
-    "bpmnlint-plugin-camunda-compat": "^2.28.1",
+    "bpmnlint-plugin-camunda-compat": "^2.29.0",
     "bpmnlint-utils": "^1.0.2",
     "camunda-bpmn-moddle": "^7.0.1",
     "clsx": "^2.0.0",

--- a/test/spec/utils/error-messages.spec.js
+++ b/test/spec/utils/error-messages.spec.js
@@ -369,7 +369,7 @@ describe('utils/error-messages', function() {
           const errorMessage = getErrorMessage(report, 'Camunda Cloud', executionPlatformVersion);
 
           // then
-          expect(errorMessage).to.equal('A <User Task> with <Implementation: Zeebe user task> is only supported by Camunda 8.5 or newer');
+          expect(errorMessage).to.equal('A <User Task> with <Implementation: Camunda user task> is only supported by Camunda 8.5 or newer');
         });
 
 
@@ -695,7 +695,7 @@ describe('utils/error-messages', function() {
           const errorMessage = getErrorMessage(report, 'Camunda Cloud', executionPlatformVersion);
 
           // then
-          expect(errorMessage).to.equal('A <User Task> with <Implementation: Job worker> is deprecated on Camunda 8.6. Consider migrating to <Implementation: Zeebe user task>.');
+          expect(errorMessage).to.equal('A <User Task> with <Implementation: Job worker> is deprecated on Camunda 8.6. Consider migrating to <Implementation: Camunda user task>.');
         });
 
       });
@@ -1389,7 +1389,7 @@ describe('utils/error-messages', function() {
         });
 
 
-        it('should adjust (Zeebe User Task) (form ID) (Camunda 8.5 and newer)', async function() {
+        it('should adjust (Camunda User Task) (form ID) (Camunda 8.5 and newer)', async function() {
 
           // given
           const node = createElement('bpmn:UserTask', {
@@ -1453,7 +1453,7 @@ describe('utils/error-messages', function() {
         });
 
 
-        it('should adjust (Zeebe User Task) (external reference) (Camunda 8.5 and newer)', async function() {
+        it('should adjust (Camunda User Task) (external reference) (Camunda 8.5 and newer)', async function() {
 
           // given
           const node = createElement('bpmn:UserTask', {

--- a/test/spec/utils/error-messages.spec.js
+++ b/test/spec/utils/error-messages.spec.js
@@ -678,6 +678,26 @@ describe('utils/error-messages', function() {
           // then
           expect(errorMessage).to.equal('A <User Task> should have a defined <Form>');
         });
+
+
+        it('should adjust (zeebe:UserTask)', async function() {
+
+          // given
+          const executionPlatformVersion = '8.6';
+
+          const node = createElement('bpmn:UserTask');
+
+          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/zeebe-user-task');
+
+          const report = await getLintError(node, rule);
+
+          // when
+          const errorMessage = getErrorMessage(report, 'Camunda Cloud', executionPlatformVersion);
+
+          // then
+          expect(errorMessage).to.equal('A <User Task> with <Implementation: Job worker> is deprecated on Camunda 8.6. Consider migrating to <Implementation: Zeebe user task>.');
+        });
+
       });
 
 

--- a/test/spec/utils/error-messages.spec.js
+++ b/test/spec/utils/error-messages.spec.js
@@ -695,7 +695,7 @@ describe('utils/error-messages', function() {
           const errorMessage = getErrorMessage(report, 'Camunda Cloud', executionPlatformVersion);
 
           // then
-          expect(errorMessage).to.equal('A <User Task> with <Implementation: Job worker> is deprecated on Camunda 8.6. Consider migrating to <Implementation: Camunda user task>.');
+          expect(errorMessage).to.equal('A <User Task> with <Implementation: Job worker> managed by Camunda is deprecated. Consider migrating to <Implementation: Camunda user task>.');
         });
 
       });

--- a/test/spec/utils/properties-panel.spec.js
+++ b/test/spec/utils/properties-panel.spec.js
@@ -900,7 +900,7 @@ describe('utils/properties-panel', function() {
       });
 
 
-      it('user-task-form (Zeebe User Task) - Form ID (Camunda 8.5 and newer)', async function() {
+      it('user-task-form (Camunda User Task) - Form ID (Camunda 8.5 and newer)', async function() {
 
         // given
         const node = createElement('bpmn:UserTask', {
@@ -928,7 +928,7 @@ describe('utils/properties-panel', function() {
       });
 
 
-      it('user-task-form (Zeebe User Task) - External reference (Camunda 8.5 and newer)', async function() {
+      it('user-task-form (Camunda User Task) - External reference (Camunda 8.5 and newer)', async function() {
 
         // given
         const node = createElement('bpmn:UserTask', {


### PR DESCRIPTION
Related to https://github.com/camunda/camunda-modeler/issues/4690

Needs to integrate https://github.com/camunda/bpmnlint-plugin-camunda-compat/pull/183/commits first because the rule currently doesn't exist