### PR TITLE
feat: adjust `variable-name` rule errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to [@camunda/linting](https://github.com/camunda/linting) ar
 
 ___Note:__ Yet to be released changes appear here._
 
+* `FEAT`: adjust `variable-name` rule errors
+
 ## 3.47.0
 
 * `FEAT`: add `conditional-event` rule to Camunda Cloud 8.9 rules ([camunda/bpmnlint-plugin-camunda-compat#222](https://github.com/camunda/bpmnlint-plugin-camunda-compat/pull/222), [#150](https://github.com/camunda/linting/pull/150))

--- a/lib/utils/error-messages.js
+++ b/lib/utils/error-messages.js
@@ -806,16 +806,16 @@ function getPropertyValueNotAllowedErrorMessage(report, executionPlatform, execu
   }
 
   if (
-    isAny(node, [
+    (isAny(node, [
       'zeebe:Input',
       'zeebe:Output'
-    ]) && property === 'target' ||
-    isAny(node, [
+    ]) && property === 'target') ||
+    (isAny(node, [
       'zeebe:Script',
       'zeebe:CalledDecision'
-    ]) && property === 'resultVariable' ||
-    is(node, 'zeebe:AdHoc') && property === 'outputCollection' ||
-    is(node, 'zeebe:LoopCharacteristics') && [ 'inputElement', 'outputCollection' ].includes(property)
+    ]) && property === 'resultVariable') ||
+    (is(node, 'zeebe:AdHoc') && property === 'outputCollection') ||
+    (is(node, 'zeebe:LoopCharacteristics') && [ 'inputElement', 'outputCollection' ].includes(property))
   ) {
     return 'Variable name must start with a letter or an underscore, and may contain only letters, digits, underscores, and dots.';
   }

--- a/lib/utils/error-messages.js
+++ b/lib/utils/error-messages.js
@@ -805,6 +805,21 @@ function getPropertyValueNotAllowedErrorMessage(report, executionPlatform, execu
     return getSupportedMessage(`${ getIndefiniteArticle(typeString) } <${ typeString }> with <Binding: ${ bindingTypeString }>`, executionPlatform, executionPlatformVersion, allowedVersion);
   }
 
+  if (
+    isAny(node, [
+      'zeebe:Input',
+      'zeebe:Output'
+    ]) && property === 'target' ||
+    isAny(node, [
+      'zeebe:Script',
+      'zeebe:CalledDecision'
+    ]) && property === 'resultVariable' ||
+    is(node, 'zeebe:AdHoc') && property === 'outputCollection' ||
+    is(node, 'zeebe:LoopCharacteristics') && [ 'inputElement', 'outputCollection' ].includes(property)
+  ) {
+    return 'Variable name must start with a letter or an underscore, and may contain only letters, digits, underscores, and dots.';
+  }
+
   return message;
 }
 

--- a/lib/utils/properties-panel.js
+++ b/lib/utils/properties-panel.js
@@ -280,22 +280,6 @@ export function getEntryIds(report) {
     }
   }
 
-  if (isPropertyError(data, 'target', 'zeebe:Input')) {
-    const index = path[ path.length - 2 ];
-
-    return [ `${ id }-input-${ index }-target` ];
-  }
-
-  if (isPropertyError(data, 'target', 'zeebe:Output')) {
-    const index = path[ path.length - 2 ];
-
-    return [ `${ id }-output-${ index }-target` ];
-  }
-
-  if (isPropertyError(data, 'inputElement', 'zeebe:LoopCharacteristics')) {
-    return [ 'multiInstance-inputElement' ];
-  }
-
   if (isType(data, 'zeebe:LoopCharacteristics')) {
     return [ `multiInstance-${getPropertyName(data)}` ];
   }

--- a/lib/utils/properties-panel.js
+++ b/lib/utils/properties-panel.js
@@ -15,6 +15,8 @@ const TIMER_PROPERTIES = [
   'timeCycle'
 ];
 
+const INVALID_VARIABLE_NAME_ERROR = 'Must be a valid variable name.';
+
 /**
  * Get errors for a given element.
  *
@@ -278,6 +280,22 @@ export function getEntryIds(report) {
     }
   }
 
+  if (isPropertyError(data, 'target', 'zeebe:Input')) {
+    const index = path[ path.length - 2 ];
+
+    return [ `${ id }-input-${ index }-target` ];
+  }
+
+  if (isPropertyError(data, 'target', 'zeebe:Output')) {
+    const index = path[ path.length - 2 ];
+
+    return [ `${ id }-output-${ index }-target` ];
+  }
+
+  if (isPropertyError(data, 'inputElement', 'zeebe:LoopCharacteristics')) {
+    return [ 'multiInstance-inputElement' ];
+  }
+
   if (isType(data, 'zeebe:LoopCharacteristics')) {
     return [ `multiInstance-${getPropertyName(data)}` ];
   }
@@ -457,10 +475,6 @@ export function getErrorMessage(id, report) {
     return 'FEEL expression must be defined.';
   }
 
-  if (id === 'resultVariable') {
-    return 'Result variable must be defined.';
-  }
-
   if (id === 'errorCode' && type === ERROR_TYPES.PROPERTY_REQUIRED) {
     return 'Code must be defined.';
   }
@@ -479,10 +493,6 @@ export function getErrorMessage(id, report) {
 
   if (id === 'multiInstance-inputCollection') {
     return 'Input collection must be defined.';
-  }
-
-  if (id === 'multiInstance-outputCollection') {
-    return 'Output collection must be defined.';
   }
 
   if (id === 'multiInstance-outputElement') {
@@ -652,6 +662,52 @@ export function getErrorMessage(id, report) {
     return 'Variable name must be defined.';
   }
 
+  if (/^.+-(?:input|output)-[0-9]+-target$/.test(id) && type === ERROR_TYPES.PROPERTY_VALUE_NOT_ALLOWED) {
+    return INVALID_VARIABLE_NAME_ERROR;
+  }
+
+  if (id === 'resultVariable') {
+    if (type === ERROR_TYPES.PROPERTY_REQUIRED) {
+      return 'Result variable must be defined.';
+    } else if (type === ERROR_TYPES.PROPERTY_VALUE_NOT_ALLOWED) {
+      return INVALID_VARIABLE_NAME_ERROR;
+    }
+  }
+
+  if (id === 'multiInstance-outputCollection') {
+    if (type === ERROR_TYPES.PROPERTY_DEPENDENT_REQUIRED || type === ERROR_TYPES.PROPERTY_REQUIRED) {
+      return 'Output collection must be defined.';
+    } else if (type === ERROR_TYPES.PROPERTY_VALUE_NOT_ALLOWED) {
+      return INVALID_VARIABLE_NAME_ERROR;
+    }
+  }
+
+  if (id === 'multiInstance-inputElement') {
+    if (type === ERROR_TYPES.PROPERTY_REQUIRED) {
+      return 'Input element must be defined.';
+    } else if (type === ERROR_TYPES.PROPERTY_VALUE_NOT_ALLOWED) {
+      return INVALID_VARIABLE_NAME_ERROR;
+    }
+  }
+
+  if (id === 'adHocOutputCollection') {
+    if (type === ERROR_TYPES.PROPERTY_DEPENDENT_REQUIRED || type === ERROR_TYPES.PROPERTY_REQUIRED) {
+      return 'Output collection must be defined.';
+    } else if (type === ERROR_TYPES.PROPERTY_NOT_ALLOWED) {
+      return getNotSupportedMessage('Output collection', allowedVersion);
+    } else if (type === ERROR_TYPES.PROPERTY_VALUE_NOT_ALLOWED) {
+      return INVALID_VARIABLE_NAME_ERROR;
+    }
+  }
+
+  if (id === 'adHocOutputElement') {
+    if (type === ERROR_TYPES.PROPERTY_DEPENDENT_REQUIRED || type === ERROR_TYPES.PROPERTY_REQUIRED) {
+      return 'Output element must be defined.';
+    } else if (type === ERROR_TYPES.PROPERTY_NOT_ALLOWED) {
+      return getNotSupportedMessage('Output element', allowedVersion);
+    }
+  }
+
   if (id === 'bindingType') {
     return getNotSupportedMessage('', allowedVersion);
   }
@@ -662,10 +718,6 @@ export function getErrorMessage(id, report) {
     } else {
       return 'Version tag must be defined.';
     }
-  }
-
-  if (isPropertyDependentRequiredError(data, 'outputCollection', 'zeebe:AdHoc')) {
-    return 'Output collection must be defined.';
   }
 
   if (isPropertyDependentRequiredError(data, 'outputElement', 'zeebe:AdHoc')) {

--- a/test/spec/utils/error-messages.spec.js
+++ b/test/spec/utils/error-messages.spec.js
@@ -2542,6 +2542,207 @@ describe('utils/error-messages', function() {
           // then
           expect(errorMessage).to.equal('An interrupting <Timer Start Event> in an <Event Sub Process> placed in an <Ad Hoc Sub Process> is not supported by Camunda 8.7');
         });
+
+
+        describe('variable name invalid', function() {
+
+          it('should adjust (input variable)', async function() {
+
+            // given
+            const node = createElement('bpmn:ServiceTask', {
+              extensionElements: createElement('bpmn:ExtensionElements', {
+                values: [
+                  createElement('zeebe:IoMapping', {
+                    inputParameters: [
+                      createElement('zeebe:Input', {
+                        source: 'foo',
+                        target: '1invalid'
+                      })
+                    ]
+                  })
+                ]
+              })
+            });
+
+            const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/variable-name');
+
+            const report = await getLintError(node, rule);
+
+            // when
+            const errorMessage = getErrorMessage(report, 'Camunda Cloud', '1.0');
+
+            // then
+            expect(errorMessage).to.equal('Variable name must start with a letter or an underscore, and may contain only letters, digits, underscores, and dots.');
+          });
+
+
+          it('should adjust (output variable)', async function() {
+
+            // given
+            const node = createElement('bpmn:ServiceTask', {
+              extensionElements: createElement('bpmn:ExtensionElements', {
+                values: [
+                  createElement('zeebe:IoMapping', {
+                    outputParameters: [
+                      createElement('zeebe:Output', {
+                        source: 'foo',
+                        target: '1invalid'
+                      })
+                    ]
+                  })
+                ]
+              })
+            });
+
+            const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/variable-name');
+
+            const report = await getLintError(node, rule);
+
+            // when
+            const errorMessage = getErrorMessage(report, 'Camunda Cloud', '1.0');
+
+            // then
+            expect(errorMessage).to.equal('Variable name must start with a letter or an underscore, and may contain only letters, digits, underscores, and dots.');
+          });
+
+
+          it('should adjust (script task result variable)', async function() {
+
+            // given
+            const node = createElement('bpmn:ScriptTask', {
+              extensionElements: createElement('bpmn:ExtensionElements', {
+                values: [
+                  createElement('zeebe:Script', {
+                    expression: '=foo',
+                    resultVariable: '1invalid'
+                  })
+                ]
+              })
+            });
+
+            const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/variable-name');
+
+            const report = await getLintError(node, rule);
+
+            // when
+            const errorMessage = getErrorMessage(report, 'Camunda Cloud', '8.2');
+
+            // then
+            expect(errorMessage).to.equal('Variable name must start with a letter or an underscore, and may contain only letters, digits, underscores, and dots.');
+          });
+
+
+          it('should adjust (business rule task result variable)', async function() {
+
+            // given
+            const node = createElement('bpmn:BusinessRuleTask', {
+              extensionElements: createElement('bpmn:ExtensionElements', {
+                values: [
+                  createElement('zeebe:CalledDecision', {
+                    decisionId: 'decision',
+                    resultVariable: '1invalid'
+                  })
+                ]
+              })
+            });
+
+            const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/variable-name');
+
+            const report = await getLintError(node, rule);
+
+            // when
+            const errorMessage = getErrorMessage(report, 'Camunda Cloud', '1.3');
+
+            // then
+            expect(errorMessage).to.equal('Variable name must start with a letter or an underscore, and may contain only letters, digits, underscores, and dots.');
+          });
+
+
+          it('should adjust (ad-hoc subprocess output collection)', async function() {
+
+            // given
+            const node = createElement('bpmn:AdHocSubProcess', {
+              flowElements: [
+                createElement('bpmn:Task')
+              ],
+              extensionElements: createElement('bpmn:ExtensionElements', {
+                values: [
+                  createElement('zeebe:AdHoc', {
+                    outputCollection: '1invalid',
+                    outputElement: 'item'
+                  })
+                ]
+              })
+            });
+
+            const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/variable-name');
+
+            const report = await getLintError(node, rule);
+
+            // when
+            const errorMessage = getErrorMessage(report, 'Camunda Cloud', '8.8');
+
+            // then
+            expect(errorMessage).to.equal('Variable name must start with a letter or an underscore, and may contain only letters, digits, underscores, and dots.');
+          });
+
+
+          it('should adjust (multi-instance input element)', async function() {
+
+            // given
+            const node = createElement('bpmn:ServiceTask', {
+              loopCharacteristics: createElement('bpmn:MultiInstanceLoopCharacteristics', {
+                extensionElements: createElement('bpmn:ExtensionElements', {
+                  values: [
+                    createElement('zeebe:LoopCharacteristics', {
+                      inputCollection: '=items',
+                      inputElement: '1invalid'
+                    })
+                  ]
+                })
+              })
+            });
+
+            const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/variable-name');
+
+            const report = await getLintError(node, rule);
+
+            // when
+            const errorMessage = getErrorMessage(report, 'Camunda Cloud', '1.0');
+
+            // then
+            expect(errorMessage).to.equal('Variable name must start with a letter or an underscore, and may contain only letters, digits, underscores, and dots.');
+          });
+
+
+          it('should adjust (multi-instance output collection)', async function() {
+
+            // given
+            const node = createElement('bpmn:ServiceTask', {
+              loopCharacteristics: createElement('bpmn:MultiInstanceLoopCharacteristics', {
+                extensionElements: createElement('bpmn:ExtensionElements', {
+                  values: [
+                    createElement('zeebe:LoopCharacteristics', {
+                      inputCollection: '=items',
+                      outputCollection: '1invalid',
+                      outputElement: 'item'
+                    })
+                  ]
+                })
+              })
+            });
+
+            const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/variable-name');
+
+            const report = await getLintError(node, rule);
+
+            // when
+            const errorMessage = getErrorMessage(report, 'Camunda Cloud', '1.0');
+
+            // then
+            expect(errorMessage).to.equal('Variable name must start with a letter or an underscore, and may contain only letters, digits, underscores, and dots.');
+          });
+        });
       });
 
 

--- a/test/spec/utils/properties-panel.spec.js
+++ b/test/spec/utils/properties-panel.spec.js
@@ -2096,6 +2096,223 @@ describe('utils/properties-panel', function() {
       });
 
 
+      describe('variable-name', function() {
+
+        it('input target with invalid variable name', async function() {
+
+          // given
+          const node = createElement('bpmn:ServiceTask', {
+            id: 'ServiceTask_1',
+            extensionElements: createElement('bpmn:ExtensionElements', {
+              values: [
+                createElement('zeebe:IoMapping', {
+                  inputParameters: [
+                    createElement('zeebe:Input', {
+                      target: 'invalid-name',
+                      source: '=value'
+                    })
+                  ],
+                })
+              ]
+            })
+          });
+
+          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/variable-name');
+
+          const report = await getLintError(node, rule, { version: '8.7' });
+
+          // when
+          const entryIds = getEntryIds(report);
+
+          // then
+          expect(entryIds).to.eql([ 'ServiceTask_1-input-0-target' ]);
+
+          expectErrorMessage(entryIds[ 0 ], 'Must be a valid variable name.', report);
+        });
+
+
+        it('output target with invalid variable name', async function() {
+
+          // given
+          const node = createElement('bpmn:ServiceTask', {
+            id: 'ServiceTask_1',
+            extensionElements: createElement('bpmn:ExtensionElements', {
+              values: [
+                createElement('zeebe:IoMapping', {
+                  outputParameters: [
+                    createElement('zeebe:Output', {
+                      target: 'invalid-name',
+                      source: '=result'
+                    })
+                  ],
+                })
+              ]
+            })
+          });
+
+          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/variable-name');
+
+          const report = await getLintError(node, rule, { version: '8.7' });
+
+          // when
+          const entryIds = getEntryIds(report);
+
+          // then
+          expect(entryIds).to.eql([ 'ServiceTask_1-output-0-target' ]);
+
+          expectErrorMessage(entryIds[ 0 ], 'Must be a valid variable name.', report);
+        });
+
+
+        it('script task result variable with invalid variable name', async function() {
+
+          // given
+          const node = createElement('bpmn:ScriptTask', {
+            extensionElements: createElement('bpmn:ExtensionElements', {
+              values: [
+                createElement('zeebe:Script', {
+                  expression: '=someExpression',
+                  resultVariable: 'invalid-result'
+                })
+              ]
+            })
+          });
+
+          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/variable-name');
+
+          const report = await getLintError(node, rule, { version: '8.7' });
+
+          // when
+          const entryIds = getEntryIds(report);
+
+          // then
+          expect(entryIds).to.eql([ 'resultVariable' ]);
+
+          expectErrorMessage(entryIds[ 0 ], 'Must be a valid variable name.', report);
+        });
+
+
+        it('business rule task result variable with invalid variable name', async function() {
+
+          // given
+          const node = createElement('bpmn:BusinessRuleTask', {
+            extensionElements: createElement('bpmn:ExtensionElements', {
+              values: [
+                createElement('zeebe:CalledDecision', {
+                  decisionId: 'decision',
+                  resultVariable: 'invalid-result'
+                })
+              ]
+            })
+          });
+
+          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/variable-name');
+
+          const report = await getLintError(node, rule, { version: '8.7' });
+
+          // when
+          const entryIds = getEntryIds(report);
+
+          // then
+          expect(entryIds).to.eql([ 'resultVariable' ]);
+
+          expectErrorMessage(entryIds[ 0 ], 'Must be a valid variable name.', report);
+        });
+
+
+        it('multi-instance input element with invalid variable name', async function() {
+
+          // given
+          const node = createElement('bpmn:ServiceTask', {
+            loopCharacteristics: createElement('bpmn:MultiInstanceLoopCharacteristics', {
+              extensionElements: createElement('bpmn:ExtensionElements', {
+                values: [
+                  createElement('zeebe:LoopCharacteristics', {
+                    inputCollection: '=items',
+                    inputElement: 'invalid-item'
+                  })
+                ]
+              })
+            })
+          });
+
+          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/variable-name');
+
+          const report = await getLintError(node, rule, { version: '8.7' });
+
+          // when
+          const entryIds = getEntryIds(report);
+
+          // then
+          expect(entryIds).to.eql([ 'multiInstance-inputElement' ]);
+
+          expectErrorMessage(entryIds[ 0 ], 'Must be a valid variable name.', report);
+        });
+
+
+        it('multi-instance output collection with invalid variable name', async function() {
+
+          // given
+          const node = createElement('bpmn:ServiceTask', {
+            loopCharacteristics: createElement('bpmn:MultiInstanceLoopCharacteristics', {
+              extensionElements: createElement('bpmn:ExtensionElements', {
+                values: [
+                  createElement('zeebe:LoopCharacteristics', {
+                    outputCollection: 'invalid-output',
+                    outputElement: '=items'
+                  })
+                ]
+              })
+            })
+          });
+
+          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/variable-name');
+
+          const report = await getLintError(node, rule, { version: '8.7' });
+
+          // when
+          const entryIds = getEntryIds(report);
+
+          // then
+          expect(entryIds).to.eql([ 'multiInstance-outputCollection' ]);
+
+          expectErrorMessage(entryIds[ 0 ], 'Must be a valid variable name.', report);
+        });
+
+
+        it('ad-hoc subprocess output collection with invalid variable name', async function() {
+
+          // given
+          const node = createElement('bpmn:AdHocSubProcess', {
+            flowElements: [
+              createElement('bpmn:Task')
+            ],
+            extensionElements: createElement('bpmn:ExtensionElements', {
+              values: [
+                createElement('zeebe:AdHoc', {
+                  outputCollection: 'invalid-results',
+                  outputElement: '=item'
+                })
+              ]
+            })
+          });
+
+          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/variable-name');
+
+          const report = await getLintError(node, rule, { version: '8.8' });
+
+          // when
+          const entryIds = getEntryIds(report);
+
+          // then
+          expect(entryIds).to.eql([ 'adHocOutputCollection' ]);
+
+          expectErrorMessage(entryIds[ 0 ], 'Must be a valid variable name.', report);
+        });
+
+      });
+
+
       describe('link event - Name', async function() {
 
         it('required', async function() {


### PR DESCRIPTION
This PR adjusts the error messages so that they are readable, and also right properties panel entry is triggered when error is clicked.

Related to https://github.com/camunda/camunda-modeler/issues/5188

### Proposed Changes

<img width="994" height="905" alt="image" src="https://github.com/user-attachments/assets/36dd0bba-6062-42e4-b20b-df8815ab8926" />


### Checklist

To ensure you provided everything we need to look at your PR:

* [x] __Brief textual description__ of the changes present
* [x] __Visual demo__ attached
* [ ] __Steps to try out__ present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->
