### PR TITLE
Only adjust message when value is required

### DIFF
--- a/lib/utils/error-messages.js
+++ b/lib/utils/error-messages.js
@@ -486,6 +486,10 @@ function getPropertyRequiredErrorMessage(report, executionPlatform, executionPla
     requiredProperty
   } = data;
 
+  function isRequiredProperty(requiredPropertyToLookUp) {
+    return requiredProperty === requiredPropertyToLookUp || (isArray(requiredProperty) && requiredProperty.includes(requiredPropertyToLookUp));
+  }
+
   const typeString = getTypeString(parentNode || node);
 
   if (parentNode && is(parentNode, 'bpmn:BusinessRuleTask') && is(node, 'zeebe:CalledDecision') && requiredProperty === 'decisionId') {
@@ -576,14 +580,14 @@ function getPropertyRequiredErrorMessage(report, executionPlatform, executionPla
 
   // Camunda User Task
   if (is(node, 'zeebe:FormDefinition') && isZeebeUserTask(parentNode)) {
-    if (isEmptyString(node.get('externalReference'))) {
+    if (isRequiredProperty('externalReference') && isEmptyString(node.get('externalReference'))) {
       return `${ getIndefiniteArticle(typeString) } <${ typeString }> with <Form type: External reference> must have a defined <External reference>`;
-    } else if (isEmptyString(node.get('formId'))) {
+    } else if (isRequiredProperty('formId') && isEmptyString(node.get('formId'))) {
       return `${ getIndefiniteArticle(typeString) } <${ typeString }> with <Form type: Camunda Form> must have a defined <Form ID>`;
     }
   }
 
-  if (is(node, 'zeebe:FormDefinition') && isArray(requiredProperty) && requiredProperty.includes('formId') && isEmptyString(node.get('formId'))) {
+  if (is(node, 'zeebe:FormDefinition') && isRequiredProperty('formId') && isEmptyString(node.get('formId'))) {
     return `${ getIndefiniteArticle(typeString) } <${ typeString }> with <Form type: Camunda form (linked)> must have a defined <Form ID>`;
   }
 

--- a/test/spec/utils/error-messages.spec.js
+++ b/test/spec/utils/error-messages.spec.js
@@ -1415,6 +1415,33 @@ describe('utils/error-messages', function() {
         });
 
 
+        it('should adjust (versionTag) (Camunda 8.6 and newer)', async function() {
+
+          // given
+          const node = createElement('bpmn:UserTask', {
+            extensionElements: createElement('bpmn:ExtensionElements', {
+              values: [
+                createElement('zeebe:FormDefinition', {
+                  formId: 'set',
+                  bindingType: 'versionTag',
+                  versionTag:''
+                })
+              ]
+            })
+          });
+
+          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/version-tag');
+
+          const report = await getLintError(node, rule, { version: '8.6' });
+
+          // when
+          const errorMessage = getErrorMessage(report);
+
+          // then
+          expect(errorMessage).to.equal('A <User Task> with <Binding: version tag> must have a defined <Version tag>');
+        });
+
+
         it('should adjust (body)', async function() {
 
           // given


### PR DESCRIPTION
Related to https://github.com/camunda/camunda-modeler/issues/4872

### Proposed Changes

By limiting the formId message adjuster to only trigger when formId is required, now the proper versionTag adjuster works

<!--
Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.
--> 

<img width="1028" alt="image" src="https://github.com/user-attachments/assets/ce3e37e7-f4cb-4d27-ad29-4771b16e3070" />

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] __Brief textual description__ of the changes present
* [x] __Visual demo__ attached
* [ ] __Steps to try out__ present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->
