### PR TITLE
feat: integrate zeebe:jobPriorityDefinition lint rule

### DIFF
--- a/lib/compiled-config.js
+++ b/lib/compiled-config.js
@@ -61,6 +61,7 @@ const rules = {
   "camunda-compat/no-execution-listeners": "error",
   "camunda-compat/no-expression": "error",
   "camunda-compat/no-interrupting-event-subprocess": "error",
+  "camunda-compat/no-job-priority-definition": "error",
   "camunda-compat/no-loop": "error",
   "camunda-compat/no-multiple-none-start-events": "error",
   "camunda-compat/no-priority-definition": "error",
@@ -243,146 +244,150 @@ import rule_31 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-inter
 
 cache['bpmnlint-plugin-camunda-compat/no-interrupting-event-subprocess'] = rule_31;
 
-import rule_32 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-loop';
+import rule_32 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-job-priority-definition';
 
-cache['bpmnlint-plugin-camunda-compat/no-loop'] = rule_32;
+cache['bpmnlint-plugin-camunda-compat/no-job-priority-definition'] = rule_32;
 
-import rule_33 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-multiple-none-start-events';
+import rule_33 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-loop';
 
-cache['bpmnlint-plugin-camunda-compat/no-multiple-none-start-events'] = rule_33;
+cache['bpmnlint-plugin-camunda-compat/no-loop'] = rule_33;
 
-import rule_34 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-priority-definition';
+import rule_34 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-multiple-none-start-events';
 
-cache['bpmnlint-plugin-camunda-compat/no-priority-definition'] = rule_34;
+cache['bpmnlint-plugin-camunda-compat/no-multiple-none-start-events'] = rule_34;
 
-import rule_35 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-propagate-all-parent-variables';
+import rule_35 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-priority-definition';
 
-cache['bpmnlint-plugin-camunda-compat/no-propagate-all-parent-variables'] = rule_35;
+cache['bpmnlint-plugin-camunda-compat/no-priority-definition'] = rule_35;
 
-import rule_36 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-signal-event-sub-process';
+import rule_36 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-propagate-all-parent-variables';
 
-cache['bpmnlint-plugin-camunda-compat/no-signal-event-sub-process'] = rule_36;
+cache['bpmnlint-plugin-camunda-compat/no-propagate-all-parent-variables'] = rule_36;
 
-import rule_37 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-task-schedule';
+import rule_37 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-signal-event-sub-process';
 
-cache['bpmnlint-plugin-camunda-compat/no-task-schedule'] = rule_37;
+cache['bpmnlint-plugin-camunda-compat/no-signal-event-sub-process'] = rule_37;
 
-import rule_38 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-task-listeners';
+import rule_38 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-task-schedule';
 
-cache['bpmnlint-plugin-camunda-compat/no-task-listeners'] = rule_38;
+cache['bpmnlint-plugin-camunda-compat/no-task-schedule'] = rule_38;
 
-import rule_39 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-template';
+import rule_39 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-task-listeners';
 
-cache['bpmnlint-plugin-camunda-compat/no-template'] = rule_39;
+cache['bpmnlint-plugin-camunda-compat/no-task-listeners'] = rule_39;
 
-import rule_40 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-version-tag';
+import rule_40 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-template';
 
-cache['bpmnlint-plugin-camunda-compat/no-version-tag'] = rule_40;
+cache['bpmnlint-plugin-camunda-compat/no-template'] = rule_40;
 
-import rule_41 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-zeebe-properties';
+import rule_41 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-version-tag';
 
-cache['bpmnlint-plugin-camunda-compat/no-zeebe-properties'] = rule_41;
+cache['bpmnlint-plugin-camunda-compat/no-version-tag'] = rule_41;
 
-import rule_42 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-zeebe-user-task';
+import rule_42 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-zeebe-properties';
 
-cache['bpmnlint-plugin-camunda-compat/no-zeebe-user-task'] = rule_42;
+cache['bpmnlint-plugin-camunda-compat/no-zeebe-properties'] = rule_42;
 
-import rule_43 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/priority-definition';
+import rule_43 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-zeebe-user-task';
 
-cache['bpmnlint-plugin-camunda-compat/priority-definition'] = rule_43;
+cache['bpmnlint-plugin-camunda-compat/no-zeebe-user-task'] = rule_43;
 
-import rule_44 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/zeebe-user-task';
+import rule_44 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/priority-definition';
 
-cache['bpmnlint-plugin-camunda-compat/zeebe-user-task'] = rule_44;
+cache['bpmnlint-plugin-camunda-compat/priority-definition'] = rule_44;
 
-import rule_45 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/secrets';
+import rule_45 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/zeebe-user-task';
 
-cache['bpmnlint-plugin-camunda-compat/secrets'] = rule_45;
+cache['bpmnlint-plugin-camunda-compat/zeebe-user-task'] = rule_45;
 
-import rule_46 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/sequence-flow-condition';
+import rule_46 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/secrets';
 
-cache['bpmnlint-plugin-camunda-compat/sequence-flow-condition'] = rule_46;
+cache['bpmnlint-plugin-camunda-compat/secrets'] = rule_46;
 
-import rule_47 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/signal-reference';
+import rule_47 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/sequence-flow-condition';
 
-cache['bpmnlint-plugin-camunda-compat/signal-reference'] = rule_47;
+cache['bpmnlint-plugin-camunda-compat/sequence-flow-condition'] = rule_47;
 
-import rule_48 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/start-event-form';
+import rule_48 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/signal-reference';
 
-cache['bpmnlint-plugin-camunda-compat/start-event-form'] = rule_48;
+cache['bpmnlint-plugin-camunda-compat/signal-reference'] = rule_48;
 
-import rule_49 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/start-event-form-embedded';
+import rule_49 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/start-event-form';
 
-cache['bpmnlint-plugin-camunda-compat/start-event-form-embedded'] = rule_49;
+cache['bpmnlint-plugin-camunda-compat/start-event-form'] = rule_49;
 
-import rule_50 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/subscription';
+import rule_50 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/start-event-form-embedded';
 
-cache['bpmnlint-plugin-camunda-compat/subscription'] = rule_50;
+cache['bpmnlint-plugin-camunda-compat/start-event-form-embedded'] = rule_50;
 
-import rule_51 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/task-listener';
+import rule_51 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/subscription';
 
-cache['bpmnlint-plugin-camunda-compat/task-listener'] = rule_51;
+cache['bpmnlint-plugin-camunda-compat/subscription'] = rule_51;
 
-import rule_52 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/task-schedule';
+import rule_52 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/task-listener';
 
-cache['bpmnlint-plugin-camunda-compat/task-schedule'] = rule_52;
+cache['bpmnlint-plugin-camunda-compat/task-listener'] = rule_52;
 
-import rule_53 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/timer';
+import rule_53 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/task-schedule';
 
-cache['bpmnlint-plugin-camunda-compat/timer'] = rule_53;
+cache['bpmnlint-plugin-camunda-compat/task-schedule'] = rule_53;
 
-import rule_54 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/user-task-definition';
+import rule_54 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/timer';
 
-cache['bpmnlint-plugin-camunda-compat/user-task-definition'] = rule_54;
+cache['bpmnlint-plugin-camunda-compat/timer'] = rule_54;
 
-import rule_55 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/user-task-form';
+import rule_55 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/user-task-definition';
 
-cache['bpmnlint-plugin-camunda-compat/user-task-form'] = rule_55;
+cache['bpmnlint-plugin-camunda-compat/user-task-definition'] = rule_55;
 
-import rule_56 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/variable-name';
+import rule_56 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/user-task-form';
 
-cache['bpmnlint-plugin-camunda-compat/variable-name'] = rule_56;
+cache['bpmnlint-plugin-camunda-compat/user-task-form'] = rule_56;
 
-import rule_57 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/version-tag';
+import rule_57 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/variable-name';
 
-cache['bpmnlint-plugin-camunda-compat/version-tag'] = rule_57;
+cache['bpmnlint-plugin-camunda-compat/variable-name'] = rule_57;
 
-import rule_58 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/wait-for-completion';
+import rule_58 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/version-tag';
 
-cache['bpmnlint-plugin-camunda-compat/wait-for-completion'] = rule_58;
+cache['bpmnlint-plugin-camunda-compat/version-tag'] = rule_58;
 
-import rule_59 from 'bpmnlint/rules/start-event-required';
+import rule_59 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/wait-for-completion';
 
-cache['bpmnlint/start-event-required'] = rule_59;
+cache['bpmnlint-plugin-camunda-compat/wait-for-completion'] = rule_59;
 
-import rule_60 from 'bpmnlint/rules/ad-hoc-sub-process';
+import rule_60 from 'bpmnlint/rules/start-event-required';
 
-cache['bpmnlint/ad-hoc-sub-process'] = rule_60;
+cache['bpmnlint/start-event-required'] = rule_60;
 
-import rule_61 from 'bpmnlint/rules/conditional-event';
+import rule_61 from 'bpmnlint/rules/ad-hoc-sub-process';
 
-cache['bpmnlint/conditional-event'] = rule_61;
+cache['bpmnlint/ad-hoc-sub-process'] = rule_61;
 
-import rule_62 from 'bpmnlint/rules/event-based-gateway';
+import rule_62 from 'bpmnlint/rules/conditional-event';
 
-cache['bpmnlint/event-based-gateway'] = rule_62;
+cache['bpmnlint/conditional-event'] = rule_62;
 
-import rule_63 from 'bpmnlint/rules/event-sub-process-typed-start-event';
+import rule_63 from 'bpmnlint/rules/event-based-gateway';
 
-cache['bpmnlint/event-sub-process-typed-start-event'] = rule_63;
+cache['bpmnlint/event-based-gateway'] = rule_63;
 
-import rule_64 from 'bpmnlint/rules/link-event';
+import rule_64 from 'bpmnlint/rules/event-sub-process-typed-start-event';
 
-cache['bpmnlint/link-event'] = rule_64;
+cache['bpmnlint/event-sub-process-typed-start-event'] = rule_64;
 
-import rule_65 from 'bpmnlint/rules/no-duplicate-sequence-flows';
+import rule_65 from 'bpmnlint/rules/link-event';
 
-cache['bpmnlint/no-duplicate-sequence-flows'] = rule_65;
+cache['bpmnlint/link-event'] = rule_65;
 
-import rule_66 from 'bpmnlint/rules/sub-process-blank-start-event';
+import rule_66 from 'bpmnlint/rules/no-duplicate-sequence-flows';
 
-cache['bpmnlint/sub-process-blank-start-event'] = rule_66;
+cache['bpmnlint/no-duplicate-sequence-flows'] = rule_66;
 
-import rule_67 from 'bpmnlint/rules/single-blank-start-event';
+import rule_67 from 'bpmnlint/rules/sub-process-blank-start-event';
 
-cache['bpmnlint/single-blank-start-event'] = rule_67;
+cache['bpmnlint/sub-process-blank-start-event'] = rule_67;
+
+import rule_68 from 'bpmnlint/rules/single-blank-start-event';
+
+cache['bpmnlint/single-blank-start-event'] = rule_68;

--- a/lib/utils/error-messages.js
+++ b/lib/utils/error-messages.js
@@ -343,6 +343,10 @@ function getExtensionElementNotAllowedErrorMessage(report, executionPlatform, ex
     return getSupportedMessage('A <User Task> with <Priority>', executionPlatform, executionPlatformVersion, allowedVersion);
   }
 
+  if (is(extensionElement, 'zeebe:JobPriorityDefinition')) {
+    return getSupportedMessage(`${ getIndefiniteArticle(typeString) } <${ typeString }> with <Job priority>`, executionPlatform, executionPlatformVersion, allowedVersion);
+  }
+
   if (is(node, 'bpmn:StartEvent') && is(extensionElement, 'zeebe:FormDefinition')) {
     return getSupportedMessage('A <Start Event> with <User Task Form>', executionPlatform, executionPlatformVersion, allowedVersion);
   }

--- a/lib/utils/properties-panel.js
+++ b/lib/utils/properties-panel.js
@@ -337,6 +337,10 @@ export function getEntryIds(report) {
     return [ 'priorityDefinitionPriority' ];
   }
 
+  if (isExtensionElementNotAllowedError(data, 'zeebe:JobPriorityDefinition')) {
+    return [ 'jobPriorityDefinitionPriority' ];
+  }
+
   if (isPropertyError(data, 'propagateAllParentVariables', 'zeebe:CalledElement')) {
     return [ 'propagateAllParentVariables' ];
   }
@@ -627,6 +631,10 @@ export function getErrorMessage(id, report) {
     } else {
       return 'Must be an expression, or an integer between 0 and 100.';
     }
+  }
+
+  if (id === 'jobPriorityDefinitionPriority') {
+    return getNotSupportedMessage('', allowedVersion);
   }
 
   if (id === 'propagateAllParentVariables') {

--- a/test/spec/utils/error-messages.spec.js
+++ b/test/spec/utils/error-messages.spec.js
@@ -475,6 +475,33 @@ describe('utils/error-messages', function() {
         });
 
 
+        it('should adjust (service task with zeebe:JobPriorityDefinition)', async function() {
+
+          // given
+          const executionPlatformVersion = '8.5';
+
+          const node = createElement('bpmn:ServiceTask', {
+            extensionElements: createElement('bpmn:ExtensionElements', {
+              values: [
+                createElement('zeebe:JobPriorityDefinition', {
+                  priority: '50'
+                })
+              ]
+            })
+          });
+
+          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-job-priority-definition');
+
+          const report = await getLintError(node, rule, { version: executionPlatformVersion });
+
+          // when
+          const errorMessage = getErrorMessage(report, 'Camunda Cloud', executionPlatformVersion);
+
+          // then
+          expect(errorMessage).to.equal('A <Service Task> with <Job priority> is only supported by Camunda 8.10 or newer');
+        });
+
+
         it('should adjust (start event with zeebe:FormDefinition)', async function() {
 
           // given

--- a/test/spec/utils/properties-panel.spec.js
+++ b/test/spec/utils/properties-panel.spec.js
@@ -1854,6 +1854,31 @@ describe('utils/properties-panel', function() {
       });
 
 
+      it('service task - Job priority not supported', async function() {
+
+        // given
+        const node = createElement('bpmn:ServiceTask', {
+          extensionElements: createElement('bpmn:ExtensionElements', {
+            values: [
+              createElement('zeebe:JobPriorityDefinition')
+            ]
+          })
+        });
+
+        const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-job-priority-definition');
+
+        const report = await getLintError(node, rule, { version: '8.9' });
+
+        // when
+        const entryIds = getEntryIds(report);
+
+        // then
+        expect(entryIds).to.eql([ 'jobPriorityDefinitionPriority' ]);
+
+        expectErrorMessage(entryIds[ 0 ], 'Only supported by Camunda 8.10 or newer.', report);
+      });
+
+
       it('call activity - Propagate all variables', async function() {
 
         // given


### PR DESCRIPTION
Integrates the `no-job-priority-definition` compat rule: human-readable error message + properties-panel field focus (`jobPriorityDefinitionPriority`) and concise message.

Part of camunda/camunda-modeler#5889.

> Depends on camunda/bpmnlint-plugin-camunda-compat (the new rule). Tested against a local overlay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)