### PR TITLE
Allow task listeners in Camunda 8.8 or newer

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -6,27 +6,20 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest ]
-        node-version: [ 20 ]
 
     runs-on: ${{ matrix.os }}
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Use Node.js
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v4
       with:
-        node-version: ${{ matrix.node-version }}
-    - name: Cache Node.js modules
-      uses: actions/cache@v2
-      with:
-        # npm cache files are stored in `~/.npm` on Linux/macOS
-        path: ~/.npm
-        key: ${{ runner.OS }}-node-${{ hashFiles('**/package-lock.json') }}
-        restore-keys: |
-          ${{ runner.OS }}-node-
-          ${{ runner.OS }}-
+        node-version: 20
+        cache: 'npm'
     - name: Install dependencies
       run: npm ci
+    - name: Setup project
+      uses: bpmn-io/actions/setup@latest
     - name: Build
       run: npm run all

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to [@camunda/linting](https://github.com/camunda/linting) ar
 
 ___Note:__ Yet to be released changes appear here._
 
+## 3.31.0
+
+* `FEAT`: allow task listeners in Camunda 8.8 or newer
+* `DEPS`: update to `bpmnlint-plugin-camunda-compat@2.30.0`
+
 ## 3.30.0
 
 * `FEAT`: rename "Zeebe user task" to "Camunda user task" ([#126](https://github.com/camunda/linting/pull/126))

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@bpmn-io/diagram-js-ui": "^0.2.3",
         "bpmn-moddle": "^9.0.1",
         "bpmnlint": "^10.3.1",
-        "bpmnlint-plugin-camunda-compat": "^2.29.0",
+        "bpmnlint-plugin-camunda-compat": "^2.30.0",
         "bpmnlint-utils": "^1.0.2",
         "camunda-bpmn-moddle": "^7.0.1",
         "clsx": "^2.0.0",
@@ -1712,9 +1712,9 @@
       }
     },
     "node_modules/bpmnlint-plugin-camunda-compat": {
-      "version": "2.29.0",
-      "resolved": "https://registry.npmjs.org/bpmnlint-plugin-camunda-compat/-/bpmnlint-plugin-camunda-compat-2.29.0.tgz",
-      "integrity": "sha512-kSvdxAWWY8PV71IXqNqDTkYFmsTjSKFsN296cWk7HdM1Iyv+jYSli4nW0nOXtrVj6ZLfH1jfdDYJmv6n3NfXTQ==",
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/bpmnlint-plugin-camunda-compat/-/bpmnlint-plugin-camunda-compat-2.30.0.tgz",
+      "integrity": "sha512-ITpEBUDoIv9N+HnZYKPwVvubLnjduWUmdn3CUqTILdkfzULdkbI5PwU7+YSPnGHLeh5L/UiZMzn+qa3pJzcpSQ==",
       "license": "MIT",
       "dependencies": {
         "@bpmn-io/feel-lint": "^1.2.0",
@@ -8703,9 +8703,9 @@
       }
     },
     "bpmnlint-plugin-camunda-compat": {
-      "version": "2.29.0",
-      "resolved": "https://registry.npmjs.org/bpmnlint-plugin-camunda-compat/-/bpmnlint-plugin-camunda-compat-2.29.0.tgz",
-      "integrity": "sha512-kSvdxAWWY8PV71IXqNqDTkYFmsTjSKFsN296cWk7HdM1Iyv+jYSli4nW0nOXtrVj6ZLfH1jfdDYJmv6n3NfXTQ==",
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/bpmnlint-plugin-camunda-compat/-/bpmnlint-plugin-camunda-compat-2.30.0.tgz",
+      "integrity": "sha512-ITpEBUDoIv9N+HnZYKPwVvubLnjduWUmdn3CUqTILdkfzULdkbI5PwU7+YSPnGHLeh5L/UiZMzn+qa3pJzcpSQ==",
       "requires": {
         "@bpmn-io/feel-lint": "^1.2.0",
         "@bpmn-io/moddle-utils": "^0.2.1",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@bpmn-io/diagram-js-ui": "^0.2.3",
     "bpmn-moddle": "^9.0.1",
     "bpmnlint": "^10.3.1",
-    "bpmnlint-plugin-camunda-compat": "^2.29.0",
+    "bpmnlint-plugin-camunda-compat": "^2.30.0",
     "bpmnlint-utils": "^1.0.2",
     "camunda-bpmn-moddle": "^7.0.1",
     "clsx": "^2.0.0",

--- a/test/spec/utils/error-messages.spec.js
+++ b/test/spec/utils/error-messages.spec.js
@@ -523,7 +523,7 @@ describe('utils/error-messages', function() {
           const errorMessage = getErrorMessage(report, 'Camunda Cloud', executionPlatformVersion);
 
           // then
-          expect(errorMessage).to.equal('A <User Task> with <Task listeners> is only supported by Camunda 8.7 or newer');
+          expect(errorMessage).to.equal('A <User Task> with <Task listeners> is only supported by Camunda 8.8 or newer');
         });
 
 


### PR DESCRIPTION
* deps: update to `bpmnlint-plugin-camunda-compat@2.30.0`
* feat: allow task listeners in Camunda 8.8 or newer

Related to https://github.com/camunda/camunda-modeler/issues/4799
