### PR TITLE
fix: show lint errors for processes displayed as participants

### DIFF
--- a/lib/Linter.js
+++ b/lib/Linter.js
@@ -7,6 +7,8 @@ import Resolver from './Resolver';
 
 import { isString } from 'min-dash';
 
+import { is } from 'bpmnlint-utils';
+
 import { resolver as RulesResolver } from './compiled-config';
 
 import modelerModdle from 'modeler-moddle/resources/modeler.json';
@@ -81,13 +83,17 @@ export class Linter {
 
     const reportsByRule = await linter.lint(rootElement);
 
+    const participantIdByProcessId = getParticipantIdByProcessId(rootElement);
+
     return Object.entries(reportsByRule).reduce((allReports, entry) => {
       const [ rule, reports ] = entry;
 
       return [
         ...allReports,
         ...reports.map(report => {
-          const entryIds = getEntryIds(report);
+          const prefixId = participantIdByProcessId[report.id] || report.id;
+
+          const entryIds = getEntryIds(report, prefixId);
 
           return {
             ...report,
@@ -169,6 +175,29 @@ export class Linter {
       ...this._plugins.map(({ resolver = NoopResolver }) => resolver)
     ]);
   }
+}
+
+/**
+ * Build a lookup from process id to the participant (pool) id displaying it.
+ * Used to resolve entry-id prefixes for processes shown as participants.
+ *
+ * @param {Object} rootElement
+ *
+ * @returns {Object<string, string>}
+ */
+function getParticipantIdByProcessId(rootElement) {
+  return (rootElement.get('rootElements') || [])
+    .filter(element => is(element, 'bpmn:Collaboration'))
+    .flatMap(collaboration => collaboration.get('participants') || [])
+    .reduce((map, participant) => {
+      const processRef = participant.get('processRef');
+
+      if (processRef) {
+        map[processRef.get('id')] = participant.get('id');
+      }
+
+      return map;
+    }, {});
 }
 
 function getConfigName(executionPlatform, executionPlatformVersion) {

--- a/lib/modeler/Linting.js
+++ b/lib/modeler/Linting.js
@@ -86,7 +86,10 @@ export default class Linting {
 
     if (!element) {
       element = this._elementRegistry.filter(element => {
-        return is(element, 'bpmn:Participant') && getBusinessObject(element).get('processRef').get('id') === id;
+        const processRef = is(element, 'bpmn:Participant')
+          && getBusinessObject(element).get('processRef');
+
+        return processRef && processRef.get('id') === id;
       })[ 0 ];
     }
 

--- a/lib/utils/properties-panel.js
+++ b/lib/utils/properties-panel.js
@@ -30,7 +30,7 @@ export function getErrors(reports, element) {
     const { category } = report;
 
     if (!element
-      || getBusinessObject(element).get('id') !== report.id
+      || !isReportForElement(report, element)
       || category !== 'error') {
       return errors;
     }
@@ -55,10 +55,31 @@ export function getErrors(reports, element) {
   }, {});
 }
 
-export function getEntryIds(report) {
+/**
+ * Check whether a report targets the given element, directly or via its
+ * process (when the element is a participant showing that process).
+ *
+ * @param {Object} report
+ * @param {Object} element
+ *
+ * @returns {boolean}
+ */
+function isReportForElement(report, element) {
+  const businessObject = getBusinessObject(element);
+
+  if (businessObject.get('id') === report.id) {
+    return true;
+  }
+
+  const processRef = is(businessObject, 'bpmn:Participant')
+    && businessObject.get('processRef');
+
+  return processRef && processRef.get('id') === report.id;
+}
+
+export function getEntryIds(report, prefixId) {
   const {
     data = {},
-    id,
     path,
     propertiesPanel = {}
   } = report;
@@ -66,6 +87,10 @@ export function getEntryIds(report) {
   if (propertiesPanel.entryIds) {
     return propertiesPanel.entryIds;
   }
+
+  // id used as entry-id prefix; resolved by the caller to the displayed
+  // element (the participant id for an expanded participant)
+  const id = prefixId || report.id;
 
   if (isPropertyError(data, 'isExecutable')) {
     return [ 'isExecutable' ];

--- a/test/spec/Linter.spec.js
+++ b/test/spec/Linter.spec.js
@@ -13,6 +13,7 @@ import simpleXML from './simple.bpmn';
 import missingDiXML from './simple-no-di.bpmn';
 import correctnessXML from './correctness.bpmn';
 import noExecutionPlatformXML from './no-execution-platform.bpmn';
+import collaborationELXML from './modeler/linting-collaboration-el.bpmn';
 import camundaCloud10XML from './camunda-cloud-1-0.bpmn';
 import camundaCloud10ErrorsXML from './camunda-cloud-1-0-errors.bpmn';
 import camundaCloud11XML from './camunda-cloud-1-1.bpmn';
@@ -141,6 +142,22 @@ describe('Linter', function() {
       reports.forEach(report => {
         expect(report.meta.documentation.url).to.exist;
       });
+    });
+
+
+    it('should prefix entry ids with participant id (expanded participant)', async function() {
+
+      // given
+      const { root } = await createModdle(collaborationELXML);
+
+      // when
+      const reports = await linter.lint(root);
+
+      // then
+      const report = reports.find(report => report.rule === 'camunda-compat/execution-listener');
+
+      expect(report).to.exist;
+      expect(report.propertiesPanel.entryIds).to.eql([ 'Participant_1-executionListener-0-listenerType' ]);
     });
 
 

--- a/test/spec/modeler/Linting.spec.js
+++ b/test/spec/modeler/Linting.spec.js
@@ -45,6 +45,7 @@ import lintingCSS from '../../../assets/linting.css';
 
 import diagramXMLCloud from './linting-cloud.bpmn';
 import diagramCollaborationXMLCloud from './linting-collaboration-cloud.bpmn';
+import diagramCollaborationELXMLCloud from './linting-collaboration-el.bpmn';
 import diagramXMLCloudScroll from './linting-cloud-scroll.bpmn';
 import diagramXMLPlatform from './linting-platform.bpmn';
 
@@ -661,6 +662,64 @@ describe('Linting', function() {
 
             // then
             expect(selection.get()).to.eql([ participant ]);
+          }
+        ));
+
+      });
+
+
+      describe('collaboration with execution listener', function() {
+
+        beforeEach(createModeler(diagramCollaborationELXMLCloud,
+          [
+            zeebePropertiesProviderModule,
+            cloudElementTemplatesPropertiesProvider
+          ],
+          {
+            zeebe: zeebeModdleExtension
+          })
+        );
+
+
+        it('should show error on participant', inject(
+          async function(bpmnjs, elementRegistry, eventBus, linting, selection) {
+
+            // given
+            const participant = elementRegistry.get('Participant_1');
+
+            const reports = await linter.lint(bpmnjs.getDefinitions());
+
+            const report = reports.find(report => report.id === 'Process_1');
+
+            linting.setErrors(reports);
+
+            linting.activate();
+
+            const propertiesPanelSetErrorSpy = sinon.spy();
+
+            eventBus.on('propertiesPanel.setErrors', propertiesPanelSetErrorSpy);
+
+            const propertiesPanelShowEntrySpy = sinon.spy();
+
+            eventBus.on('propertiesPanel.showEntry', propertiesPanelShowEntrySpy);
+
+            // when
+            linting.showError(report);
+
+            clock.tick();
+
+            // then
+            expect(selection.get()).to.eql([ participant ]);
+
+            expect(propertiesPanelSetErrorSpy).to.have.been.calledOnce;
+            expect(propertiesPanelSetErrorSpy).to.have.been.calledWithMatch({
+              errors: getErrors(reports, participant)
+            });
+
+            expect(propertiesPanelShowEntrySpy).to.have.been.calledOnce;
+            expect(propertiesPanelShowEntrySpy).to.have.been.calledWithMatch({
+              id: 'Participant_1-executionListener-0-listenerType'
+            });
           }
         ));
 

--- a/test/spec/modeler/linting-collaboration-el.bpmn
+++ b/test/spec/modeler/linting-collaboration-el.bpmn
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_el" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.22.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.6.0">
+  <bpmn:collaboration id="Collaboration_1">
+    <bpmn:participant id="Participant_1" processRef="Process_1" />
+    <bpmn:participant id="Participant_2" />
+  </bpmn:collaboration>
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:extensionElements>
+      <zeebe:executionListeners>
+        <zeebe:executionListener eventType="start" />
+      </zeebe:executionListeners>
+    </bpmn:extensionElements>
+    <bpmn:startEvent id="StartEvent_1" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Collaboration_1">
+      <bpmndi:BPMNShape id="Participant_1_di" bpmnElement="Participant_1" isHorizontal="true">
+        <dc:Bounds x="129" y="52" width="600" height="250" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Participant_2_di" bpmnElement="Participant_2" isHorizontal="true">
+        <dc:Bounds x="129" y="332" width="600" height="250" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="StartEvent_1_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="209" y="139" width="36" height="36" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/spec/utils/properties-panel.spec.js
+++ b/test/spec/utils/properties-panel.spec.js
@@ -18,6 +18,7 @@ import {
 
 import propertiesPanelXML from './properties-panel.bpmn';
 import propertiesPanelInfoXML from './properties-panel-info.bpmn';
+import collaborationELXML from '../modeler/linting-collaboration-el.bpmn';
 
 describe('utils/properties-panel', function() {
 
@@ -2962,6 +2963,29 @@ describe('utils/properties-panel', function() {
         // then
         expect(errors).to.eql({
           targetProcessId: 'Process ID must be defined.'
+        });
+      });
+
+
+      it('should return errors for participant (expanded participant)', async function() {
+
+        // given
+        const linter = new Linter();
+
+        const { root } = await createModdle(collaborationELXML);
+
+        const reports = await linter.lint(root);
+
+        // when
+        const collaboration = root.rootElements.find(({ $type }) => $type === 'bpmn:Collaboration');
+
+        const participant = collaboration.participants.find(({ id }) => id === 'Participant_1');
+
+        const errors = getErrors(reports, participant);
+
+        // then
+        expect(errors).to.eql({
+          'Participant_1-executionListener-0-listenerType': 'Must be defined.'
         });
       });
 


### PR DESCRIPTION
Related to https://github.com/camunda/camunda-modeler/issues/5981

### Proposed Changes

**Cause:** bpmnlint reports the error against the **process** id, but the panel renders the entries under the **participant** id, so they never matched. Locating the participant also dereferenced `processRef` without a null check.

**Fix:** resolve the entry-id prefix to the participant when the process is displayed as one, match reports against the participant via its `processRef`, and null-guard `processRef`.


https://github.com/user-attachments/assets/e763981d-24d4-475a-b2fc-1d0c5fe85f52



### Checklist

To ensure you provided everything we need to look at your PR:

* [x] __Brief textual description__ of the changes present
* [x] __Visual demo__ attached
* [ ] __Steps to try out__ present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->
