### PR TITLE
Support cancel execution listener rules and start event forms rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,9 @@ All notable changes to [@camunda/linting](https://github.com/camunda/linting) ar
 
 ___Note:__ Yet to be released changes appear here._
 
+* `FEAT`: support cancel execution listener rules
 * `FEAT`: add and adjust `before-all-execution-listener`, `no-before-all-execution-listener` rules ([#155](https://github.com/camunda/linting/pull/155), [camunda/bpmnlint-plugin-camunda-compat#239](https://github.com/camunda/bpmnlint-plugin-camunda-compat/pull/239))
-* `DEPS`: update to `bpmnlint-plugin-camunda-compat@2.50.0`
+* `DEPS`: update to `bpmnlint-plugin-camunda-compat@2.51.0`
 
 
 ## 3.49.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,12 @@ All notable changes to [@camunda/linting](https://github.com/camunda/linting) ar
 
 ___Note:__ Yet to be released changes appear here._
 
-* `FEAT`: support cancel execution listener rules
-* `FEAT`: add and adjust `before-all-execution-listener`, `no-before-all-execution-listener` rules ([#155](https://github.com/camunda/linting/pull/155), [camunda/bpmnlint-plugin-camunda-compat#239](https://github.com/camunda/bpmnlint-plugin-camunda-compat/pull/239))
-* `DEPS`: update to `bpmnlint-plugin-camunda-compat@2.51.0`
+## 3.50.0
 
+* `FEAT`: support cancel execution listener rules ([#156](https://github.com/camunda/linting/pull/156))
+* `FEAT`: support start event form rules ([#156](https://github.com/camunda/linting/pull/156))
+* `FEAT`: add and adjust `before-all-execution-listener`, `no-before-all-execution-listener` rules ([#155](https://github.com/camunda/linting/pull/155), [camunda/bpmnlint-plugin-camunda-compat#239](https://github.com/camunda/bpmnlint-plugin-camunda-compat/pull/239))
+* `DEPS`: update to `bpmnlint-plugin-camunda-compat@2.52.0`
 
 ## 3.49.1
 

--- a/lib/compiled-config.js
+++ b/lib/compiled-config.js
@@ -78,6 +78,7 @@ const rules = {
   "camunda-compat/sequence-flow-condition": "error",
   "camunda-compat/signal-reference": "error",
   "camunda-compat/start-event-form": "error",
+  "camunda-compat/start-event-form-embedded": "warn",
   "camunda-compat/subscription": "error",
   "camunda-compat/task-listener": "error",
   "camunda-compat/task-schedule": "error",
@@ -310,74 +311,78 @@ import rule_48 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/start-ev
 
 cache['bpmnlint-plugin-camunda-compat/start-event-form'] = rule_48;
 
-import rule_49 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/subscription';
+import rule_49 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/start-event-form-embedded';
 
-cache['bpmnlint-plugin-camunda-compat/subscription'] = rule_49;
+cache['bpmnlint-plugin-camunda-compat/start-event-form-embedded'] = rule_49;
 
-import rule_50 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/task-listener';
+import rule_50 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/subscription';
 
-cache['bpmnlint-plugin-camunda-compat/task-listener'] = rule_50;
+cache['bpmnlint-plugin-camunda-compat/subscription'] = rule_50;
 
-import rule_51 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/task-schedule';
+import rule_51 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/task-listener';
 
-cache['bpmnlint-plugin-camunda-compat/task-schedule'] = rule_51;
+cache['bpmnlint-plugin-camunda-compat/task-listener'] = rule_51;
 
-import rule_52 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/timer';
+import rule_52 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/task-schedule';
 
-cache['bpmnlint-plugin-camunda-compat/timer'] = rule_52;
+cache['bpmnlint-plugin-camunda-compat/task-schedule'] = rule_52;
 
-import rule_53 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/user-task-definition';
+import rule_53 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/timer';
 
-cache['bpmnlint-plugin-camunda-compat/user-task-definition'] = rule_53;
+cache['bpmnlint-plugin-camunda-compat/timer'] = rule_53;
 
-import rule_54 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/user-task-form';
+import rule_54 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/user-task-definition';
 
-cache['bpmnlint-plugin-camunda-compat/user-task-form'] = rule_54;
+cache['bpmnlint-plugin-camunda-compat/user-task-definition'] = rule_54;
 
-import rule_55 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/variable-name';
+import rule_55 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/user-task-form';
 
-cache['bpmnlint-plugin-camunda-compat/variable-name'] = rule_55;
+cache['bpmnlint-plugin-camunda-compat/user-task-form'] = rule_55;
 
-import rule_56 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/version-tag';
+import rule_56 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/variable-name';
 
-cache['bpmnlint-plugin-camunda-compat/version-tag'] = rule_56;
+cache['bpmnlint-plugin-camunda-compat/variable-name'] = rule_56;
 
-import rule_57 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/wait-for-completion';
+import rule_57 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/version-tag';
 
-cache['bpmnlint-plugin-camunda-compat/wait-for-completion'] = rule_57;
+cache['bpmnlint-plugin-camunda-compat/version-tag'] = rule_57;
 
-import rule_58 from 'bpmnlint/rules/start-event-required';
+import rule_58 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/wait-for-completion';
 
-cache['bpmnlint/start-event-required'] = rule_58;
+cache['bpmnlint-plugin-camunda-compat/wait-for-completion'] = rule_58;
 
-import rule_59 from 'bpmnlint/rules/ad-hoc-sub-process';
+import rule_59 from 'bpmnlint/rules/start-event-required';
 
-cache['bpmnlint/ad-hoc-sub-process'] = rule_59;
+cache['bpmnlint/start-event-required'] = rule_59;
 
-import rule_60 from 'bpmnlint/rules/conditional-event';
+import rule_60 from 'bpmnlint/rules/ad-hoc-sub-process';
 
-cache['bpmnlint/conditional-event'] = rule_60;
+cache['bpmnlint/ad-hoc-sub-process'] = rule_60;
 
-import rule_61 from 'bpmnlint/rules/event-based-gateway';
+import rule_61 from 'bpmnlint/rules/conditional-event';
 
-cache['bpmnlint/event-based-gateway'] = rule_61;
+cache['bpmnlint/conditional-event'] = rule_61;
 
-import rule_62 from 'bpmnlint/rules/event-sub-process-typed-start-event';
+import rule_62 from 'bpmnlint/rules/event-based-gateway';
 
-cache['bpmnlint/event-sub-process-typed-start-event'] = rule_62;
+cache['bpmnlint/event-based-gateway'] = rule_62;
 
-import rule_63 from 'bpmnlint/rules/link-event';
+import rule_63 from 'bpmnlint/rules/event-sub-process-typed-start-event';
 
-cache['bpmnlint/link-event'] = rule_63;
+cache['bpmnlint/event-sub-process-typed-start-event'] = rule_63;
 
-import rule_64 from 'bpmnlint/rules/no-duplicate-sequence-flows';
+import rule_64 from 'bpmnlint/rules/link-event';
 
-cache['bpmnlint/no-duplicate-sequence-flows'] = rule_64;
+cache['bpmnlint/link-event'] = rule_64;
 
-import rule_65 from 'bpmnlint/rules/sub-process-blank-start-event';
+import rule_65 from 'bpmnlint/rules/no-duplicate-sequence-flows';
 
-cache['bpmnlint/sub-process-blank-start-event'] = rule_65;
+cache['bpmnlint/no-duplicate-sequence-flows'] = rule_65;
 
-import rule_66 from 'bpmnlint/rules/single-blank-start-event';
+import rule_66 from 'bpmnlint/rules/sub-process-blank-start-event';
 
-cache['bpmnlint/single-blank-start-event'] = rule_66;
+cache['bpmnlint/sub-process-blank-start-event'] = rule_66;
+
+import rule_67 from 'bpmnlint/rules/single-blank-start-event';
+
+cache['bpmnlint/single-blank-start-event'] = rule_67;

--- a/lib/compiled-config.js
+++ b/lib/compiled-config.js
@@ -32,6 +32,7 @@ const rules = {
   "camunda-compat/ad-hoc-sub-process": "error",
   "camunda-compat/before-all-execution-listener": "error",
   "camunda-compat/element-type": "error",
+  "camunda-compat/cancel-execution-listener": "error",
   "camunda-compat/called-element": "error",
   "camunda-compat/collapsed-subprocess": "error",
   "camunda-compat/connector-properties": "warn",
@@ -55,6 +56,7 @@ const rules = {
   "camunda-compat/no-binding-type": "error",
   "camunda-compat/no-before-all-execution-listener": "error",
   "camunda-compat/no-candidate-users": "error",
+  "camunda-compat/no-cancel-execution-listener": "error",
   "camunda-compat/no-execution-listener-headers": "error",
   "camunda-compat/no-execution-listeners": "error",
   "camunda-compat/no-expression": "error",
@@ -124,250 +126,258 @@ import rule_2 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/element-t
 
 cache['bpmnlint-plugin-camunda-compat/element-type'] = rule_2;
 
-import rule_3 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/called-element';
+import rule_3 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/cancel-execution-listener';
 
-cache['bpmnlint-plugin-camunda-compat/called-element'] = rule_3;
+cache['bpmnlint-plugin-camunda-compat/cancel-execution-listener'] = rule_3;
 
-import rule_4 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/collapsed-subprocess';
+import rule_4 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/called-element';
 
-cache['bpmnlint-plugin-camunda-compat/collapsed-subprocess'] = rule_4;
+cache['bpmnlint-plugin-camunda-compat/called-element'] = rule_4;
 
-import rule_5 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/connector-properties';
+import rule_5 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/collapsed-subprocess';
 
-cache['bpmnlint-plugin-camunda-compat/connector-properties'] = rule_5;
+cache['bpmnlint-plugin-camunda-compat/collapsed-subprocess'] = rule_5;
 
-import rule_6 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/duplicate-execution-listener-headers';
+import rule_6 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/connector-properties';
 
-cache['bpmnlint-plugin-camunda-compat/duplicate-execution-listener-headers'] = rule_6;
+cache['bpmnlint-plugin-camunda-compat/connector-properties'] = rule_6;
 
-import rule_7 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/duplicate-execution-listeners';
+import rule_7 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/duplicate-execution-listener-headers';
 
-cache['bpmnlint-plugin-camunda-compat/duplicate-execution-listeners'] = rule_7;
+cache['bpmnlint-plugin-camunda-compat/duplicate-execution-listener-headers'] = rule_7;
 
-import rule_8 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/duplicate-task-headers';
+import rule_8 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/duplicate-execution-listeners';
 
-cache['bpmnlint-plugin-camunda-compat/duplicate-task-headers'] = rule_8;
+cache['bpmnlint-plugin-camunda-compat/duplicate-execution-listeners'] = rule_8;
 
-import rule_9 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/error-reference';
+import rule_9 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/duplicate-task-headers';
 
-cache['bpmnlint-plugin-camunda-compat/error-reference'] = rule_9;
+cache['bpmnlint-plugin-camunda-compat/duplicate-task-headers'] = rule_9;
 
-import rule_10 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/escalation-boundary-event-attached-to-ref';
+import rule_10 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/error-reference';
 
-cache['bpmnlint-plugin-camunda-compat/escalation-boundary-event-attached-to-ref'] = rule_10;
+cache['bpmnlint-plugin-camunda-compat/error-reference'] = rule_10;
 
-import rule_11 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/escalation-reference';
+import rule_11 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/escalation-boundary-event-attached-to-ref';
 
-cache['bpmnlint-plugin-camunda-compat/escalation-reference'] = rule_11;
+cache['bpmnlint-plugin-camunda-compat/escalation-boundary-event-attached-to-ref'] = rule_11;
 
-import rule_12 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/event-based-gateway-target';
+import rule_12 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/escalation-reference';
 
-cache['bpmnlint-plugin-camunda-compat/event-based-gateway-target'] = rule_12;
+cache['bpmnlint-plugin-camunda-compat/escalation-reference'] = rule_12;
 
-import rule_13 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/executable-process';
+import rule_13 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/event-based-gateway-target';
 
-cache['bpmnlint-plugin-camunda-compat/executable-process'] = rule_13;
+cache['bpmnlint-plugin-camunda-compat/event-based-gateway-target'] = rule_13;
 
-import rule_14 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/execution-listener';
+import rule_14 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/executable-process';
 
-cache['bpmnlint-plugin-camunda-compat/execution-listener'] = rule_14;
+cache['bpmnlint-plugin-camunda-compat/executable-process'] = rule_14;
 
-import rule_15 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/feel';
+import rule_15 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/execution-listener';
 
-cache['bpmnlint-plugin-camunda-compat/feel'] = rule_15;
+cache['bpmnlint-plugin-camunda-compat/execution-listener'] = rule_15;
 
-import rule_16 from 'bpmnlint-plugin-camunda-compat/rules/camunda-platform/history-time-to-live';
+import rule_16 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/feel';
 
-cache['bpmnlint-plugin-camunda-compat/history-time-to-live'] = rule_16;
+cache['bpmnlint-plugin-camunda-compat/feel'] = rule_16;
 
-import rule_17 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/implementation';
+import rule_17 from 'bpmnlint-plugin-camunda-compat/rules/camunda-platform/history-time-to-live';
 
-cache['bpmnlint-plugin-camunda-compat/implementation'] = rule_17;
+cache['bpmnlint-plugin-camunda-compat/history-time-to-live'] = rule_17;
 
-import rule_18 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/inclusive-gateway';
+import rule_18 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/implementation';
 
-cache['bpmnlint-plugin-camunda-compat/inclusive-gateway'] = rule_18;
+cache['bpmnlint-plugin-camunda-compat/implementation'] = rule_18;
 
-import rule_19 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/link-event';
+import rule_19 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/inclusive-gateway';
 
-cache['bpmnlint-plugin-camunda-compat/link-event'] = rule_19;
+cache['bpmnlint-plugin-camunda-compat/inclusive-gateway'] = rule_19;
 
-import rule_20 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/loop-characteristics';
+import rule_20 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/link-event';
 
-cache['bpmnlint-plugin-camunda-compat/loop-characteristics'] = rule_20;
+cache['bpmnlint-plugin-camunda-compat/link-event'] = rule_20;
 
-import rule_21 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/io-mapping';
+import rule_21 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/loop-characteristics';
 
-cache['bpmnlint-plugin-camunda-compat/io-mapping'] = rule_21;
+cache['bpmnlint-plugin-camunda-compat/loop-characteristics'] = rule_21;
 
-import rule_22 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/message-reference';
+import rule_22 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/io-mapping';
 
-cache['bpmnlint-plugin-camunda-compat/message-reference'] = rule_22;
+cache['bpmnlint-plugin-camunda-compat/io-mapping'] = rule_22;
 
-import rule_23 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-binding-type';
+import rule_23 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/message-reference';
 
-cache['bpmnlint-plugin-camunda-compat/no-binding-type'] = rule_23;
+cache['bpmnlint-plugin-camunda-compat/message-reference'] = rule_23;
 
-import rule_24 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-before-all-execution-listener';
+import rule_24 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-binding-type';
 
-cache['bpmnlint-plugin-camunda-compat/no-before-all-execution-listener'] = rule_24;
+cache['bpmnlint-plugin-camunda-compat/no-binding-type'] = rule_24;
 
-import rule_25 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-candidate-users';
+import rule_25 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-before-all-execution-listener';
 
-cache['bpmnlint-plugin-camunda-compat/no-candidate-users'] = rule_25;
+cache['bpmnlint-plugin-camunda-compat/no-before-all-execution-listener'] = rule_25;
 
-import rule_26 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-execution-listener-headers';
+import rule_26 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-candidate-users';
 
-cache['bpmnlint-plugin-camunda-compat/no-execution-listener-headers'] = rule_26;
+cache['bpmnlint-plugin-camunda-compat/no-candidate-users'] = rule_26;
 
-import rule_27 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-execution-listeners';
+import rule_27 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-cancel-execution-listener';
 
-cache['bpmnlint-plugin-camunda-compat/no-execution-listeners'] = rule_27;
+cache['bpmnlint-plugin-camunda-compat/no-cancel-execution-listener'] = rule_27;
 
-import rule_28 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-expression';
+import rule_28 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-execution-listener-headers';
 
-cache['bpmnlint-plugin-camunda-compat/no-expression'] = rule_28;
+cache['bpmnlint-plugin-camunda-compat/no-execution-listener-headers'] = rule_28;
 
-import rule_29 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-interrupting-event-subprocess';
+import rule_29 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-execution-listeners';
 
-cache['bpmnlint-plugin-camunda-compat/no-interrupting-event-subprocess'] = rule_29;
+cache['bpmnlint-plugin-camunda-compat/no-execution-listeners'] = rule_29;
 
-import rule_30 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-loop';
+import rule_30 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-expression';
 
-cache['bpmnlint-plugin-camunda-compat/no-loop'] = rule_30;
+cache['bpmnlint-plugin-camunda-compat/no-expression'] = rule_30;
 
-import rule_31 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-multiple-none-start-events';
+import rule_31 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-interrupting-event-subprocess';
 
-cache['bpmnlint-plugin-camunda-compat/no-multiple-none-start-events'] = rule_31;
+cache['bpmnlint-plugin-camunda-compat/no-interrupting-event-subprocess'] = rule_31;
 
-import rule_32 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-priority-definition';
+import rule_32 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-loop';
 
-cache['bpmnlint-plugin-camunda-compat/no-priority-definition'] = rule_32;
+cache['bpmnlint-plugin-camunda-compat/no-loop'] = rule_32;
 
-import rule_33 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-propagate-all-parent-variables';
+import rule_33 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-multiple-none-start-events';
 
-cache['bpmnlint-plugin-camunda-compat/no-propagate-all-parent-variables'] = rule_33;
+cache['bpmnlint-plugin-camunda-compat/no-multiple-none-start-events'] = rule_33;
 
-import rule_34 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-signal-event-sub-process';
+import rule_34 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-priority-definition';
 
-cache['bpmnlint-plugin-camunda-compat/no-signal-event-sub-process'] = rule_34;
+cache['bpmnlint-plugin-camunda-compat/no-priority-definition'] = rule_34;
 
-import rule_35 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-task-schedule';
+import rule_35 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-propagate-all-parent-variables';
 
-cache['bpmnlint-plugin-camunda-compat/no-task-schedule'] = rule_35;
+cache['bpmnlint-plugin-camunda-compat/no-propagate-all-parent-variables'] = rule_35;
 
-import rule_36 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-task-listeners';
+import rule_36 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-signal-event-sub-process';
 
-cache['bpmnlint-plugin-camunda-compat/no-task-listeners'] = rule_36;
+cache['bpmnlint-plugin-camunda-compat/no-signal-event-sub-process'] = rule_36;
 
-import rule_37 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-template';
+import rule_37 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-task-schedule';
 
-cache['bpmnlint-plugin-camunda-compat/no-template'] = rule_37;
+cache['bpmnlint-plugin-camunda-compat/no-task-schedule'] = rule_37;
 
-import rule_38 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-version-tag';
+import rule_38 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-task-listeners';
 
-cache['bpmnlint-plugin-camunda-compat/no-version-tag'] = rule_38;
+cache['bpmnlint-plugin-camunda-compat/no-task-listeners'] = rule_38;
 
-import rule_39 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-zeebe-properties';
+import rule_39 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-template';
 
-cache['bpmnlint-plugin-camunda-compat/no-zeebe-properties'] = rule_39;
+cache['bpmnlint-plugin-camunda-compat/no-template'] = rule_39;
 
-import rule_40 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-zeebe-user-task';
+import rule_40 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-version-tag';
 
-cache['bpmnlint-plugin-camunda-compat/no-zeebe-user-task'] = rule_40;
+cache['bpmnlint-plugin-camunda-compat/no-version-tag'] = rule_40;
 
-import rule_41 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/priority-definition';
+import rule_41 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-zeebe-properties';
 
-cache['bpmnlint-plugin-camunda-compat/priority-definition'] = rule_41;
+cache['bpmnlint-plugin-camunda-compat/no-zeebe-properties'] = rule_41;
 
-import rule_42 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/zeebe-user-task';
+import rule_42 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-zeebe-user-task';
 
-cache['bpmnlint-plugin-camunda-compat/zeebe-user-task'] = rule_42;
+cache['bpmnlint-plugin-camunda-compat/no-zeebe-user-task'] = rule_42;
 
-import rule_43 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/secrets';
+import rule_43 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/priority-definition';
 
-cache['bpmnlint-plugin-camunda-compat/secrets'] = rule_43;
+cache['bpmnlint-plugin-camunda-compat/priority-definition'] = rule_43;
 
-import rule_44 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/sequence-flow-condition';
+import rule_44 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/zeebe-user-task';
 
-cache['bpmnlint-plugin-camunda-compat/sequence-flow-condition'] = rule_44;
+cache['bpmnlint-plugin-camunda-compat/zeebe-user-task'] = rule_44;
 
-import rule_45 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/signal-reference';
+import rule_45 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/secrets';
 
-cache['bpmnlint-plugin-camunda-compat/signal-reference'] = rule_45;
+cache['bpmnlint-plugin-camunda-compat/secrets'] = rule_45;
 
-import rule_46 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/start-event-form';
+import rule_46 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/sequence-flow-condition';
 
-cache['bpmnlint-plugin-camunda-compat/start-event-form'] = rule_46;
+cache['bpmnlint-plugin-camunda-compat/sequence-flow-condition'] = rule_46;
 
-import rule_47 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/subscription';
+import rule_47 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/signal-reference';
 
-cache['bpmnlint-plugin-camunda-compat/subscription'] = rule_47;
+cache['bpmnlint-plugin-camunda-compat/signal-reference'] = rule_47;
 
-import rule_48 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/task-listener';
+import rule_48 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/start-event-form';
 
-cache['bpmnlint-plugin-camunda-compat/task-listener'] = rule_48;
+cache['bpmnlint-plugin-camunda-compat/start-event-form'] = rule_48;
 
-import rule_49 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/task-schedule';
+import rule_49 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/subscription';
 
-cache['bpmnlint-plugin-camunda-compat/task-schedule'] = rule_49;
+cache['bpmnlint-plugin-camunda-compat/subscription'] = rule_49;
 
-import rule_50 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/timer';
+import rule_50 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/task-listener';
 
-cache['bpmnlint-plugin-camunda-compat/timer'] = rule_50;
+cache['bpmnlint-plugin-camunda-compat/task-listener'] = rule_50;
 
-import rule_51 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/user-task-definition';
+import rule_51 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/task-schedule';
 
-cache['bpmnlint-plugin-camunda-compat/user-task-definition'] = rule_51;
+cache['bpmnlint-plugin-camunda-compat/task-schedule'] = rule_51;
 
-import rule_52 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/user-task-form';
+import rule_52 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/timer';
 
-cache['bpmnlint-plugin-camunda-compat/user-task-form'] = rule_52;
+cache['bpmnlint-plugin-camunda-compat/timer'] = rule_52;
 
-import rule_53 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/variable-name';
+import rule_53 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/user-task-definition';
 
-cache['bpmnlint-plugin-camunda-compat/variable-name'] = rule_53;
+cache['bpmnlint-plugin-camunda-compat/user-task-definition'] = rule_53;
 
-import rule_54 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/version-tag';
+import rule_54 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/user-task-form';
 
-cache['bpmnlint-plugin-camunda-compat/version-tag'] = rule_54;
+cache['bpmnlint-plugin-camunda-compat/user-task-form'] = rule_54;
 
-import rule_55 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/wait-for-completion';
+import rule_55 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/variable-name';
 
-cache['bpmnlint-plugin-camunda-compat/wait-for-completion'] = rule_55;
+cache['bpmnlint-plugin-camunda-compat/variable-name'] = rule_55;
 
-import rule_56 from 'bpmnlint/rules/start-event-required';
+import rule_56 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/version-tag';
 
-cache['bpmnlint/start-event-required'] = rule_56;
+cache['bpmnlint-plugin-camunda-compat/version-tag'] = rule_56;
 
-import rule_57 from 'bpmnlint/rules/ad-hoc-sub-process';
+import rule_57 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/wait-for-completion';
 
-cache['bpmnlint/ad-hoc-sub-process'] = rule_57;
+cache['bpmnlint-plugin-camunda-compat/wait-for-completion'] = rule_57;
 
-import rule_58 from 'bpmnlint/rules/conditional-event';
+import rule_58 from 'bpmnlint/rules/start-event-required';
 
-cache['bpmnlint/conditional-event'] = rule_58;
+cache['bpmnlint/start-event-required'] = rule_58;
 
-import rule_59 from 'bpmnlint/rules/event-based-gateway';
+import rule_59 from 'bpmnlint/rules/ad-hoc-sub-process';
 
-cache['bpmnlint/event-based-gateway'] = rule_59;
+cache['bpmnlint/ad-hoc-sub-process'] = rule_59;
 
-import rule_60 from 'bpmnlint/rules/event-sub-process-typed-start-event';
+import rule_60 from 'bpmnlint/rules/conditional-event';
 
-cache['bpmnlint/event-sub-process-typed-start-event'] = rule_60;
+cache['bpmnlint/conditional-event'] = rule_60;
 
-import rule_61 from 'bpmnlint/rules/link-event';
+import rule_61 from 'bpmnlint/rules/event-based-gateway';
 
-cache['bpmnlint/link-event'] = rule_61;
+cache['bpmnlint/event-based-gateway'] = rule_61;
 
-import rule_62 from 'bpmnlint/rules/no-duplicate-sequence-flows';
+import rule_62 from 'bpmnlint/rules/event-sub-process-typed-start-event';
 
-cache['bpmnlint/no-duplicate-sequence-flows'] = rule_62;
+cache['bpmnlint/event-sub-process-typed-start-event'] = rule_62;
 
-import rule_63 from 'bpmnlint/rules/sub-process-blank-start-event';
+import rule_63 from 'bpmnlint/rules/link-event';
 
-cache['bpmnlint/sub-process-blank-start-event'] = rule_63;
+cache['bpmnlint/link-event'] = rule_63;
 
-import rule_64 from 'bpmnlint/rules/single-blank-start-event';
+import rule_64 from 'bpmnlint/rules/no-duplicate-sequence-flows';
 
-cache['bpmnlint/single-blank-start-event'] = rule_64;
+cache['bpmnlint/no-duplicate-sequence-flows'] = rule_64;
+
+import rule_65 from 'bpmnlint/rules/sub-process-blank-start-event';
+
+cache['bpmnlint/sub-process-blank-start-event'] = rule_65;
+
+import rule_66 from 'bpmnlint/rules/single-blank-start-event';
+
+cache['bpmnlint/single-blank-start-event'] = rule_66;

--- a/lib/utils/error-messages.js
+++ b/lib/utils/error-messages.js
@@ -836,10 +836,11 @@ function getPropertyValueNotAllowedErrorMessage(report, executionPlatform, execu
   if (
     is(node, 'zeebe:ExecutionListener')
     && property === 'eventType'
-    && node.get('eventType') === 'beforeAll'
     && allowedVersion
   ) {
-    return getSupportedMessage('An <Execution listener> with <Before all> event type', executionPlatform, executionPlatformVersion, allowedVersion);
+    const eventType = node.get('eventType');
+
+    return getSupportedMessage(`An <Execution listener> with <${ camelCaseToSentence(eventType) }> event type`, executionPlatform, executionPlatformVersion, allowedVersion);
   }
 
   if (
@@ -909,4 +910,16 @@ function isZeebeUserTask(node) {
   return node.get('extensionElements').get('values').some(extensionElement => {
     return is(extensionElement, 'zeebe:UserTask');
   });
+}
+
+/**
+ * Transform from camel case to sentence case, e.g. "beforeAll" to "Before all".
+ *
+ * @param {string} camelcase
+ * @returns {string}
+ */
+function camelCaseToSentence(camelcase) {
+  const result = camelcase.replace(/([A-Z])/g, ' $1');
+
+  return result.charAt(0).toUpperCase() + result.slice(1).toLowerCase();
 }

--- a/lib/utils/properties-panel.js
+++ b/lib/utils/properties-panel.js
@@ -645,7 +645,7 @@ export function getErrorMessage(id, report) {
   }
 
   if (/^.+-executionListener-[0-9]+-eventType$/.test(id)) {
-    if (allowedVersion && data.node.get('eventType') === 'beforeAll') {
+    if (type === ERROR_TYPES.PROPERTY_VALUE_NOT_ALLOWED) {
       return getNotSupportedMessage('', allowedVersion);
     }
   }

--- a/lib/utils/properties-panel.js
+++ b/lib/utils/properties-panel.js
@@ -160,6 +160,11 @@ export function getEntryIds(report) {
     return [ 'messageSubscriptionCorrelationKey' ];
   }
 
+  if (data.type === ERROR_TYPES.PROPERTY_DEPRECATED
+    && isPropertyError(data, 'formKey', 'zeebe:FormDefinition')) {
+    return [ 'formType' ];
+  }
+
   if (isPropertyError(data, 'formKey', 'zeebe:FormDefinition')) {
     return [ 'customFormKey' ];
   }
@@ -558,6 +563,10 @@ export function getErrorMessage(id, report) {
     } else if (type === ERROR_TYPES.EXTENSION_ELEMENT_REQUIRED) {
       return getNotSupportedMessage('');
     }
+  }
+
+  if (id === 'formType' && type === ERROR_TYPES.EXTENSION_ELEMENT_NOT_ALLOWED) {
+    return getNotSupportedMessage('', allowedVersion);
   }
 
   if (id === 'conditionExpression') {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "bpmn-moddle": "^10.0.0",
         "bpmnlint": "^11.12.1",
         "bpmnlint-plugin-camunda-compat": "^2.52.0",
-        "bpmnlint-utils": "^1.0.2",
+        "bpmnlint-utils": "^1.1.1",
         "camunda-bpmn-moddle": "^7.0.1",
         "clsx": "^2.0.0",
         "min-dash": "^5.0.0",
@@ -23,10 +23,10 @@
         "zeebe-bpmn-moddle": "^1.13.0"
       },
       "devDependencies": {
-        "bpmn-js": "^18.14.0",
-        "bpmn-js-element-templates": "^2.23.1",
-        "bpmn-js-properties-panel": "^5.56.0",
-        "camunda-bpmn-js-behaviors": "^1.15.0",
+        "bpmn-js": "^18.16.1",
+        "bpmn-js-element-templates": "^2.24.0",
+        "bpmn-js-properties-panel": "^5.57.0",
+        "camunda-bpmn-js-behaviors": "^1.16.1",
         "chai": "^4.5.0",
         "cross-env": "^7.0.3",
         "eslint": "^8.57.1",
@@ -269,14 +269,14 @@
       }
     },
     "node_modules/@bpmn-io/element-templates-validator": {
-      "version": "2.20.1",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/element-templates-validator/-/element-templates-validator-2.20.1.tgz",
-      "integrity": "sha512-kzlgjzxq1dYVkBzuGrDjU/lXF0s7AfafATy7TglamnPZtbwYuHgpeuM0qPBKRWmtTHccpDbrtQxbUmJWCBTz6w==",
+      "version": "2.21.0",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/element-templates-validator/-/element-templates-validator-2.21.0.tgz",
+      "integrity": "sha512-MPX7ftvRSU3Fs8RrefNvC6YN/ubX5kMR30jrPkltZBYb7szZuPoeVimATpgVP1VkSzEAAy1TGPjA5Xvjcw9oQA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@camunda/element-templates-json-schema": "^0.21.0",
-        "@camunda/zeebe-element-templates-json-schema": "^0.39.1",
+        "@camunda/zeebe-element-templates-json-schema": "^0.40.0",
         "json-source-map": "^0.6.1",
         "min-dash": "^5.0.0"
       }
@@ -427,9 +427,9 @@
       "license": "MIT"
     },
     "node_modules/@camunda/zeebe-element-templates-json-schema": {
-      "version": "0.39.2",
-      "resolved": "https://registry.npmjs.org/@camunda/zeebe-element-templates-json-schema/-/zeebe-element-templates-json-schema-0.39.2.tgz",
-      "integrity": "sha512-Cp5gS9vTw3/nZl+2sQ3EU6832rZeimSwXb6CObq0RGW6cX7hfiM57z6yuLRmMbSmHyrQdokE0CLSZ8gfU2feSg==",
+      "version": "0.40.0",
+      "resolved": "https://registry.npmjs.org/@camunda/zeebe-element-templates-json-schema/-/zeebe-element-templates-json-schema-0.40.0.tgz",
+      "integrity": "sha512-XCJp7ijUtQFnUKBYzceDcpLl2CDzc9kKeZ8s/x6UAnlyf/THsg7rH1fYKxGhcxHWAAn4gtBze/0jiXhIZLIMOQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -1804,19 +1804,19 @@
       }
     },
     "node_modules/bpmn-js": {
-      "version": "18.14.0",
-      "resolved": "https://registry.npmjs.org/bpmn-js/-/bpmn-js-18.14.0.tgz",
-      "integrity": "sha512-z4CjyvK2wtP+IIunQJpZK1g5Xkfa089rueB2MCY2+NeZFz2RaHn17qJcXOvOhXvLHbUo+ldiXnkFuiGqslxIbQ==",
+      "version": "18.16.1",
+      "resolved": "https://registry.npmjs.org/bpmn-js/-/bpmn-js-18.16.1.tgz",
+      "integrity": "sha512-qdJp/1JbKY3JtqB2L7LF4VEJtVlbl9AGkvyUjzJlBJ8jURNNTx+22OdrZMVNPxaGOjW+nuHK38ObFCmMCp/Kcg==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "bpmn-moddle": "^10.0.0",
-        "diagram-js": "^15.11.0",
+        "diagram-js": "^15.14.0",
         "diagram-js-direct-editing": "^3.3.0",
         "ids": "^3.0.2",
         "inherits-browser": "^0.1.0",
         "min-dash": "^5.0.0",
-        "min-dom": "^5.2.0",
+        "min-dom": "^5.3.0",
         "tiny-svg": "^4.1.4"
       },
       "engines": {
@@ -1824,13 +1824,13 @@
       }
     },
     "node_modules/bpmn-js-element-templates": {
-      "version": "2.23.1",
-      "resolved": "https://registry.npmjs.org/bpmn-js-element-templates/-/bpmn-js-element-templates-2.23.1.tgz",
-      "integrity": "sha512-9KKoWkRld4YM0KWKl5aWh2WmxwIjsSU5yREsc0jSkgBPh/c46ZJ6jL4E/dA9q13MGRLgrs+QxQZfnwlJyn4wIQ==",
+      "version": "2.24.0",
+      "resolved": "https://registry.npmjs.org/bpmn-js-element-templates/-/bpmn-js-element-templates-2.24.0.tgz",
+      "integrity": "sha512-+knoREJRRW0mGVPCc8wJQUv+mA5tepJguT3OkwVJaHQY1B1atqZ6YPwBIIEndudMIf32/UxIwvHxlt9KkVT5rg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@bpmn-io/element-templates-validator": "^2.20.1",
+        "@bpmn-io/element-templates-validator": "^2.21.0",
         "@bpmn-io/extract-process-variables": "^2.2.1",
         "bpmnlint": "^11.12.0",
         "classnames": "^2.5.1",
@@ -1840,7 +1840,7 @@
         "preact-markup": "^2.1.1",
         "semver": "^7.7.4",
         "semver-compare": "^1.0.0",
-        "uuid": "^13.0.0"
+        "uuid": "^14.0.0"
       },
       "engines": {
         "node": "*"
@@ -1867,9 +1867,9 @@
       }
     },
     "node_modules/bpmn-js-properties-panel": {
-      "version": "5.56.0",
-      "resolved": "https://registry.npmjs.org/bpmn-js-properties-panel/-/bpmn-js-properties-panel-5.56.0.tgz",
-      "integrity": "sha512-5qaZxZ9ljQgegLaZZ36iGSX6Uj5YB5CzNN+nqm/D3rf/A7Ox7ag+pqNg77sT3wa7TqOGgA9SAl7NfWugiXlj1w==",
+      "version": "5.57.0",
+      "resolved": "https://registry.npmjs.org/bpmn-js-properties-panel/-/bpmn-js-properties-panel-5.57.0.tgz",
+      "integrity": "sha512-SyHL6Wt8HmF+SVf/biuuZHsOaMjtYxI0/2vmd4zhRdTMqa6NygxFkSE8fAdXPvWPv8hvd1mTqd/K4a/1NJsmAA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2083,9 +2083,9 @@
       }
     },
     "node_modules/camunda-bpmn-js-behaviors": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/camunda-bpmn-js-behaviors/-/camunda-bpmn-js-behaviors-1.15.0.tgz",
-      "integrity": "sha512-3HVWJsDn2/XqOiwmi8TKsYlNxbV003YqPpAsLWSxu0RPezWa9FoDyymRlfW98qhU4uw/5iBaFQUc7RZEe5ygfw==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/camunda-bpmn-js-behaviors/-/camunda-bpmn-js-behaviors-1.16.1.tgz",
+      "integrity": "sha512-0RL1Wei37Rl4wTQqrxtsSipBRubbthx2wIsJRKVEtxXEYIQoTfZREVcQrG3LJywMpjElVIBgG1qQjrqEMfYC9A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2683,9 +2683,9 @@
       "dev": true
     },
     "node_modules/diagram-js": {
-      "version": "15.12.0",
-      "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-15.12.0.tgz",
-      "integrity": "sha512-BQmdvh4fbnvP/2r6QnEEwbpPwS80OLMTn64UQN4CKfg4u08fQd7aqMVyP1kVF2mElYfK7477sAI4kdVKKR1F+g==",
+      "version": "15.14.0",
+      "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-15.14.0.tgz",
+      "integrity": "sha512-xXIKBgK9qC5YIfdUs0Qx+rSlz3DNGMtYxx+pRK+U8eVBD184eZnLCu6KVzaZXXyyC5YRirQayorCVI55Ulhzvg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7325,9 +7325,9 @@
       }
     },
     "node_modules/uuid": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
-      "integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
       "dev": true,
       "funding": [
         "https://github.com/sponsors/broofa",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@bpmn-io/diagram-js-ui": "^0.2.3",
         "bpmn-moddle": "^10.0.0",
         "bpmnlint": "^11.12.1",
-        "bpmnlint-plugin-camunda-compat": "^2.51.0",
+        "bpmnlint-plugin-camunda-compat": "^2.52.0",
         "bpmnlint-utils": "^1.0.2",
         "camunda-bpmn-moddle": "^7.0.1",
         "clsx": "^2.0.0",
@@ -1928,9 +1928,9 @@
       }
     },
     "node_modules/bpmnlint-plugin-camunda-compat": {
-      "version": "2.51.0",
-      "resolved": "https://registry.npmjs.org/bpmnlint-plugin-camunda-compat/-/bpmnlint-plugin-camunda-compat-2.51.0.tgz",
-      "integrity": "sha512-bBLouHd0Yatj2TO5NMwUoMC/jWQu0gCHhApWd+mojXp01+YX73c0nSCKB3zOcuz8I/qtMxPz+7pEjKtFMGph8Q==",
+      "version": "2.52.0",
+      "resolved": "https://registry.npmjs.org/bpmnlint-plugin-camunda-compat/-/bpmnlint-plugin-camunda-compat-2.52.0.tgz",
+      "integrity": "sha512-fsZQbWrsIfmeG8SMZ/aQWZcyqhdtiUIy+b+btBQp3eAAEQZWedxtllqgoGMnFp9ZX6S+JtFKVgwpTirGGeVRLw==",
       "license": "MIT",
       "dependencies": {
         "@bpmn-io/feel-lint": "^3.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@bpmn-io/diagram-js-ui": "^0.2.3",
         "bpmn-moddle": "^10.0.0",
         "bpmnlint": "^11.12.1",
-        "bpmnlint-plugin-camunda-compat": "^2.50.0",
+        "bpmnlint-plugin-camunda-compat": "^2.51.0",
         "bpmnlint-utils": "^1.0.2",
         "camunda-bpmn-moddle": "^7.0.1",
         "clsx": "^2.0.0",
@@ -25,7 +25,7 @@
       "devDependencies": {
         "bpmn-js": "^18.14.0",
         "bpmn-js-element-templates": "^2.23.1",
-        "bpmn-js-properties-panel": "^5.55.0",
+        "bpmn-js-properties-panel": "^5.56.0",
         "camunda-bpmn-js-behaviors": "^1.15.0",
         "chai": "^4.5.0",
         "cross-env": "^7.0.3",
@@ -1867,9 +1867,9 @@
       }
     },
     "node_modules/bpmn-js-properties-panel": {
-      "version": "5.55.0",
-      "resolved": "https://registry.npmjs.org/bpmn-js-properties-panel/-/bpmn-js-properties-panel-5.55.0.tgz",
-      "integrity": "sha512-4NSFpktf+hS9Q0fHyde8lH4LCHc5L535Jgb+SnWkNqQYcDu95DSYKIMN+x958tWv45uEj7fUXAYqVK4Ry9TUcg==",
+      "version": "5.56.0",
+      "resolved": "https://registry.npmjs.org/bpmn-js-properties-panel/-/bpmn-js-properties-panel-5.56.0.tgz",
+      "integrity": "sha512-5qaZxZ9ljQgegLaZZ36iGSX6Uj5YB5CzNN+nqm/D3rf/A7Ox7ag+pqNg77sT3wa7TqOGgA9SAl7NfWugiXlj1w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1928,9 +1928,9 @@
       }
     },
     "node_modules/bpmnlint-plugin-camunda-compat": {
-      "version": "2.50.0",
-      "resolved": "https://registry.npmjs.org/bpmnlint-plugin-camunda-compat/-/bpmnlint-plugin-camunda-compat-2.50.0.tgz",
-      "integrity": "sha512-tY7zRXFHdy6j/1kqDZXuHHPL7uctzt/2DniL00IBQpXL7AYZN5pleaM//neLXCJMolAzuBrzON+8KI8fNjxpgw==",
+      "version": "2.51.0",
+      "resolved": "https://registry.npmjs.org/bpmnlint-plugin-camunda-compat/-/bpmnlint-plugin-camunda-compat-2.51.0.tgz",
+      "integrity": "sha512-bBLouHd0Yatj2TO5NMwUoMC/jWQu0gCHhApWd+mojXp01+YX73c0nSCKB3zOcuz8I/qtMxPz+7pEjKtFMGph8Q==",
       "license": "MIT",
       "dependencies": {
         "@bpmn-io/feel-lint": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@bpmn-io/diagram-js-ui": "^0.2.3",
     "bpmn-moddle": "^10.0.0",
     "bpmnlint": "^11.12.1",
-    "bpmnlint-plugin-camunda-compat": "^2.50.0",
+    "bpmnlint-plugin-camunda-compat": "^2.51.0",
     "bpmnlint-utils": "^1.0.2",
     "camunda-bpmn-moddle": "^7.0.1",
     "clsx": "^2.0.0",
@@ -45,7 +45,7 @@
   "devDependencies": {
     "bpmn-js": "^18.14.0",
     "bpmn-js-element-templates": "^2.23.1",
-    "bpmn-js-properties-panel": "^5.55.0",
+    "bpmn-js-properties-panel": "^5.56.0",
     "camunda-bpmn-js-behaviors": "^1.15.0",
     "chai": "^4.5.0",
     "cross-env": "^7.0.3",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@bpmn-io/diagram-js-ui": "^0.2.3",
     "bpmn-moddle": "^10.0.0",
     "bpmnlint": "^11.12.1",
-    "bpmnlint-plugin-camunda-compat": "^2.51.0",
+    "bpmnlint-plugin-camunda-compat": "^2.52.0",
     "bpmnlint-utils": "^1.0.2",
     "camunda-bpmn-moddle": "^7.0.1",
     "clsx": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "bpmn-moddle": "^10.0.0",
     "bpmnlint": "^11.12.1",
     "bpmnlint-plugin-camunda-compat": "^2.52.0",
-    "bpmnlint-utils": "^1.0.2",
+    "bpmnlint-utils": "^1.1.1",
     "camunda-bpmn-moddle": "^7.0.1",
     "clsx": "^2.0.0",
     "min-dash": "^5.0.0",
@@ -43,10 +43,10 @@
     "zeebe-bpmn-moddle": "^1.13.0"
   },
   "devDependencies": {
-    "bpmn-js": "^18.14.0",
-    "bpmn-js-element-templates": "^2.23.1",
-    "bpmn-js-properties-panel": "^5.56.0",
-    "camunda-bpmn-js-behaviors": "^1.15.0",
+    "bpmn-js": "^18.16.1",
+    "bpmn-js-element-templates": "^2.24.0",
+    "bpmn-js-properties-panel": "^5.57.0",
+    "camunda-bpmn-js-behaviors": "^1.16.1",
     "chai": "^4.5.0",
     "cross-env": "^7.0.3",
     "eslint": "^8.57.1",

--- a/test/spec/utils/error-messages.spec.js
+++ b/test/spec/utils/error-messages.spec.js
@@ -648,6 +648,39 @@ describe('utils/error-messages', function() {
         });
 
 
+        it('should adjust (zeebe:ExecutionListener with `cancel` event type)', async function() {
+
+          // given
+          const executionPlatformVersion = '8.9';
+
+          const node = createElement('bpmn:Process', {
+            isExecutable: true,
+            extensionElements: createElement('bpmn:ExtensionElements', {
+              values: [
+                createElement('zeebe:ExecutionListeners', {
+                  listeners: [
+                    createElement('zeebe:ExecutionListener', {
+                      eventType: 'cancel',
+                      type: 'process-cancelled'
+                    })
+                  ]
+                })
+              ]
+            })
+          });
+
+          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-cancel-execution-listener');
+
+          const report = await getLintError(node, rule, { version: executionPlatformVersion });
+
+          // when
+          const errorMessage = getErrorMessage(report, 'Camunda Cloud', executionPlatformVersion);
+
+          // then
+          expect(errorMessage).to.equal('An <Execution listener> with <Cancel> event type is only supported by Camunda 8.10 or newer');
+        });
+
+
         it('should adjust (zeebe:VersionTag)', async function() {
 
           // given

--- a/test/spec/utils/properties-panel.spec.js
+++ b/test/spec/utils/properties-panel.spec.js
@@ -842,6 +842,33 @@ describe('utils/properties-panel', function() {
 
         // then
         expect(entryIds).to.eql([ 'formType' ]);
+
+        expectErrorMessage(entryIds[ 0 ], 'Only supported by Camunda 8.3 or newer.', report);
+      });
+
+
+      it('start-event-form-embedded - Form', async function() {
+
+        // given
+        const node = createElement('bpmn:StartEvent', {
+          extensionElements: createElement('bpmn:ExtensionElements', {
+            values: [
+              createElement('zeebe:FormDefinition', {
+                formKey: 'camunda-forms:bpmn:UserTaskForm_1'
+              })
+            ]
+          })
+        });
+
+        const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/start-event-form-embedded');
+
+        const report = await getLintError(node, rule, { version: '8.9' });
+
+        // when
+        const entryIds = getEntryIds(report);
+
+        // then
+        expect(entryIds).to.eql([ 'formType' ]);
       });
 
 

--- a/test/spec/utils/properties-panel.spec.js
+++ b/test/spec/utils/properties-panel.spec.js
@@ -2497,6 +2497,40 @@ describe('utils/properties-panel', function() {
           expectErrorMessage(entryIds[ 0 ], 'Only supported by Camunda 8.10 or newer.', report);
         });
 
+
+        it('should mark `cancel` event type as not supported on Camunda < 8.10', async function() {
+
+          // given
+          const node = createElement('bpmn:Process', {
+            id: 'Process_1',
+            isExecutable: true,
+            extensionElements: createElement('bpmn:ExtensionElements', {
+              values: [
+                createElement('zeebe:ExecutionListeners', {
+                  listeners: [
+                    createElement('zeebe:ExecutionListener', {
+                      eventType: 'cancel',
+                      type: 'process-cancelled'
+                    })
+                  ]
+                })
+              ]
+            })
+          });
+
+          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-cancel-execution-listener');
+
+          const report = await getLintError(node, rule, { version: '8.9' });
+
+          // when
+          const entryIds = getEntryIds(report);
+
+          // then
+          expect(entryIds).to.eql([ 'Process_1-executionListener-0-eventType' ]);
+
+          expectErrorMessage(entryIds[ 0 ], 'Only supported by Camunda 8.10 or newer.', report);
+        });
+
       });
 
 


### PR DESCRIPTION
Related to https://github.com/camunda/camunda-modeler/issues/5929

deps: update to `bpmnlint-plugin-camunda-compat@2.51.0`

### Proposed Changes

This PR adds support for the cancel execution listener rules. Also, we get ready for the future event types rules without code adjustments.

<img width="1245" height="1072" alt="image" src="https://github.com/user-attachments/assets/58710660-c1b8-452f-b9b0-7bb496414910" />


### Checklist

To ensure you provided everything we need to look at your PR:

* [x] __Brief textual description__ of the changes present
* [x] __Visual demo__ attached
* [ ] __Steps to try out__ present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->
