### PR TITLE
fix: adjust error message for execution listener with headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to [@camunda/linting](https://github.com/camunda/linting) ar
 
 ___Note:__ Yet to be released changes appear here._
 
+## 3.49.1
+
+* `FIX`: adjust an error message for execution listener with headers ([#154](https://github.com/camunda/linting/pull/154))
+
 ## 3.49.0
 
 * `FEAT`: add Camunda 8.10 config ([camunda/bpmnlint-plugin-camunda-compat#233](https://github.com/camunda/bpmnlint-plugin-camunda-compat/pull/233))

--- a/lib/utils/error-messages.js
+++ b/lib/utils/error-messages.js
@@ -504,6 +504,10 @@ function getPropertyNotAllowedErrorMessage(report, executionPlatform, executionP
     return getSupportedMessage(`${ getIndefiniteArticle(typeString) } <${ typeString }> with <Output element>`, executionPlatform, executionPlatformVersion, allowedVersion);
   }
 
+  if (is(node, 'zeebe:ExecutionListener') && property === 'headers') {
+    return getSupportedMessage('An <Execution listener> with <Headers>', executionPlatform, executionPlatformVersion, allowedVersion);
+  }
+
   return message;
 }
 

--- a/test/spec/utils/error-messages.spec.js
+++ b/test/spec/utils/error-messages.spec.js
@@ -550,6 +550,39 @@ describe('utils/error-messages', function() {
         });
 
 
+        it('should adjust (zeebe:ExecutionListener with headers)', async function() {
+
+          // given
+          const executionPlatformVersion = '8.9';
+
+          const node = createElement('bpmn:ServiceTask', {
+            extensionElements: createElement('bpmn:ExtensionElements', {
+              values: [
+                createElement('zeebe:ExecutionListeners', {
+                  listeners: [
+                    createElement('zeebe:ExecutionListener', {
+                      eventType: 'start',
+                      type: 'foo',
+                      headers: createElement('zeebe:TaskHeaders')
+                    })
+                  ]
+                })
+              ]
+            })
+          });
+
+          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-execution-listener-headers');
+
+          const report = await getLintError(node, rule, { version: executionPlatformVersion });
+
+          // when
+          const errorMessage = getErrorMessage(report, 'Camunda Cloud', executionPlatformVersion);
+
+          // then
+          expect(errorMessage).to.equal('An <Execution listener> with <Headers> is only supported by Camunda 8.10 or newer');
+        });
+
+
         it('should adjust (zeebe:VersionTag)', async function() {
 
           // given


### PR DESCRIPTION
Related to https://github.com/camunda/camunda-modeler/issues/5918

### Proposed Changes

Adjust error message for execution listener with headers to be user friendly:
`An <Execution listener> with <Headers> is only supported by Camunda 8.10 or newer`

<img width="1720" height="545" alt="image" src="https://github.com/user-attachments/assets/5ddfd242-b796-4dbd-a8ca-ca091dbec696" />


### Checklist

To ensure you provided everything we need to look at your PR:

* [x] __Brief textual description__ of the changes present
* [x] __Visual demo__ attached
* [ ] __Steps to try out__ present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->
