### PR TITLE
fix(properties-panel): don't override conditionExpression message for non-PROPERTY_REQUIRED errors

### DIFF
--- a/lib/utils/properties-panel.js
+++ b/lib/utils/properties-panel.js
@@ -599,7 +599,11 @@ export function getErrorMessage(id, report) {
   }
 
   if (id === 'conditionExpression') {
-    return 'Condition expression must be defined.';
+    if (type === ERROR_TYPES.PROPERTY_REQUIRED) {
+      return 'Condition expression must be defined.';
+    }
+
+    return message;
   }
 
   if (id === 'timerEventDefinitionType' && type === ERROR_TYPES.PROPERTY_NOT_ALLOWED) {

--- a/test/spec/utils/properties-panel.spec.js
+++ b/test/spec/utils/properties-panel.spec.js
@@ -1242,6 +1242,27 @@ describe('utils/properties-panel', function() {
       });
 
 
+      it('does not show "must be defined" when a condition is present but not allowed', async function() {
+
+        // given
+        const node = createElement('bpmn:SequenceFlow', {
+          sourceRef: createElement('bpmn:Task'),
+          conditionExpression: createElement('bpmn:FormalExpression', { body: '=true' })
+        });
+
+        const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/sequence-flow-condition');
+
+        const report = await getLintError(node, rule);
+
+        // when
+        const entryIds = getEntryIds(report);
+
+        // then
+        expect(entryIds).to.eql([ 'conditionExpression' ]);
+        expectErrorMessage(entryIds[ 0 ], 'Property <conditionExpression> only allowed if source is of type <bpmn:ExclusiveGateway> or <bpmn:InclusiveGateway>', report);
+      });
+
+
       describe('timer', function() {
 
         it('no type', async function() {


### PR DESCRIPTION
🤖

## Summary

Closes #165.

`getErrorMessage`'s `conditionExpression` branch returned "Condition expression must be defined." unconditionally, regardless of error `type`, unlike the equivalent branches for `errorCode`, `formId`, and `timerEventDefinitionType` which all guard on `PROPERTY_REQUIRED`. As a result a `PROPERTY_NOT_ALLOWED` error (a condition present on a non-gateway source) showed the wrong message, and once `agent-fromai-contract` ships, its `AGENT_FEEL_WRONG_CONTEXT` case (a `fromAi()` call placed in a sequence-flow condition) would hit the same bug: both reuse the `conditionExpression` entry id and both would have their rule-authored message clobbered.

Fix: guard the branch on `type === ERROR_TYPES.PROPERTY_REQUIRED`; for any other type, return the rule's own `message`.

## Test plan

- [x] `npm run all` (lint + full karma suite): 320/320 passing
- [x] New case in `properties-panel.spec.js` (`sequence-flow-condition` block): a condition present on a non-gateway source (`PROPERTY_NOT_ALLOWED`) keeps the rule's own "only allowed if source is of type ..." message instead of "must be defined."
- [x] Existing `PROPERTY_REQUIRED` case (`inclusive-gateway (no condition expression)`) still shows "Condition expression must be defined." unchanged

This bug was originally bundled into #162's PR (#164); split out here so #164 stays scoped to the template entry-id remap.

*Authored by Claude, on behalf of Eric Lundberg.*