### PR TITLE
feat: support `bpmn:AdHocSubProcess`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ ___Note:__ Yet to be released changes appear here._
 ## 3.31.0
 
 * `FEAT`: allow task listeners in Camunda 8.8 or newer
-* `DEPS`: update to `bpmnlint-plugin-camunda-compat@2.30.0`
+* `FEAT`: support `bpmn:AdHocSubProcess` for Camunda 8.7 or newer
+* `DEPS`: update to `bpmnlint-plugin-camunda-compat@2.31.0`
+* `DEPS`: update to `zeebe-bpmn-moddle@1.9.0`
 
 ## 3.30.0
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@bpmn-io/diagram-js-ui": "^0.2.3",
         "bpmn-moddle": "^9.0.1",
         "bpmnlint": "^10.3.1",
-        "bpmnlint-plugin-camunda-compat": "^2.30.0",
+        "bpmnlint-plugin-camunda-compat": "^2.31.0",
         "bpmnlint-utils": "^1.0.2",
         "camunda-bpmn-moddle": "^7.0.1",
         "clsx": "^2.0.0",
@@ -20,7 +20,7 @@
         "min-dom": "^5.1.1",
         "modeler-moddle": "^0.2.0",
         "semver-compare": "^1.0.0",
-        "zeebe-bpmn-moddle": "^1.7.0"
+        "zeebe-bpmn-moddle": "^1.9.0"
       },
       "devDependencies": {
         "bpmn-js": "^17.11.1",
@@ -1712,10 +1712,9 @@
       }
     },
     "node_modules/bpmnlint-plugin-camunda-compat": {
-      "version": "2.30.0",
-      "resolved": "https://registry.npmjs.org/bpmnlint-plugin-camunda-compat/-/bpmnlint-plugin-camunda-compat-2.30.0.tgz",
-      "integrity": "sha512-ITpEBUDoIv9N+HnZYKPwVvubLnjduWUmdn3CUqTILdkfzULdkbI5PwU7+YSPnGHLeh5L/UiZMzn+qa3pJzcpSQ==",
-      "license": "MIT",
+      "version": "2.31.0",
+      "resolved": "https://registry.npmjs.org/bpmnlint-plugin-camunda-compat/-/bpmnlint-plugin-camunda-compat-2.31.0.tgz",
+      "integrity": "sha512-CbY/ySguL/RGNNVCILAml1Et1mX+vB5sB4I7kpY9wMz55dTMxpnLYXx9s5isklZpNnjY1FAA0mSFgs6/Fx8gfw==",
       "dependencies": {
         "@bpmn-io/feel-lint": "^1.2.0",
         "@bpmn-io/moddle-utils": "^0.2.1",
@@ -7287,10 +7286,9 @@
       }
     },
     "node_modules/zeebe-bpmn-moddle": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/zeebe-bpmn-moddle/-/zeebe-bpmn-moddle-1.7.0.tgz",
-      "integrity": "sha512-eZ6OXSt0c4n9V/oN/46gTlwDIS3GhWQLt9jbM5uS/YryB4yN8wdrrKrtw+TpyNy0SSKWXNDHyC83nCA2blPO3Q==",
-      "license": "MIT"
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/zeebe-bpmn-moddle/-/zeebe-bpmn-moddle-1.9.0.tgz",
+      "integrity": "sha512-Y9ncIdP4m1PKbIBDqSghwZud2eiiBpfygE0bTApGqtnGlJMA/6Xanl/J7ujxG5zREoAliwf6rJyJFk3FZ75AYg=="
     },
     "node_modules/zod": {
       "version": "3.23.8",
@@ -8703,9 +8701,9 @@
       }
     },
     "bpmnlint-plugin-camunda-compat": {
-      "version": "2.30.0",
-      "resolved": "https://registry.npmjs.org/bpmnlint-plugin-camunda-compat/-/bpmnlint-plugin-camunda-compat-2.30.0.tgz",
-      "integrity": "sha512-ITpEBUDoIv9N+HnZYKPwVvubLnjduWUmdn3CUqTILdkfzULdkbI5PwU7+YSPnGHLeh5L/UiZMzn+qa3pJzcpSQ==",
+      "version": "2.31.0",
+      "resolved": "https://registry.npmjs.org/bpmnlint-plugin-camunda-compat/-/bpmnlint-plugin-camunda-compat-2.31.0.tgz",
+      "integrity": "sha512-CbY/ySguL/RGNNVCILAml1Et1mX+vB5sB4I7kpY9wMz55dTMxpnLYXx9s5isklZpNnjY1FAA0mSFgs6/Fx8gfw==",
       "requires": {
         "@bpmn-io/feel-lint": "^1.2.0",
         "@bpmn-io/moddle-utils": "^0.2.1",
@@ -12743,9 +12741,9 @@
       "dev": true
     },
     "zeebe-bpmn-moddle": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/zeebe-bpmn-moddle/-/zeebe-bpmn-moddle-1.7.0.tgz",
-      "integrity": "sha512-eZ6OXSt0c4n9V/oN/46gTlwDIS3GhWQLt9jbM5uS/YryB4yN8wdrrKrtw+TpyNy0SSKWXNDHyC83nCA2blPO3Q=="
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/zeebe-bpmn-moddle/-/zeebe-bpmn-moddle-1.9.0.tgz",
+      "integrity": "sha512-Y9ncIdP4m1PKbIBDqSghwZud2eiiBpfygE0bTApGqtnGlJMA/6Xanl/J7ujxG5zREoAliwf6rJyJFk3FZ75AYg=="
     },
     "zod": {
       "version": "3.23.8",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@bpmn-io/diagram-js-ui": "^0.2.3",
     "bpmn-moddle": "^9.0.1",
     "bpmnlint": "^10.3.1",
-    "bpmnlint-plugin-camunda-compat": "^2.30.0",
+    "bpmnlint-plugin-camunda-compat": "^2.31.0",
     "bpmnlint-utils": "^1.0.2",
     "camunda-bpmn-moddle": "^7.0.1",
     "clsx": "^2.0.0",
@@ -40,7 +40,7 @@
     "min-dom": "^5.1.1",
     "modeler-moddle": "^0.2.0",
     "semver-compare": "^1.0.0",
-    "zeebe-bpmn-moddle": "^1.7.0"
+    "zeebe-bpmn-moddle": "^1.9.0"
   },
   "devDependencies": {
     "bpmn-js": "^17.11.1",


### PR DESCRIPTION
Support `bpmm:AdHocSubProcess` for Camunda 8.7 and newer.

Related to https://github.com/camunda/camunda-modeler/issues/4739