### PR TITLE
feat(properties-panel): show inline lint errors on template-bound fields

### DIFF
--- a/lib/modeler/Linting.js
+++ b/lib/modeler/Linting.js
@@ -1,6 +1,6 @@
 import { getBusinessObject, is } from 'bpmn-js/lib/util/ModelUtil';
 
-import { getErrors } from '../utils/properties-panel';
+import { getErrors, remapTemplateEntryId } from '../utils/properties-panel';
 
 export default class Linting {
   constructor(canvas, config, elementRegistry, eventBus, injector, lintingAnnotations, selection) {
@@ -39,10 +39,16 @@ export default class Linting {
 
     const { entryIds = [] } = propertiesPanel;
 
+    const templates = this._elementTemplates && this._elementTemplates.getAll();
+
+    const remappedEntryIds = selectableElement
+      ? entryIds.map(entryId => remapTemplateEntryId(entryId, selectableElement, templates))
+      : entryIds;
+
     // TODO(philippfromme): remove timeout once properties panel is fixed
     setTimeout(() => {
       this._eventBus.fire('propertiesPanel.showEntry', {
-        id: entryIds[ Math.max(0, entryIds.length - 1) ]
+        id: remappedEntryIds[ Math.max(0, remappedEntryIds.length - 1) ]
       });
     });
   }

--- a/lib/modeler/Linting.js
+++ b/lib/modeler/Linting.js
@@ -1,6 +1,6 @@
 import { getBusinessObject, is } from 'bpmn-js/lib/util/ModelUtil';
 
-import { getErrors, remapTemplateEntryId } from '../utils/properties-panel';
+import { getErrors, remapEntryIds } from '../utils/properties-panel';
 
 export default class Linting {
   constructor(canvas, config, elementRegistry, eventBus, injector, lintingAnnotations, selection) {
@@ -41,14 +41,18 @@ export default class Linting {
 
     const templates = this._elementTemplates && this._elementTemplates.getAll();
 
-    const remappedEntryIds = selectableElement
-      ? entryIds.map(entryId => remapTemplateEntryId(entryId, selectableElement, templates))
-      : entryIds;
+    const lastEntryId = entryIds[ Math.max(0, entryIds.length - 1) ];
+
+    // remapping can expand a single generic entry id into several (e.g. a
+    // duplicate fromAi() key spans more than one input); focus the first one
+    const showEntryId = selectableElement && lastEntryId !== undefined
+      ? remapEntryIds(lastEntryId, selectableElement, templates, report)[ 0 ]
+      : lastEntryId;
 
     // TODO(philippfromme): remove timeout once properties panel is fixed
     setTimeout(() => {
       this._eventBus.fire('propertiesPanel.showEntry', {
-        id: remappedEntryIds[ Math.max(0, remappedEntryIds.length - 1) ]
+        id: showEntryId
       });
     });
   }

--- a/lib/modeler/Linting.js
+++ b/lib/modeler/Linting.js
@@ -3,10 +3,11 @@ import { getBusinessObject, is } from 'bpmn-js/lib/util/ModelUtil';
 import { getErrors } from '../utils/properties-panel';
 
 export default class Linting {
-  constructor(canvas, config, elementRegistry, eventBus, lintingAnnotations, selection) {
+  constructor(canvas, config, elementRegistry, eventBus, injector, lintingAnnotations, selection) {
     this._canvas = canvas;
     this._elementRegistry = elementRegistry;
     this._eventBus = eventBus;
+    this._elementTemplates = injector.get('elementTemplates', false);
     this._lintingAnnotations = lintingAnnotations;
     this._selection = selection;
 
@@ -76,8 +77,10 @@ export default class Linting {
     // set properties panel errors
     const selectedElement = this._getSelectedElement();
 
+    const templates = this._elementTemplates && this._elementTemplates.getAll();
+
     this._eventBus.fire('propertiesPanel.setErrors', {
-      errors: getErrors(this._reports, selectedElement)
+      errors: getErrors(this._reports, selectedElement, templates)
     });
   }
 
@@ -118,6 +121,7 @@ Linting.$inject = [
   'config.linting',
   'elementRegistry',
   'eventBus',
+  'injector',
   'lintingAnnotations',
   'selection'
 ];

--- a/lib/utils/properties-panel.js
+++ b/lib/utils/properties-panel.js
@@ -17,15 +17,26 @@ const TIMER_PROPERTIES = [
 
 const INVALID_VARIABLE_NAME_ERROR = 'Must be a valid variable name.';
 
+const GENERIC_IO_MAPPING_ENTRY_ID = /^(.+)-(input|output)-(\d+)-source$/;
+
+const TEMPLATE_BINDING_TYPES = {
+  input: 'zeebe:input',
+  output: 'zeebe:output'
+};
+
 /**
  * Get errors for a given element.
  *
  * @param {Object[]} reports
  * @param {Object} element
+ * @param {Object[]} [templates] - as returned by elementTemplates.getAll();
+ * when provided, a generic io-mapping entry id on an error-severity report
+ * is remapped to the applied element template's own entry id, so the error
+ * attaches inline the same way it already does for non-templated fields.
  *
  * @returns {Object}
  */
-export function getErrors(reports, element) {
+export function getErrors(reports, element, templates) {
   return reports.reduce((errors, report) => {
     const { category } = report;
 
@@ -48,11 +59,137 @@ export function getErrors(reports, element) {
       ...ids.reduce((errors, id) => {
         return {
           ...errors,
-          [ id ]: getErrorMessage(id, report) || message
+          [ remapTemplateEntryId(id, element, templates) ]: getErrorMessage(id, report) || message
         };
       }, {})
     };
   }, {});
+}
+
+/**
+ * Remap a generic io-mapping entry id ({taskId}-input-{index}-source) to the
+ * real properties-panel entry id when the field is bound through an applied
+ * element template. Reports that don't carry a generic io-mapping entry id,
+ * or whose template can't be resolved, are returned unchanged.
+ */
+function remapTemplateEntryId(entryId, element, templates) {
+  if (!templates || !templates.length) {
+    return entryId;
+  }
+
+  const match = entryId.match(GENERIC_IO_MAPPING_ENTRY_ID);
+
+  if (!match) {
+    return entryId;
+  }
+
+  const [ , taskId, kind, index ] = match;
+
+  const businessObject = getBusinessObject(element);
+
+  if (!businessObject || businessObject.get('id') !== taskId) {
+    return entryId;
+  }
+
+  const templateId = businessObject.get('modelerTemplate');
+
+  if (!templateId) {
+    return entryId;
+  }
+
+  const template = findTemplate(templates, templateId, businessObject.get('modelerTemplateVersion'));
+
+  if (!template) {
+    return entryId;
+  }
+
+  const target = getIoMappingTarget(businessObject, kind, Number(index));
+
+  if (!target) {
+    return entryId;
+  }
+
+  return resolveTemplateEntryId(template, kind, target) || entryId;
+}
+
+function findTemplate(templates, templateId, templateVersion) {
+  const candidates = templates.filter((template) => template.id === templateId);
+
+  if (candidates.length <= 1) {
+    return candidates[ 0 ] || null;
+  }
+
+  if (templateVersion === undefined || templateVersion === null) {
+    return null;
+  }
+
+  return candidates.find((template) => String(template.version) === String(templateVersion)) || null;
+}
+
+function getIoMappingTarget(businessObject, kind, index) {
+  const extensionElements = businessObject.get('extensionElements');
+
+  if (!extensionElements) {
+    return null;
+  }
+
+  const ioMapping = (extensionElements.get('values') || []).find((value) => is(value, 'zeebe:IoMapping'));
+
+  if (!ioMapping) {
+    return null;
+  }
+
+  const parameters = ioMapping.get(kind === 'input' ? 'inputParameters' : 'outputParameters') || [];
+
+  const parameter = parameters[ index ];
+
+  return parameter ? parameter.get('target') : null;
+}
+
+/**
+ * Resolve the properties-panel entry id that bpmn-js-element-templates
+ * generates for a template-bound property, given the template descriptor and
+ * the io-mapping target it's bound to.
+ *
+ * Reverse-engineered from bpmn-js-element-templates' CustomProperties$1 /
+ * createCustomEntry$1 / groupByGroupId$1 (dist/index.esm.js, ~line
+ * 7618-8055): properties are grouped by their `group` field; groups that
+ * resolve to a declared `template.groups` entry render under
+ * `custom-entry-{template.id}-{groupId}-{indexWithinGroup}`, everything else
+ * (no group, or a group id not declared in template.groups) falls into a
+ * single default bucket rendered under
+ * `custom-entry-{template.id}-{indexWithinDefaultBucket}`, in original
+ * `template.properties` order.
+ */
+function resolveTemplateEntryId(template, kind, target) {
+  if (!template || !template.properties) {
+    return null;
+  }
+
+  const bindingType = TEMPLATE_BINDING_TYPES[ kind ];
+
+  const property = template.properties.find(
+    (p) => p.binding && p.binding.type === bindingType && p.binding.name === target
+  );
+
+  if (!property) {
+    return null;
+  }
+
+  const groups = template.groups || [];
+  const validGroup = property.group && groups.some((group) => group.id === property.group);
+
+  if (validGroup) {
+    const siblings = template.properties.filter((p) => p.group === property.group);
+    const index = siblings.indexOf(property);
+
+    return `custom-entry-${template.id}-${property.group}-${index}`;
+  }
+
+  const defaultBucket = template.properties.filter((p) => !p.group || !groups.some((group) => group.id === p.group));
+  const index = defaultBucket.indexOf(property);
+
+  return `custom-entry-${template.id}-${index}`;
 }
 
 /**

--- a/lib/utils/properties-panel.js
+++ b/lib/utils/properties-panel.js
@@ -72,7 +72,7 @@ export function getErrors(reports, element, templates) {
  * element template. Reports that don't carry a generic io-mapping entry id,
  * or whose template can't be resolved, are returned unchanged.
  */
-function remapTemplateEntryId(entryId, element, templates) {
+export function remapTemplateEntryId(entryId, element, templates) {
   if (!templates || !templates.length) {
     return entryId;
   }

--- a/lib/utils/properties-panel.js
+++ b/lib/utils/properties-panel.js
@@ -19,6 +19,13 @@ const INVALID_VARIABLE_NAME_ERROR = 'Must be a valid variable name.';
 
 const GENERIC_IO_MAPPING_ENTRY_ID = /^(.+)-(input|output)-(\d+)-source$/;
 
+// bpmnlint-plugin-camunda-compat/rules/utils/error-types' ERROR_TYPES doesn't
+// export this yet (agent-fromai-contract's duplicate-key check is still in
+// bpmnlint-plugin-camunda-compat#245, unpublished). Hardcode the string value
+// directly rather than depending on an undefined import, so the comparison
+// below stays meaningful once that PR ships too.
+const AGENT_FEEL_KEY_DUPLICATE = 'camunda.agentFeelKeyDuplicate';
+
 const TEMPLATE_BINDING_TYPES = {
   input: 'zeebe:input',
   output: 'zeebe:output'
@@ -57,10 +64,14 @@ export function getErrors(reports, element, templates) {
     return {
       ...errors,
       ...ids.reduce((errors, id) => {
-        return {
-          ...errors,
-          [ remapTemplateEntryId(id, element, templates) ]: getErrorMessage(id, report) || message
-        };
+        const errorMessage = getErrorMessage(id, report) || message;
+
+        return remapEntryIds(id, element, templates, report).reduce((errors, remappedId) => {
+          return {
+            ...errors,
+            [ remappedId ]: errorMessage
+          };
+        }, errors);
       }, {})
     };
   }, {});
@@ -110,6 +121,94 @@ export function remapTemplateEntryId(entryId, element, templates) {
   }
 
   return resolveTemplateEntryId(template, kind, target) || entryId;
+}
+
+const FROM_AI_KEY_PATTERN = /fromAi\(\s*(toolCall\.[A-Za-z_][A-Za-z0-9_]*)/;
+
+/**
+ * Remap a report's entry id(s) to the properties-panel entry id(s) that
+ * should actually show the error inline. Most reports carry a single generic
+ * io-mapping entry id, remapped 1:1 by {@link remapTemplateEntryId}. A
+ * duplicate fromAi() key, however, spans more than one input, so
+ * agent-fromai-contract's checkDuplicateKeys reports the generic 'inputs'
+ * group id instead of a per-index one; this expands that into the real
+ * template-bound entry id of every input declaring the duplicated key, so all
+ * of them get the inline error, not just the group as a whole.
+ *
+ * @returns {string[]}
+ */
+export function remapEntryIds(entryId, element, templates, report) {
+  const isDuplicateKeyReport = report && report.data && report.data.type === AGENT_FEEL_KEY_DUPLICATE;
+
+  if (entryId !== 'inputs' || !isDuplicateKeyReport) {
+    return [ remapTemplateEntryId(entryId, element, templates) ];
+  }
+
+  const businessObject = getBusinessObject(element);
+  const taskId = businessObject && businessObject.get('id');
+
+  const duplicateIndices = findDuplicateFromAiInputIndices(businessObject);
+
+  if (!taskId || !duplicateIndices.length) {
+    return [ entryId ];
+  }
+
+  return duplicateIndices.map(
+    (index) => remapTemplateEntryId(`${ taskId }-input-${ index }-source`, element, templates)
+  );
+}
+
+/**
+ * Find the io-mapping input indices whose fromAi() call declares a key that's
+ * also declared by another input on the same task (the structural condition
+ * agent-fromai-contract's checkDuplicateKeys reports on), in io-mapping order.
+ *
+ * @returns {number[]}
+ */
+function findDuplicateFromAiInputIndices(businessObject) {
+  if (!businessObject) {
+    return [];
+  }
+
+  const extensionElements = businessObject.get('extensionElements');
+
+  if (!extensionElements) {
+    return [];
+  }
+
+  const ioMapping = (extensionElements.get('values') || []).find((value) => is(value, 'zeebe:IoMapping'));
+
+  if (!ioMapping) {
+    return [];
+  }
+
+  const keysByIndex = (ioMapping.get('inputParameters') || []).map((input) => {
+    const source = input.get('source');
+
+    if (!source || !source.startsWith('=')) {
+      return null;
+    }
+
+    const match = source.match(FROM_AI_KEY_PATTERN);
+
+    return match ? match[ 1 ] : null;
+  });
+
+  const countByKey = keysByIndex.reduce((counts, key) => {
+    if (key) {
+      counts[ key ] = (counts[ key ] || 0) + 1;
+    }
+
+    return counts;
+  }, {});
+
+  return keysByIndex.reduce((indices, key, index) => {
+    if (key && countByKey[ key ] > 1) {
+      indices.push(index);
+    }
+
+    return indices;
+  }, []);
 }
 
 function findTemplate(templates, templateId, templateVersion) {

--- a/test/spec/modeler/Linting.spec.js
+++ b/test/spec/modeler/Linting.spec.js
@@ -50,6 +50,7 @@ import diagramCollaborationXMLCloud from './linting-collaboration-cloud.bpmn';
 import diagramCollaborationELXMLCloud from './linting-collaboration-el.bpmn';
 import diagramXMLCloudScroll from './linting-cloud-scroll.bpmn';
 import diagramXMLCloudTemplate from './linting-cloud-template.bpmn';
+import diagramXMLCloudTemplateDuplicate from './linting-cloud-template-duplicate.bpmn';
 import diagramXMLPlatform from './linting-platform.bpmn';
 
 insertCSS('diagram-js.css', diagramCSS);
@@ -952,6 +953,12 @@ describe('Linting', function() {
           type: 'String',
           group: 'endpoint',
           binding: { type: 'zeebe:input', name: 'url' }
+        },
+        {
+          label: 'Headers',
+          type: 'String',
+          group: 'endpoint',
+          binding: { type: 'zeebe:input', name: 'headers' }
         }
       ]
     };
@@ -1054,6 +1061,77 @@ describe('Linting', function() {
         }
       }
     ));
+
+
+    describe('duplicate fromAi() key', function() {
+
+      beforeEach(bootstrapModeler(diagramXMLCloudTemplateDuplicate, {
+        additionalModules: [
+          lintingModule,
+          propertiesPanelModule,
+          bpmnPropertiesProviderModule,
+          zeebePropertiesProviderModule,
+          cloudElementTemplatesPropertiesProvider
+        ],
+        moddleExtensions: {
+          modeler: modelerModdleExtension,
+          zeebe: zeebeModdleExtension
+        },
+        elementTemplates: [ TEMPLATE ]
+      }));
+
+
+      it('focuses the first template-bound input declaring the duplicated key', inject(
+        function(elementRegistry, elementTemplatesPropertiesProvider, eventBus, linting, selection) {
+
+          // given
+          const clock = sinon.useFakeTimers();
+
+          try {
+            const task = elementRegistry.get('ServiceTask_1');
+
+            const providerEntryIds = elementTemplatesPropertiesProvider
+              .getGroups(task)([])
+              .reduce((ids, group) => ids.concat((group.entries || []).map(entry => entry.id)), []);
+
+            const report = {
+              id: 'ServiceTask_1',
+              category: 'error',
+              message: 'fromAi() key toolCall.foo is declared more than once in this tool. ' +
+                'Declare it once and reference it directly elsewhere.',
+              data: { type: 'camunda.agentFeelKeyDuplicate' },
+              propertiesPanel: { entryIds: [ 'inputs' ] }
+            };
+
+            linting.setErrors([ report ]);
+            linting.activate();
+
+            const propertiesPanelShowEntrySpy = sinon.spy();
+
+            eventBus.on('propertiesPanel.showEntry', propertiesPanelShowEntrySpy);
+
+            // when
+            linting.showError(report);
+
+            clock.tick();
+
+            // then
+            expect(selection.get()).to.eql([ task ]);
+
+            expect(propertiesPanelShowEntrySpy).to.have.been.calledOnce;
+
+            const { id: shownEntryId } = propertiesPanelShowEntrySpy.getCall(0).args[ 0 ];
+
+            // first input in io-mapping order (url), not the generic group id
+            expect(shownEntryId).to.equal('custom-entry-my.rest.template-endpoint-0');
+            expect(providerEntryIds).to.include(shownEntryId);
+          } finally {
+            clock.restore();
+          }
+        }
+      ));
+
+    });
 
   });
 

--- a/test/spec/modeler/Linting.spec.js
+++ b/test/spec/modeler/Linting.spec.js
@@ -49,6 +49,7 @@ import diagramXMLCloud from './linting-cloud.bpmn';
 import diagramCollaborationXMLCloud from './linting-collaboration-cloud.bpmn';
 import diagramCollaborationELXMLCloud from './linting-collaboration-el.bpmn';
 import diagramXMLCloudScroll from './linting-cloud-scroll.bpmn';
+import diagramXMLCloudTemplate from './linting-cloud-template.bpmn';
 import diagramXMLPlatform from './linting-platform.bpmn';
 
 insertCSS('diagram-js.css', diagramCSS);
@@ -923,6 +924,87 @@ describe('Linting', function() {
         }
       ));
     });
+
+  });
+
+
+  describe('template-bound entry-id remap (integration)', function() {
+
+    // A real element template. `resolveTemplateEntryId` in
+    // lib/utils/properties-panel.js reverse-engineers the entry id that
+    // bpmn-js-element-templates generates for a template-bound property. This
+    // guards that reverse-engineering against the real library: if a future
+    // bpmn-js-element-templates version changes its id scheme, the remapped id
+    // will no longer be one the provider actually generates and this test
+    // fails, instead of the remap silently degrading in production.
+    const TEMPLATE = {
+      $schema: 'https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json',
+      name: 'REST Connector',
+      id: 'my.rest.template',
+      version: 1,
+      appliesTo: [ 'bpmn:ServiceTask' ],
+      groups: [
+        { id: 'endpoint', label: 'HTTP endpoint' }
+      ],
+      properties: [
+        {
+          label: 'URL',
+          type: 'String',
+          group: 'endpoint',
+          binding: { type: 'zeebe:input', name: 'url' }
+        }
+      ]
+    };
+
+    beforeEach(bootstrapModeler(diagramXMLCloudTemplate, {
+      additionalModules: [
+        lintingModule,
+        propertiesPanelModule,
+        bpmnPropertiesProviderModule,
+        zeebePropertiesProviderModule,
+        cloudElementTemplatesPropertiesProvider
+      ],
+      moddleExtensions: {
+        modeler: modelerModdleExtension,
+        zeebe: zeebeModdleExtension
+      },
+      elementTemplates: [ TEMPLATE ]
+    }));
+
+
+    it('remaps to an id the element-templates provider actually generates', inject(
+      function(elementRegistry, elementTemplates, elementTemplatesPropertiesProvider) {
+
+        // given
+        const task = elementRegistry.get('ServiceTask_1');
+
+        // the ids the real bpmn-js-element-templates provider renders for this element
+        const providerEntryIds = elementTemplatesPropertiesProvider
+          .getGroups(task)([])
+          .reduce((ids, group) => ids.concat((group.entries || []).map(entry => entry.id)), []);
+
+        // a lint error on the template-bound `url` input, carrying the generic
+        // io-mapping entry id the rules emit
+        const report = {
+          id: 'ServiceTask_1',
+          category: 'error',
+          message: 'Unparsable FEEL expression.',
+          propertiesPanel: { entryIds: [ 'ServiceTask_1-input-0-source' ] }
+        };
+
+        // when
+        const errors = getErrors([ report ], task, elementTemplates.getAll());
+
+        const remappedId = Object.keys(errors)[ 0 ];
+
+        // then: our remap produced a template custom-entry id ...
+        expect(remappedId).to.match(/^custom-entry-/);
+
+        // ... and it is one the provider really generates (guards the
+        // reverse-engineered id scheme against library drift)
+        expect(providerEntryIds).to.include(remappedId);
+      }
+    ));
 
   });
 

--- a/test/spec/modeler/Linting.spec.js
+++ b/test/spec/modeler/Linting.spec.js
@@ -1006,6 +1006,55 @@ describe('Linting', function() {
       }
     ));
 
+
+    it('remaps the entry id on click-to-jump, not just on inline highlighting', inject(
+      function(elementRegistry, elementTemplates, elementTemplatesPropertiesProvider, eventBus, linting, selection) {
+
+        // given
+        const clock = sinon.useFakeTimers();
+
+        try {
+          const task = elementRegistry.get('ServiceTask_1');
+
+          const providerEntryIds = elementTemplatesPropertiesProvider
+            .getGroups(task)([])
+            .reduce((ids, group) => ids.concat((group.entries || []).map(entry => entry.id)), []);
+
+          const report = {
+            id: 'ServiceTask_1',
+            category: 'error',
+            message: 'Unparsable FEEL expression.',
+            propertiesPanel: { entryIds: [ 'ServiceTask_1-input-0-source' ] }
+          };
+
+          linting.setErrors([ report ]);
+          linting.activate();
+
+          const propertiesPanelShowEntrySpy = sinon.spy();
+
+          eventBus.on('propertiesPanel.showEntry', propertiesPanelShowEntrySpy);
+
+          // when
+          linting.showError(report);
+
+          clock.tick();
+
+          // then
+          expect(selection.get()).to.eql([ task ]);
+
+          expect(propertiesPanelShowEntrySpy).to.have.been.calledOnce;
+
+          const { id: shownEntryId } = propertiesPanelShowEntrySpy.getCall(0).args[ 0 ];
+
+          expect(shownEntryId).not.to.equal('ServiceTask_1-input-0-source');
+          expect(shownEntryId).to.match(/^custom-entry-/);
+          expect(providerEntryIds).to.include(shownEntryId);
+        } finally {
+          clock.restore();
+        }
+      }
+    ));
+
   });
 
 

--- a/test/spec/modeler/Linting.spec.js
+++ b/test/spec/modeler/Linting.spec.js
@@ -314,6 +314,43 @@ describe('Linting', function() {
     });
 
 
+    describe('elementTemplates not registered', function() {
+
+      beforeEach(bootstrapModeler(diagramXMLCloud, {
+        additionalModules: [
+          lintingModule
+        ]
+      }));
+
+
+      it('should not crash and should return unremapped errors', inject(
+        async function(bpmnjs, elementRegistry, eventBus, linting, selection) {
+
+          // given
+          const serviceTask = elementRegistry.get('ServiceTask_1');
+
+          const reports = await linter.lint(bpmnjs.getDefinitions());
+
+          selection.select(serviceTask);
+
+          const propertiesPanelSetErrorSpy = sinon.spy();
+
+          eventBus.on('propertiesPanel.setErrors', propertiesPanelSetErrorSpy);
+
+          // when
+          expect(() => linting.setErrors(reports)).to.not.throw();
+
+          // then
+          expect(propertiesPanelSetErrorSpy).to.have.been.calledOnce;
+          expect(propertiesPanelSetErrorSpy).to.have.been.calledWithMatch({
+            errors: getErrors(reports, serviceTask)
+          });
+        }
+      ));
+
+    });
+
+
     it('should activate', inject(
       async function(bpmnjs, elementRegistry, eventBus, linting, lintingAnnotations, overlays, selection) {
 
@@ -431,6 +468,27 @@ describe('Linting', function() {
         });
 
         expect(overlays.get({ type: 'linting' })).to.have.length(1);
+      }
+    ));
+
+
+    it('should call elementTemplates.getAll before computing properties panel errors', inject(
+      async function(bpmnjs, elementRegistry, elementTemplates, linting, selection) {
+
+        // given
+        const serviceTask = elementRegistry.get('ServiceTask_1');
+
+        const reports = await linter.lint(bpmnjs.getDefinitions());
+
+        selection.select(serviceTask);
+
+        const getAllSpy = sinon.spy(elementTemplates, 'getAll');
+
+        // when
+        linting.setErrors(reports);
+
+        // then
+        expect(getAllSpy).to.have.been.called;
       }
     ));
 

--- a/test/spec/modeler/linting-cloud-template-duplicate.bpmn
+++ b/test/spec/modeler/linting-cloud-template-duplicate.bpmn
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_template" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.5.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.8.0">
+  <bpmn:process id="Process_template" isExecutable="true">
+    <bpmn:serviceTask id="ServiceTask_1" name="Fetch URL" zeebe:modelerTemplate="my.rest.template" zeebe:modelerTemplateVersion="1">
+      <bpmn:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:input source="=fromAi(toolCall.foo, &quot;x&quot;)" target="url" />
+          <zeebe:input source="=fromAi(toolCall.foo, &quot;y&quot;)" target="headers" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:serviceTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_template">
+      <bpmndi:BPMNShape id="ServiceTask_1_di" bpmnElement="ServiceTask_1">
+        <dc:Bounds x="160" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/spec/modeler/linting-cloud-template.bpmn
+++ b/test/spec/modeler/linting-cloud-template.bpmn
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_template" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.5.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.6.0">
+  <bpmn:process id="Process_template" isExecutable="true">
+    <bpmn:serviceTask id="ServiceTask_1" name="Fetch URL" zeebe:modelerTemplate="my.rest.template" zeebe:modelerTemplateVersion="1">
+      <bpmn:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:input source="===" target="url" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:serviceTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_template">
+      <bpmndi:BPMNShape id="ServiceTask_1_di" bpmnElement="ServiceTask_1">
+        <dc:Bounds x="160" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/spec/utils/properties-panel.spec.js
+++ b/test/spec/utils/properties-panel.spec.js
@@ -3095,6 +3095,130 @@ describe('utils/properties-panel', function() {
         expect(errors).to.be.empty;
       });
 
+
+      describe('template-bound entry ids', function() {
+
+        let rule;
+
+        const INVALID_FEEL = '===';
+
+        const TEMPLATE = {
+          id: 'io.camunda.connectors.HttpJson.v2',
+          version: 12,
+          groups: [
+            { id: 'endpoint', label: 'HTTP endpoint' }
+          ],
+          properties: [
+            { binding: { type: 'zeebe:input', name: 'method' }, group: 'endpoint' },
+            { binding: { type: 'zeebe:input', name: 'url' }, group: 'endpoint' }
+          ]
+        };
+
+        before(async function() {
+          ({ default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/feel'));
+        });
+
+        function createTemplatedNode(templateProperties = {}) {
+          return createElement('bpmn:ServiceTask', {
+            id: 'ServiceTask_1',
+            ...templateProperties,
+            extensionElements: createElement('bpmn:ExtensionElements', {
+              values: [
+                createElement('zeebe:IoMapping', {
+                  inputParameters: [
+                    createElement('zeebe:Input', {
+                      target: 'method',
+                      source: '="GET"'
+                    }),
+                    createElement('zeebe:Input', {
+                      target: 'url',
+                      source: INVALID_FEEL
+                    })
+                  ]
+                })
+              ]
+            })
+          });
+        }
+
+        it('remaps a template-bound input entry id to the template\'s custom-entry id', async function() {
+
+          // given
+          const node = createTemplatedNode({
+            modelerTemplate: 'io.camunda.connectors.HttpJson.v2',
+            modelerTemplateVersion: 12
+          });
+
+          const report = await getLintError(node, rule);
+
+          // when
+          const errors = getErrors([ report ], node, [ TEMPLATE ]);
+
+          // then
+          expect(errors).to.eql({
+            'custom-entry-io.camunda.connectors.HttpJson.v2-endpoint-1': 'Unparsable FEEL expression.'
+          });
+        });
+
+
+        it('leaves the entry id unchanged when no templates are passed', async function() {
+
+          // given
+          const node = createTemplatedNode({
+            modelerTemplate: 'io.camunda.connectors.HttpJson.v2',
+            modelerTemplateVersion: 12
+          });
+
+          const report = await getLintError(node, rule);
+
+          // when
+          const errors = getErrors([ report ], node);
+
+          // then
+          expect(errors).to.eql({
+            'ServiceTask_1-input-1-source': 'Unparsable FEEL expression.'
+          });
+        });
+
+
+        it('leaves the entry id unchanged when the element has no applied template', async function() {
+
+          // given
+          const node = createTemplatedNode();
+
+          const report = await getLintError(node, rule);
+
+          // when
+          const errors = getErrors([ report ], node, [ TEMPLATE ]);
+
+          // then
+          expect(errors).to.eql({
+            'ServiceTask_1-input-1-source': 'Unparsable FEEL expression.'
+          });
+        });
+
+
+        it('leaves the entry id unchanged when the applied template is not found in the provided templates array', async function() {
+
+          // given
+          const node = createTemplatedNode({
+            modelerTemplate: 'io.camunda.connectors.HttpJson.v2',
+            modelerTemplateVersion: 12
+          });
+
+          const report = await getLintError(node, rule);
+
+          // when
+          const errors = getErrors([ report ], node, []);
+
+          // then
+          expect(errors).to.eql({
+            'ServiceTask_1-input-1-source': 'Unparsable FEEL expression.'
+          });
+        });
+
+      });
+
     });
 
   });

--- a/test/spec/utils/properties-panel.spec.js
+++ b/test/spec/utils/properties-panel.spec.js
@@ -3118,23 +3118,17 @@ describe('utils/properties-panel', function() {
           ({ default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/feel'));
         });
 
-        function createTemplatedNode(templateProperties = {}) {
+        function createTemplatedNode(templateProperties = {}, inputs = [
+          { target: 'method', source: '="GET"' },
+          { target: 'url', source: INVALID_FEEL }
+        ]) {
           return createElement('bpmn:ServiceTask', {
             id: 'ServiceTask_1',
             ...templateProperties,
             extensionElements: createElement('bpmn:ExtensionElements', {
               values: [
                 createElement('zeebe:IoMapping', {
-                  inputParameters: [
-                    createElement('zeebe:Input', {
-                      target: 'method',
-                      source: '="GET"'
-                    }),
-                    createElement('zeebe:Input', {
-                      target: 'url',
-                      source: INVALID_FEEL
-                    })
-                  ]
+                  inputParameters: inputs.map((input) => createElement('zeebe:Input', input))
                 })
               ]
             })
@@ -3215,6 +3209,94 @@ describe('utils/properties-panel', function() {
           expect(errors).to.eql({
             'ServiceTask_1-input-1-source': 'Unparsable FEEL expression.'
           });
+        });
+
+
+        describe('duplicate fromAi() key', function() {
+
+          const DUPLICATE_KEY_MESSAGE = 'fromAi() key toolCall.foo is declared more than once in this tool. ' +
+            'Declare it once and reference it directly elsewhere.';
+
+          function duplicateKeyReport() {
+            return {
+              id: 'ServiceTask_1',
+              category: 'error',
+              message: DUPLICATE_KEY_MESSAGE,
+
+              // the real constant (bpmnlint-plugin-camunda-compat's
+              // ERROR_TYPES.AGENT_FEEL_KEY_DUPLICATE) isn't in the published
+              // dependency yet; hardcode its string value so this test is
+              // meaningful whether or not a PR245 checkout happens to be linked
+              data: { type: 'camunda.agentFeelKeyDuplicate' },
+              propertiesPanel: { entryIds: [ 'inputs' ] }
+            };
+          }
+
+          it('remaps the generic \'inputs\' id to every template-bound input declaring the duplicated key', function() {
+
+            // given
+            const node = createTemplatedNode({
+              modelerTemplate: 'io.camunda.connectors.HttpJson.v2',
+              modelerTemplateVersion: 12
+            }, [
+              { target: 'method', source: '=fromAi(toolCall.foo, "x")' },
+              { target: 'url', source: '=fromAi(toolCall.foo, "y")' }
+            ]);
+
+            // when
+            const errors = getErrors([ duplicateKeyReport() ], node, [ TEMPLATE ]);
+
+            // then
+            expect(errors).to.eql({
+              'custom-entry-io.camunda.connectors.HttpJson.v2-endpoint-0': DUPLICATE_KEY_MESSAGE,
+              'custom-entry-io.camunda.connectors.HttpJson.v2-endpoint-1': DUPLICATE_KEY_MESSAGE
+            });
+          });
+
+
+          it('leaves the generic \'inputs\' id unchanged when no structural duplicate is found', function() {
+
+            // given
+            const node = createTemplatedNode({
+              modelerTemplate: 'io.camunda.connectors.HttpJson.v2',
+              modelerTemplateVersion: 12
+            }, [
+              { target: 'method', source: '=fromAi(toolCall.foo, "x")' },
+              { target: 'url', source: '=fromAi(toolCall.bar, "y")' }
+            ]);
+
+            // when
+            const errors = getErrors([ duplicateKeyReport() ], node, [ TEMPLATE ]);
+
+            // then
+            expect(errors).to.eql({
+              inputs: DUPLICATE_KEY_MESSAGE
+            });
+          });
+
+
+          it('leaves the generic \'inputs\' id unchanged for a non-duplicate-key error', async function() {
+
+            // given
+            const node = createTemplatedNode({
+              modelerTemplate: 'io.camunda.connectors.HttpJson.v2',
+              modelerTemplateVersion: 12
+            });
+
+            const report = {
+              ...await getLintError(node, rule),
+              propertiesPanel: { entryIds: [ 'inputs' ] }
+            };
+
+            // when
+            const errors = getErrors([ report ], node, [ TEMPLATE ]);
+
+            // then
+            expect(errors).to.eql({
+              inputs: 'Unparsable FEEL expression.'
+            });
+          });
+
         });
 
       });


### PR DESCRIPTION
🤖

## Summary

Closes #162. Closes #167. Part of [camunda/product-hub#3719](https://github.com/camunda/product-hub/issues/3719) (Agent Config Discoverability).

Surfaced by Maciej Barelkowski's review of [bpmnlint-plugin-camunda-compat#245](https://github.com/camunda/bpmnlint-plugin-camunda-compat/pull/245#issuecomment-4915173208): the agent lint rules ship in core `bpmnlint-plugin-camunda-compat`, so they already run in both Desktop Modeler and Web Modeler. A template entry-id remap prototyped only in camunda-hub ([camunda-hub#26033](https://github.com/camunda/camunda-hub/issues/26033), [camunda-hub#26035](https://github.com/camunda/camunda-hub/pull/26035), merged onto a feature branch, not `main`) would leave Desktop Modeler degraded for the same rules. This PR relocates the fix here so every host consuming `@camunda/linting` gets it.

- **`getErrors`** takes an optional third `templates` argument (`elementTemplates.getAll()`). When a generic io-mapping entry id (`{taskId}-input-{index}-source`) resolves to a template-bound property, the returned error-map key is the template's own `custom-entry-*` id instead, so the properties panel attaches the error inline the same way it already does for plain fields. `getEntryIds` itself is untouched; remap happens only in `getErrors`, after message resolution.
- **`Linting`** now resolves `elementTemplates` via `injector.get('elementTemplates', false)` (didi 11 has no built-in optional-dependency syntax) and passes `elementTemplates.getAll()` into `getErrors`. A host without an `elementTemplates` module registered doesn't crash; reports come back unremapped.
- **`Linting.showError`** (the click-to-jump path, #167) remaps `propertiesPanel.entryIds` through the same `remapTemplateEntryId` helper (now exported from `properties-panel.js`) before firing `propertiesPanel.showEntry`. Without this, clicking a Problems-panel error on a template-bound field selected the element and scrolled to it, but the field's group stayed collapsed since `showEntry` was still firing the raw, un-remapped id. Caught this manually driving a real Desktop Modeler dev build against an applied connector template, not from a unit test gap.

## The reverse-engineering, and its guard

`resolveTemplateEntryId` reconstructs the `custom-entry-{template.id}-{group}-{index}` id that `bpmn-js-element-templates` generates internally. That scheme is undocumented and has no public API contract, so a future version of that library could change it and silently break inline attachment. To make that failure loud instead of silent, this PR adds an **integration guard** (`test/spec/modeler/`): it registers a real element template, drives the real `CloudElementTemplatesPropertiesProvider` to generate the entry ids it actually renders, and asserts the id `getErrors` produces is among them. A library id-scheme drift now fails CI.

This is the one human-judgment call in the PR: shipping the reverse-engineering is what unblocks inline errors now; the durable fix is for the bpmn.io team to expose a public entry-id resolver in `bpmn-js-element-templates` when they build this out, retiring the reconstruction here.

## Test plan

- [x] `npm run all` (lint + full karma suite): 327/327 passing
- [x] New cases: template-bound remap (4 unit cases: remaps, no templates, no applied template, template not in array), `elementTemplates` wiring (getAll called; no-crash without it registered), the real-library integration guard above, and a click-to-jump case asserting `showError` fires `propertiesPanel.showEntry` with the remapped id, not the raw one
- [x] Existing `properties-panel.spec.js` and `Linting.spec.js` suites pass unchanged
- [x] Manually verified in a real Desktop Modeler dev build (isolated user-data dir, no impact on real Modeler state): applied a real marketplace connector template to a service task with a deliberately invalid FEEL expression, confirmed the Problems-panel error attaches inline to the correct field; then, for #167, built an agentic tool task with a broken `fromAi()` call and confirmed clicking the Problems-panel row now expands the field's group and focuses it, not just scrolls to the task

## Scope notes

- The `conditionExpression` message-override bug originally bundled into this branch is split out to #165, shipping separately in #166, so this PR stays scoped to #162 and #167.
- The **jump-to-field** companion (#167, clicking a Problems-panel error should focus a template-bound field, not just show the inline border) is now included in this PR rather than shipping separately: it turned out to be a few lines reusing this PR's own remap helper, and manual verification surfaced the gap directly.

Follow-up once this ships: [camunda/linting#163](https://github.com/camunda/linting/issues/163) (bump `bpmnlint-plugin-camunda-compat`, regenerate `compiled-config.js`), [camunda-hub#26207](https://github.com/camunda/camunda-hub/issues/26207) (adopt this instead of the interim hub-only code).

*Authored by Claude, on behalf of Eric Lundberg.*

