### PR TITLE
Support for `completionCondition` and `cancelRemainingInstances` on ad-hoc subprocess

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to [@camunda/linting](https://github.com/camunda/linting) ar
 
 ___Note:__ Yet to be released changes appear here._
 
+* `FEAT`: add ad-hoc subprocess completion support ([camunda/bpmnlint-plugin-camunda-compat#196](https://github.com/camunda/bpmnlint-plugin-camunda-compat/pull/196))
+* `DEPS`: update to `bpmn-js-properties-panel@5.34.0`
+* `DEPS`: update to `bpmnlint-plugin-camunda-compat@2.34.0`
+
 ## 3.34.0
 
 * `FEAT`: rework message on elements that should not be used ([bpmn-io/bpmnlint#173](https://github.com/bpmn-io/bpmnlint/pull/173))

--- a/lib/utils/properties-panel.js
+++ b/lib/utils/properties-panel.js
@@ -459,6 +459,10 @@ export function getErrorMessage(id, report) {
     return getNotSupportedMessage('', allowedVersion);
   }
 
+  if (id === 'cancelRemainingInstances' && type === ERROR_TYPES.PROPERTY_VALUE_NOT_ALLOWED) {
+    return 'Must be checked.';
+  }
+
   if (id === 'targetProcessId') {
     return 'Process ID must be defined.';
   }

--- a/lib/utils/properties-panel.js
+++ b/lib/utils/properties-panel.js
@@ -229,6 +229,14 @@ export function getEntryIds(report) {
     return [ 'multiInstance-completionCondition' ];
   }
 
+  if (isPropertyError(data, 'completionCondition', 'bpmn:AdHocSubProcess')) {
+    return [ 'completionCondition' ];
+  }
+
+  if (isPropertyError(data, 'cancelRemainingInstances', 'bpmn:AdHocSubProcess')) {
+    return [ 'cancelRemainingInstances' ];
+  }
+
   if (TIMER_PROPERTIES.some(property =>
     isOneOfPropertiesRequiredError(data, property, 'bpmn:TimerEventDefinition'))
   ) {
@@ -445,6 +453,10 @@ export function getErrorMessage(id, report) {
 
   if (id === 'multiInstance-outputElement') {
     return 'Output element must be defined.';
+  }
+
+  if (id === 'completionCondition' && type === ERROR_TYPES.PROPERTY_NOT_ALLOWED) {
+    return getNotSupportedMessage('', allowedVersion);
   }
 
   if (id === 'targetProcessId') {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@bpmn-io/diagram-js-ui": "^0.2.3",
         "bpmn-moddle": "^9.0.1",
         "bpmnlint": "^11.4.1",
-        "bpmnlint-plugin-camunda-compat": "^2.33.1",
+        "bpmnlint-plugin-camunda-compat": "^2.34.0",
         "bpmnlint-utils": "^1.0.2",
         "camunda-bpmn-moddle": "^7.0.1",
         "clsx": "^2.0.0",
@@ -25,7 +25,7 @@
       "devDependencies": {
         "bpmn-js": "^18.3.1",
         "bpmn-js-element-templates": "^2.5.3",
-        "bpmn-js-properties-panel": "^5.32.1",
+        "bpmn-js-properties-panel": "^5.34.0",
         "camunda-bpmn-js-behaviors": "^1.9.1",
         "chai": "^4.5.0",
         "cross-env": "^7.0.3",
@@ -1580,9 +1580,9 @@
       }
     },
     "node_modules/bpmn-js-properties-panel": {
-      "version": "5.32.1",
-      "resolved": "https://registry.npmjs.org/bpmn-js-properties-panel/-/bpmn-js-properties-panel-5.32.1.tgz",
-      "integrity": "sha512-SZXkyI5jK04SMgs+J0XpyQfAXaT38PJKVdumr5RAu2oS5g1exkKBCpgs8j1D+Ee3nUUkQk9DFtPRnrQsfjKh+w==",
+      "version": "5.34.0",
+      "resolved": "https://registry.npmjs.org/bpmn-js-properties-panel/-/bpmn-js-properties-panel-5.34.0.tgz",
+      "integrity": "sha512-Uc7kdhIjWg9pGW11MW5sgBUxKVeids9Y4f3ShEUmccXLiWcWgeevt09L06uhNDNIPVOpXbG+jLKWxDyyLIGfnw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1685,9 +1685,9 @@
       }
     },
     "node_modules/bpmnlint-plugin-camunda-compat": {
-      "version": "2.33.1",
-      "resolved": "https://registry.npmjs.org/bpmnlint-plugin-camunda-compat/-/bpmnlint-plugin-camunda-compat-2.33.1.tgz",
-      "integrity": "sha512-0kxDJM1rYd68qVofho6GHoDGadKboMXefn8SZWPDnaY0/kac8nO12GX2J6htCjHr4Bb7NziYtZKZvEJpmqe3IA==",
+      "version": "2.34.0",
+      "resolved": "https://registry.npmjs.org/bpmnlint-plugin-camunda-compat/-/bpmnlint-plugin-camunda-compat-2.34.0.tgz",
+      "integrity": "sha512-1Mk9EU3OTQI/Vbzyei4LdeklLFrJdMNsxlI5dC07PybT4aTGMVSF3iB0w8DE20UXjAUBJq52Ff1HeFdbnO+qRg==",
       "license": "MIT",
       "dependencies": {
         "@bpmn-io/feel-lint": "^1.4.0",
@@ -8512,9 +8512,9 @@
       }
     },
     "bpmn-js-properties-panel": {
-      "version": "5.32.1",
-      "resolved": "https://registry.npmjs.org/bpmn-js-properties-panel/-/bpmn-js-properties-panel-5.32.1.tgz",
-      "integrity": "sha512-SZXkyI5jK04SMgs+J0XpyQfAXaT38PJKVdumr5RAu2oS5g1exkKBCpgs8j1D+Ee3nUUkQk9DFtPRnrQsfjKh+w==",
+      "version": "5.34.0",
+      "resolved": "https://registry.npmjs.org/bpmn-js-properties-panel/-/bpmn-js-properties-panel-5.34.0.tgz",
+      "integrity": "sha512-Uc7kdhIjWg9pGW11MW5sgBUxKVeids9Y4f3ShEUmccXLiWcWgeevt09L06uhNDNIPVOpXbG+jLKWxDyyLIGfnw==",
       "dev": true,
       "requires": {
         "@bpmn-io/extract-process-variables": "^1.0.0",
@@ -8571,9 +8571,9 @@
       }
     },
     "bpmnlint-plugin-camunda-compat": {
-      "version": "2.33.1",
-      "resolved": "https://registry.npmjs.org/bpmnlint-plugin-camunda-compat/-/bpmnlint-plugin-camunda-compat-2.33.1.tgz",
-      "integrity": "sha512-0kxDJM1rYd68qVofho6GHoDGadKboMXefn8SZWPDnaY0/kac8nO12GX2J6htCjHr4Bb7NziYtZKZvEJpmqe3IA==",
+      "version": "2.34.0",
+      "resolved": "https://registry.npmjs.org/bpmnlint-plugin-camunda-compat/-/bpmnlint-plugin-camunda-compat-2.34.0.tgz",
+      "integrity": "sha512-1Mk9EU3OTQI/Vbzyei4LdeklLFrJdMNsxlI5dC07PybT4aTGMVSF3iB0w8DE20UXjAUBJq52Ff1HeFdbnO+qRg==",
       "requires": {
         "@bpmn-io/feel-lint": "^1.4.0",
         "@bpmn-io/moddle-utils": "^0.2.1",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@bpmn-io/diagram-js-ui": "^0.2.3",
     "bpmn-moddle": "^9.0.1",
     "bpmnlint": "^11.4.1",
-    "bpmnlint-plugin-camunda-compat": "^2.33.1",
+    "bpmnlint-plugin-camunda-compat": "^2.34.0",
     "bpmnlint-utils": "^1.0.2",
     "camunda-bpmn-moddle": "^7.0.1",
     "clsx": "^2.0.0",
@@ -45,7 +45,7 @@
   "devDependencies": {
     "bpmn-js": "^18.3.1",
     "bpmn-js-element-templates": "^2.5.3",
-    "bpmn-js-properties-panel": "^5.32.1",
+    "bpmn-js-properties-panel": "^5.34.0",
     "camunda-bpmn-js-behaviors": "^1.9.1",
     "chai": "^4.5.0",
     "cross-env": "^7.0.3",

--- a/test/spec/utils/properties-panel.spec.js
+++ b/test/spec/utils/properties-panel.spec.js
@@ -649,6 +649,7 @@ describe('utils/properties-panel', function() {
           expectErrorMessage(entryIds[ 0 ], 'Only supported by Camunda 8.8 or newer.', report);
         });
 
+
         it('Cancel remaining instances (Camunda 8.7 and older)', async function() {
 
           // given
@@ -1613,6 +1614,7 @@ describe('utils/properties-panel', function() {
           expect(entryIds).to.eql([ 'multiInstance-completionCondition' ]);
         });
 
+
         it('should return error for ad-hoc subprocess completion condition', async function() {
           const node = createElement('bpmn:AdHocSubProcess', {
             completionCondition: createElement('bpmn:FormalExpression', {
@@ -1628,6 +1630,7 @@ describe('utils/properties-panel', function() {
           // then
           expect(entryIds).to.eql([ 'completionCondition' ]);
         });
+
 
         it('should return error for conditional flow', async function() {
           const node = createElement('bpmn:SequenceFlow', {

--- a/test/spec/utils/properties-panel.spec.js
+++ b/test/spec/utils/properties-panel.spec.js
@@ -670,7 +670,7 @@ describe('utils/properties-panel', function() {
           // then
           expect(entryIds).to.eql([ 'cancelRemainingInstances' ]);
 
-          expectNoErrorMessage(entryIds[ 0 ], report);
+          expectErrorMessage(entryIds[ 0 ], 'Must be checked.', report);
         });
       });
 

--- a/test/spec/utils/properties-panel.spec.js
+++ b/test/spec/utils/properties-panel.spec.js
@@ -622,6 +622,56 @@ describe('utils/properties-panel', function() {
         expectErrorMessage(entryIds[ 0 ], 'Output element must be defined.', report);
       });
 
+      describe('ad-hoc-subprocess', async function() {
+
+        it('Completion condition (Camunda 8.7 and older)', async function() {
+
+          // given
+          const node = createElement('bpmn:AdHocSubProcess', {
+            completionCondition: createElement('bpmn:FormalExpression', {
+              body: '=true'
+            }),
+            flowElements: [
+              createElement('bpmn:Task')
+            ],
+          });
+
+          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/ad-hoc-sub-process');
+
+          const report = await getLintError(node, rule, { version: '8.7' });
+
+          // when
+          const entryIds = getEntryIds(report);
+
+          // then
+          expect(entryIds).to.eql([ 'completionCondition' ]);
+
+          expectErrorMessage(entryIds[ 0 ], 'Only supported by Camunda 8.8 or newer.', report);
+        });
+
+        it('Cancel remaining instances (Camunda 8.7 and older)', async function() {
+
+          // given
+          const node = createElement('bpmn:AdHocSubProcess', {
+            cancelRemainingInstances: false,
+            flowElements: [
+              createElement('bpmn:Task')
+            ],
+          });
+
+          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/ad-hoc-sub-process');
+
+          const report = await getLintError(node, rule, { version: '8.7' });
+
+          // when
+          const entryIds = getEntryIds(report);
+
+          // then
+          expect(entryIds).to.eql([ 'cancelRemainingInstances' ]);
+
+          expectNoErrorMessage(entryIds[ 0 ], report);
+        });
+      });
 
       describe('called-element', function() {
 
@@ -1563,6 +1613,21 @@ describe('utils/properties-panel', function() {
           expect(entryIds).to.eql([ 'multiInstance-completionCondition' ]);
         });
 
+        it('should return error for ad-hoc subprocess completion condition', async function() {
+          const node = createElement('bpmn:AdHocSubProcess', {
+            completionCondition: createElement('bpmn:FormalExpression', {
+              body: INVALID_FEEL
+            })
+          });
+
+          const report = await getLintError(node, rule);
+
+          // when
+          const entryIds = getEntryIds(report);
+
+          // then
+          expect(entryIds).to.eql([ 'completionCondition' ]);
+        });
 
         it('should return error for conditional flow', async function() {
           const node = createElement('bpmn:SequenceFlow', {


### PR DESCRIPTION
### Proposed Changes

Adds integration for linting rules added in https://github.com/camunda/bpmnlint-plugin-camunda-compat/pull/196

![image](https://github.com/user-attachments/assets/9e3a0f7f-8af3-4b3a-bf9b-7ee515108ecb)

Related to https://github.com/camunda/camunda-modeler/issues/4850

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] __Brief textual description__ of the changes present
* [x] __Visual demo__ attached
* [ ] __Steps to try out__ present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->
