### PR TITLE
Not allow escalationBoundaryEvents on tasks

### DIFF
--- a/lib/utils/error-messages.js
+++ b/lib/utils/error-messages.js
@@ -157,6 +157,10 @@ export function getErrorMessage(report, executionPlatform, executionPlatformVers
     return getLoopNotAllowedErrorMessage(report);
   }
 
+  if (type === ERROR_TYPES.ATTACHED_TO_REF_ELEMENT_TYPE_NOT_ALLOWED) {
+    return getAttachedToRefElementTypeNotAllowed(report);
+  }
+
   return message;
 }
 
@@ -796,6 +800,17 @@ function getLoopNotAllowedErrorMessage(report) {
   const { elements } = data;
 
   return `A <Process> is not allowed to contain a straight-through processing loop: ${ elements.map(element => `<${ element }>`).join(', ') }`;
+}
+
+function getAttachedToRefElementTypeNotAllowed(report) {
+  const { data } = report;
+
+  const { node , attachedToRef } = data;
+
+  const nodeTypeString = getTypeString(node);
+  const attachedToTypeString = getTypeString(attachedToRef);
+
+  return `${ getIndefiniteArticle(nodeTypeString) } <${nodeTypeString}> is not allowed on ${ getIndefiniteArticle(attachedToTypeString, false) } <${attachedToTypeString}>`;
 }
 
 function isEmptyString(value) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@bpmn-io/diagram-js-ui": "^0.2.3",
         "bpmn-moddle": "^9.0.1",
         "bpmnlint": "^11.4.1",
-        "bpmnlint-plugin-camunda-compat": "^2.34.0",
+        "bpmnlint-plugin-camunda-compat": "^2.34.1",
         "bpmnlint-utils": "^1.0.2",
         "camunda-bpmn-moddle": "^7.0.1",
         "clsx": "^2.0.0",
@@ -1685,9 +1685,9 @@
       }
     },
     "node_modules/bpmnlint-plugin-camunda-compat": {
-      "version": "2.34.0",
-      "resolved": "https://registry.npmjs.org/bpmnlint-plugin-camunda-compat/-/bpmnlint-plugin-camunda-compat-2.34.0.tgz",
-      "integrity": "sha512-1Mk9EU3OTQI/Vbzyei4LdeklLFrJdMNsxlI5dC07PybT4aTGMVSF3iB0w8DE20UXjAUBJq52Ff1HeFdbnO+qRg==",
+      "version": "2.34.1",
+      "resolved": "https://registry.npmjs.org/bpmnlint-plugin-camunda-compat/-/bpmnlint-plugin-camunda-compat-2.34.1.tgz",
+      "integrity": "sha512-M6FLDjtuoracGLjeenAyN1vsnqJH0bcqb0Zr5bm5ptxQUuT+CyiINCfbkzUPwQ68gypiZCXloUVraqa2QFXjGA==",
       "license": "MIT",
       "dependencies": {
         "@bpmn-io/feel-lint": "^1.4.0",
@@ -8571,9 +8571,9 @@
       }
     },
     "bpmnlint-plugin-camunda-compat": {
-      "version": "2.34.0",
-      "resolved": "https://registry.npmjs.org/bpmnlint-plugin-camunda-compat/-/bpmnlint-plugin-camunda-compat-2.34.0.tgz",
-      "integrity": "sha512-1Mk9EU3OTQI/Vbzyei4LdeklLFrJdMNsxlI5dC07PybT4aTGMVSF3iB0w8DE20UXjAUBJq52Ff1HeFdbnO+qRg==",
+      "version": "2.34.1",
+      "resolved": "https://registry.npmjs.org/bpmnlint-plugin-camunda-compat/-/bpmnlint-plugin-camunda-compat-2.34.1.tgz",
+      "integrity": "sha512-M6FLDjtuoracGLjeenAyN1vsnqJH0bcqb0Zr5bm5ptxQUuT+CyiINCfbkzUPwQ68gypiZCXloUVraqa2QFXjGA==",
       "requires": {
         "@bpmn-io/feel-lint": "^1.4.0",
         "@bpmn-io/moddle-utils": "^0.2.1",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@bpmn-io/diagram-js-ui": "^0.2.3",
     "bpmn-moddle": "^9.0.1",
     "bpmnlint": "^11.4.1",
-    "bpmnlint-plugin-camunda-compat": "^2.34.0",
+    "bpmnlint-plugin-camunda-compat": "^2.34.1",
     "bpmnlint-utils": "^1.0.2",
     "camunda-bpmn-moddle": "^7.0.1",
     "clsx": "^2.0.0",

--- a/test/spec/utils/error-messages.spec.js
+++ b/test/spec/utils/error-messages.spec.js
@@ -2480,6 +2480,30 @@ describe('utils/error-messages', function() {
       });
 
 
+      describe('attached to ref element type not allowed', function() {
+
+        it('should adjust', async function() {
+
+          const node = createElement('bpmn:BoundaryEvent', {
+            attachedToRef: createElement('bpmn:UserTask'),
+            cancelActivity: false,
+            eventDefinitions: [
+              createElement('bpmn:EscalationEventDefinition')
+            ]
+          });
+
+          // when
+          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/escalation-boundary-event-attached-to-ref');
+          const report = await getLintError(node, rule);
+          const errorMessage = getErrorMessage(report);
+
+          // then
+          expect(errorMessage).to.equal('An <Escalation Boundary Event> is not allowed on a <User Task>');
+        });
+
+      });
+
+
       describe('loop not allowed', function() {
 
         it('should adjust', async function() {


### PR DESCRIPTION
Related to camunda/camunda-modeler#4859

### Proposed Changes

Only not Allow BoundaryEvent on Tasks (via dep update) and adjust the related error message

<!--
Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.
--> 

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] __Brief textual description__ of the changes present
* [ ] __Visual demo__ attached
* [ ] __Steps to try out__ present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->
