### PR TITLE
feat: integrate agent config rules

### DIFF
--- a/lib/compiled-config.js
+++ b/lib/compiled-config.js
@@ -30,6 +30,9 @@ const resolver = new Resolver();
 
 const rules = {
   "camunda-compat/ad-hoc-sub-process": "error",
+  "camunda-compat/agent-fromai-contract": "error",
+  "camunda-compat/agent-tool-documentation": "warn",
+  "camunda-compat/agent-tool-output-key": "warn",
   "camunda-compat/before-all-execution-listener": "error",
   "camunda-compat/element-type": "error",
   "camunda-compat/cancel-execution-listener": "error",
@@ -121,278 +124,290 @@ import rule_0 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/ad-hoc-su
 
 cache['bpmnlint-plugin-camunda-compat/ad-hoc-sub-process'] = rule_0;
 
-import rule_1 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/before-all-execution-listener';
+import rule_1 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/agent-fromai-contract';
 
-cache['bpmnlint-plugin-camunda-compat/before-all-execution-listener'] = rule_1;
+cache['bpmnlint-plugin-camunda-compat/agent-fromai-contract'] = rule_1;
 
-import rule_2 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/element-type';
+import rule_2 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/agent-tool-documentation';
 
-cache['bpmnlint-plugin-camunda-compat/element-type'] = rule_2;
+cache['bpmnlint-plugin-camunda-compat/agent-tool-documentation'] = rule_2;
 
-import rule_3 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/cancel-execution-listener';
+import rule_3 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/agent-tool-output-key';
 
-cache['bpmnlint-plugin-camunda-compat/cancel-execution-listener'] = rule_3;
+cache['bpmnlint-plugin-camunda-compat/agent-tool-output-key'] = rule_3;
 
-import rule_4 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/called-element';
+import rule_4 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/before-all-execution-listener';
 
-cache['bpmnlint-plugin-camunda-compat/called-element'] = rule_4;
+cache['bpmnlint-plugin-camunda-compat/before-all-execution-listener'] = rule_4;
 
-import rule_5 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/collapsed-subprocess';
+import rule_5 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/element-type';
 
-cache['bpmnlint-plugin-camunda-compat/collapsed-subprocess'] = rule_5;
+cache['bpmnlint-plugin-camunda-compat/element-type'] = rule_5;
 
-import rule_6 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/connector-properties';
+import rule_6 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/cancel-execution-listener';
 
-cache['bpmnlint-plugin-camunda-compat/connector-properties'] = rule_6;
+cache['bpmnlint-plugin-camunda-compat/cancel-execution-listener'] = rule_6;
 
-import rule_7 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/duplicate-execution-listener-headers';
+import rule_7 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/called-element';
 
-cache['bpmnlint-plugin-camunda-compat/duplicate-execution-listener-headers'] = rule_7;
+cache['bpmnlint-plugin-camunda-compat/called-element'] = rule_7;
 
-import rule_8 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/duplicate-execution-listeners';
+import rule_8 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/collapsed-subprocess';
 
-cache['bpmnlint-plugin-camunda-compat/duplicate-execution-listeners'] = rule_8;
+cache['bpmnlint-plugin-camunda-compat/collapsed-subprocess'] = rule_8;
 
-import rule_9 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/duplicate-task-headers';
+import rule_9 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/connector-properties';
 
-cache['bpmnlint-plugin-camunda-compat/duplicate-task-headers'] = rule_9;
+cache['bpmnlint-plugin-camunda-compat/connector-properties'] = rule_9;
 
-import rule_10 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/error-reference';
+import rule_10 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/duplicate-execution-listener-headers';
 
-cache['bpmnlint-plugin-camunda-compat/error-reference'] = rule_10;
+cache['bpmnlint-plugin-camunda-compat/duplicate-execution-listener-headers'] = rule_10;
 
-import rule_11 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/escalation-boundary-event-attached-to-ref';
+import rule_11 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/duplicate-execution-listeners';
 
-cache['bpmnlint-plugin-camunda-compat/escalation-boundary-event-attached-to-ref'] = rule_11;
+cache['bpmnlint-plugin-camunda-compat/duplicate-execution-listeners'] = rule_11;
 
-import rule_12 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/escalation-reference';
+import rule_12 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/duplicate-task-headers';
 
-cache['bpmnlint-plugin-camunda-compat/escalation-reference'] = rule_12;
+cache['bpmnlint-plugin-camunda-compat/duplicate-task-headers'] = rule_12;
 
-import rule_13 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/event-based-gateway-target';
+import rule_13 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/error-reference';
 
-cache['bpmnlint-plugin-camunda-compat/event-based-gateway-target'] = rule_13;
+cache['bpmnlint-plugin-camunda-compat/error-reference'] = rule_13;
 
-import rule_14 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/executable-process';
+import rule_14 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/escalation-boundary-event-attached-to-ref';
 
-cache['bpmnlint-plugin-camunda-compat/executable-process'] = rule_14;
+cache['bpmnlint-plugin-camunda-compat/escalation-boundary-event-attached-to-ref'] = rule_14;
 
-import rule_15 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/execution-listener';
+import rule_15 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/escalation-reference';
 
-cache['bpmnlint-plugin-camunda-compat/execution-listener'] = rule_15;
+cache['bpmnlint-plugin-camunda-compat/escalation-reference'] = rule_15;
 
-import rule_16 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/feel';
+import rule_16 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/event-based-gateway-target';
 
-cache['bpmnlint-plugin-camunda-compat/feel'] = rule_16;
+cache['bpmnlint-plugin-camunda-compat/event-based-gateway-target'] = rule_16;
 
-import rule_17 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/feel-compatibility';
+import rule_17 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/executable-process';
 
-cache['bpmnlint-plugin-camunda-compat/feel-compatibility'] = rule_17;
+cache['bpmnlint-plugin-camunda-compat/executable-process'] = rule_17;
 
-import rule_18 from 'bpmnlint-plugin-camunda-compat/rules/camunda-platform/history-time-to-live';
+import rule_18 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/execution-listener';
 
-cache['bpmnlint-plugin-camunda-compat/history-time-to-live'] = rule_18;
+cache['bpmnlint-plugin-camunda-compat/execution-listener'] = rule_18;
 
-import rule_19 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/implementation';
+import rule_19 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/feel';
 
-cache['bpmnlint-plugin-camunda-compat/implementation'] = rule_19;
+cache['bpmnlint-plugin-camunda-compat/feel'] = rule_19;
 
-import rule_20 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/inclusive-gateway';
+import rule_20 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/feel-compatibility';
 
-cache['bpmnlint-plugin-camunda-compat/inclusive-gateway'] = rule_20;
+cache['bpmnlint-plugin-camunda-compat/feel-compatibility'] = rule_20;
 
-import rule_21 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/link-event';
+import rule_21 from 'bpmnlint-plugin-camunda-compat/rules/camunda-platform/history-time-to-live';
 
-cache['bpmnlint-plugin-camunda-compat/link-event'] = rule_21;
+cache['bpmnlint-plugin-camunda-compat/history-time-to-live'] = rule_21;
 
-import rule_22 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/loop-characteristics';
+import rule_22 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/implementation';
 
-cache['bpmnlint-plugin-camunda-compat/loop-characteristics'] = rule_22;
+cache['bpmnlint-plugin-camunda-compat/implementation'] = rule_22;
 
-import rule_23 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/io-mapping';
+import rule_23 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/inclusive-gateway';
 
-cache['bpmnlint-plugin-camunda-compat/io-mapping'] = rule_23;
+cache['bpmnlint-plugin-camunda-compat/inclusive-gateway'] = rule_23;
 
-import rule_24 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/message-reference';
+import rule_24 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/link-event';
 
-cache['bpmnlint-plugin-camunda-compat/message-reference'] = rule_24;
+cache['bpmnlint-plugin-camunda-compat/link-event'] = rule_24;
 
-import rule_25 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-binding-type';
+import rule_25 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/loop-characteristics';
 
-cache['bpmnlint-plugin-camunda-compat/no-binding-type'] = rule_25;
+cache['bpmnlint-plugin-camunda-compat/loop-characteristics'] = rule_25;
 
-import rule_26 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-before-all-execution-listener';
+import rule_26 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/io-mapping';
 
-cache['bpmnlint-plugin-camunda-compat/no-before-all-execution-listener'] = rule_26;
+cache['bpmnlint-plugin-camunda-compat/io-mapping'] = rule_26;
 
-import rule_27 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-candidate-users';
+import rule_27 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/message-reference';
 
-cache['bpmnlint-plugin-camunda-compat/no-candidate-users'] = rule_27;
+cache['bpmnlint-plugin-camunda-compat/message-reference'] = rule_27;
 
-import rule_28 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-cancel-execution-listener';
+import rule_28 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-binding-type';
 
-cache['bpmnlint-plugin-camunda-compat/no-cancel-execution-listener'] = rule_28;
+cache['bpmnlint-plugin-camunda-compat/no-binding-type'] = rule_28;
 
-import rule_29 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-execution-listener-headers';
+import rule_29 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-before-all-execution-listener';
 
-cache['bpmnlint-plugin-camunda-compat/no-execution-listener-headers'] = rule_29;
+cache['bpmnlint-plugin-camunda-compat/no-before-all-execution-listener'] = rule_29;
 
-import rule_30 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-execution-listeners';
+import rule_30 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-candidate-users';
 
-cache['bpmnlint-plugin-camunda-compat/no-execution-listeners'] = rule_30;
+cache['bpmnlint-plugin-camunda-compat/no-candidate-users'] = rule_30;
 
-import rule_31 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-expression';
+import rule_31 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-cancel-execution-listener';
 
-cache['bpmnlint-plugin-camunda-compat/no-expression'] = rule_31;
+cache['bpmnlint-plugin-camunda-compat/no-cancel-execution-listener'] = rule_31;
 
-import rule_32 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-interrupting-event-subprocess';
+import rule_32 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-execution-listener-headers';
 
-cache['bpmnlint-plugin-camunda-compat/no-interrupting-event-subprocess'] = rule_32;
+cache['bpmnlint-plugin-camunda-compat/no-execution-listener-headers'] = rule_32;
 
-import rule_33 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-job-priority-definition';
+import rule_33 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-execution-listeners';
 
-cache['bpmnlint-plugin-camunda-compat/no-job-priority-definition'] = rule_33;
+cache['bpmnlint-plugin-camunda-compat/no-execution-listeners'] = rule_33;
 
-import rule_34 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-loop';
+import rule_34 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-expression';
 
-cache['bpmnlint-plugin-camunda-compat/no-loop'] = rule_34;
+cache['bpmnlint-plugin-camunda-compat/no-expression'] = rule_34;
 
-import rule_35 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-multiple-none-start-events';
+import rule_35 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-interrupting-event-subprocess';
 
-cache['bpmnlint-plugin-camunda-compat/no-multiple-none-start-events'] = rule_35;
+cache['bpmnlint-plugin-camunda-compat/no-interrupting-event-subprocess'] = rule_35;
 
-import rule_36 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-priority-definition';
+import rule_36 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-job-priority-definition';
 
-cache['bpmnlint-plugin-camunda-compat/no-priority-definition'] = rule_36;
+cache['bpmnlint-plugin-camunda-compat/no-job-priority-definition'] = rule_36;
 
-import rule_37 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-propagate-all-parent-variables';
+import rule_37 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-loop';
 
-cache['bpmnlint-plugin-camunda-compat/no-propagate-all-parent-variables'] = rule_37;
+cache['bpmnlint-plugin-camunda-compat/no-loop'] = rule_37;
 
-import rule_38 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-signal-event-sub-process';
+import rule_38 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-multiple-none-start-events';
 
-cache['bpmnlint-plugin-camunda-compat/no-signal-event-sub-process'] = rule_38;
+cache['bpmnlint-plugin-camunda-compat/no-multiple-none-start-events'] = rule_38;
 
-import rule_39 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-task-schedule';
+import rule_39 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-priority-definition';
 
-cache['bpmnlint-plugin-camunda-compat/no-task-schedule'] = rule_39;
+cache['bpmnlint-plugin-camunda-compat/no-priority-definition'] = rule_39;
 
-import rule_40 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-task-listeners';
+import rule_40 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-propagate-all-parent-variables';
 
-cache['bpmnlint-plugin-camunda-compat/no-task-listeners'] = rule_40;
+cache['bpmnlint-plugin-camunda-compat/no-propagate-all-parent-variables'] = rule_40;
 
-import rule_41 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-template';
+import rule_41 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-signal-event-sub-process';
 
-cache['bpmnlint-plugin-camunda-compat/no-template'] = rule_41;
+cache['bpmnlint-plugin-camunda-compat/no-signal-event-sub-process'] = rule_41;
 
-import rule_42 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-version-tag';
+import rule_42 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-task-schedule';
 
-cache['bpmnlint-plugin-camunda-compat/no-version-tag'] = rule_42;
+cache['bpmnlint-plugin-camunda-compat/no-task-schedule'] = rule_42;
 
-import rule_43 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-zeebe-properties';
+import rule_43 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-task-listeners';
 
-cache['bpmnlint-plugin-camunda-compat/no-zeebe-properties'] = rule_43;
+cache['bpmnlint-plugin-camunda-compat/no-task-listeners'] = rule_43;
 
-import rule_44 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-zeebe-user-task';
+import rule_44 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-template';
 
-cache['bpmnlint-plugin-camunda-compat/no-zeebe-user-task'] = rule_44;
+cache['bpmnlint-plugin-camunda-compat/no-template'] = rule_44;
 
-import rule_45 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/priority-definition';
+import rule_45 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-version-tag';
 
-cache['bpmnlint-plugin-camunda-compat/priority-definition'] = rule_45;
+cache['bpmnlint-plugin-camunda-compat/no-version-tag'] = rule_45;
 
-import rule_46 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/zeebe-user-task';
+import rule_46 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-zeebe-properties';
 
-cache['bpmnlint-plugin-camunda-compat/zeebe-user-task'] = rule_46;
+cache['bpmnlint-plugin-camunda-compat/no-zeebe-properties'] = rule_46;
 
-import rule_47 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/secrets';
+import rule_47 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-zeebe-user-task';
 
-cache['bpmnlint-plugin-camunda-compat/secrets'] = rule_47;
+cache['bpmnlint-plugin-camunda-compat/no-zeebe-user-task'] = rule_47;
 
-import rule_48 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/sequence-flow-condition';
+import rule_48 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/priority-definition';
 
-cache['bpmnlint-plugin-camunda-compat/sequence-flow-condition'] = rule_48;
+cache['bpmnlint-plugin-camunda-compat/priority-definition'] = rule_48;
 
-import rule_49 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/signal-reference';
+import rule_49 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/zeebe-user-task';
 
-cache['bpmnlint-plugin-camunda-compat/signal-reference'] = rule_49;
+cache['bpmnlint-plugin-camunda-compat/zeebe-user-task'] = rule_49;
 
-import rule_50 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/start-event-form';
+import rule_50 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/secrets';
 
-cache['bpmnlint-plugin-camunda-compat/start-event-form'] = rule_50;
+cache['bpmnlint-plugin-camunda-compat/secrets'] = rule_50;
 
-import rule_51 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/start-event-form-embedded';
+import rule_51 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/sequence-flow-condition';
 
-cache['bpmnlint-plugin-camunda-compat/start-event-form-embedded'] = rule_51;
+cache['bpmnlint-plugin-camunda-compat/sequence-flow-condition'] = rule_51;
 
-import rule_52 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/subscription';
+import rule_52 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/signal-reference';
 
-cache['bpmnlint-plugin-camunda-compat/subscription'] = rule_52;
+cache['bpmnlint-plugin-camunda-compat/signal-reference'] = rule_52;
 
-import rule_53 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/task-listener';
+import rule_53 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/start-event-form';
 
-cache['bpmnlint-plugin-camunda-compat/task-listener'] = rule_53;
+cache['bpmnlint-plugin-camunda-compat/start-event-form'] = rule_53;
 
-import rule_54 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/task-schedule';
+import rule_54 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/start-event-form-embedded';
 
-cache['bpmnlint-plugin-camunda-compat/task-schedule'] = rule_54;
+cache['bpmnlint-plugin-camunda-compat/start-event-form-embedded'] = rule_54;
 
-import rule_55 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/timer';
+import rule_55 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/subscription';
 
-cache['bpmnlint-plugin-camunda-compat/timer'] = rule_55;
+cache['bpmnlint-plugin-camunda-compat/subscription'] = rule_55;
 
-import rule_56 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/user-task-definition';
+import rule_56 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/task-listener';
 
-cache['bpmnlint-plugin-camunda-compat/user-task-definition'] = rule_56;
+cache['bpmnlint-plugin-camunda-compat/task-listener'] = rule_56;
 
-import rule_57 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/user-task-form';
+import rule_57 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/task-schedule';
 
-cache['bpmnlint-plugin-camunda-compat/user-task-form'] = rule_57;
+cache['bpmnlint-plugin-camunda-compat/task-schedule'] = rule_57;
 
-import rule_58 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/variable-name';
+import rule_58 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/timer';
 
-cache['bpmnlint-plugin-camunda-compat/variable-name'] = rule_58;
+cache['bpmnlint-plugin-camunda-compat/timer'] = rule_58;
 
-import rule_59 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/version-tag';
+import rule_59 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/user-task-definition';
 
-cache['bpmnlint-plugin-camunda-compat/version-tag'] = rule_59;
+cache['bpmnlint-plugin-camunda-compat/user-task-definition'] = rule_59;
 
-import rule_60 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/wait-for-completion';
+import rule_60 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/user-task-form';
 
-cache['bpmnlint-plugin-camunda-compat/wait-for-completion'] = rule_60;
+cache['bpmnlint-plugin-camunda-compat/user-task-form'] = rule_60;
 
-import rule_61 from 'bpmnlint/rules/start-event-required';
+import rule_61 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/variable-name';
 
-cache['bpmnlint/start-event-required'] = rule_61;
+cache['bpmnlint-plugin-camunda-compat/variable-name'] = rule_61;
 
-import rule_62 from 'bpmnlint/rules/ad-hoc-sub-process';
+import rule_62 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/version-tag';
 
-cache['bpmnlint/ad-hoc-sub-process'] = rule_62;
+cache['bpmnlint-plugin-camunda-compat/version-tag'] = rule_62;
 
-import rule_63 from 'bpmnlint/rules/conditional-event';
+import rule_63 from 'bpmnlint-plugin-camunda-compat/rules/camunda-cloud/wait-for-completion';
 
-cache['bpmnlint/conditional-event'] = rule_63;
+cache['bpmnlint-plugin-camunda-compat/wait-for-completion'] = rule_63;
 
-import rule_64 from 'bpmnlint/rules/event-based-gateway';
+import rule_64 from 'bpmnlint/rules/start-event-required';
 
-cache['bpmnlint/event-based-gateway'] = rule_64;
+cache['bpmnlint/start-event-required'] = rule_64;
 
-import rule_65 from 'bpmnlint/rules/event-sub-process-typed-start-event';
+import rule_65 from 'bpmnlint/rules/ad-hoc-sub-process';
 
-cache['bpmnlint/event-sub-process-typed-start-event'] = rule_65;
+cache['bpmnlint/ad-hoc-sub-process'] = rule_65;
 
-import rule_66 from 'bpmnlint/rules/link-event';
+import rule_66 from 'bpmnlint/rules/conditional-event';
 
-cache['bpmnlint/link-event'] = rule_66;
+cache['bpmnlint/conditional-event'] = rule_66;
 
-import rule_67 from 'bpmnlint/rules/no-duplicate-sequence-flows';
+import rule_67 from 'bpmnlint/rules/event-based-gateway';
 
-cache['bpmnlint/no-duplicate-sequence-flows'] = rule_67;
+cache['bpmnlint/event-based-gateway'] = rule_67;
 
-import rule_68 from 'bpmnlint/rules/sub-process-blank-start-event';
+import rule_68 from 'bpmnlint/rules/event-sub-process-typed-start-event';
 
-cache['bpmnlint/sub-process-blank-start-event'] = rule_68;
+cache['bpmnlint/event-sub-process-typed-start-event'] = rule_68;
 
-import rule_69 from 'bpmnlint/rules/single-blank-start-event';
+import rule_69 from 'bpmnlint/rules/link-event';
 
-cache['bpmnlint/single-blank-start-event'] = rule_69;
+cache['bpmnlint/link-event'] = rule_69;
+
+import rule_70 from 'bpmnlint/rules/no-duplicate-sequence-flows';
+
+cache['bpmnlint/no-duplicate-sequence-flows'] = rule_70;
+
+import rule_71 from 'bpmnlint/rules/sub-process-blank-start-event';
+
+cache['bpmnlint/sub-process-blank-start-event'] = rule_71;
+
+import rule_72 from 'bpmnlint/rules/single-blank-start-event';
+
+cache['bpmnlint/single-blank-start-event'] = rule_72;

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@bpmn-io/diagram-js-ui": "^0.2.4",
         "bpmn-moddle": "^10.0.0",
         "bpmnlint": "^11.12.1",
-        "bpmnlint-plugin-camunda-compat": "^2.55.0",
+        "bpmnlint-plugin-camunda-compat": "^2.57.0",
         "bpmnlint-utils": "^1.1.1",
         "camunda-bpmn-moddle": "^7.0.1",
         "clsx": "^2.0.0",
@@ -253,13 +253,13 @@
       }
     },
     "node_modules/@bpmn-io/lezer-feel": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/lezer-feel/-/lezer-feel-2.1.0.tgz",
-      "integrity": "sha512-cvNlgSYlcgFq5hfJpe6R0FD/GbkDox/9Jv8WeLIjCsgmbC9JrrzZcUQ5VrEsbTkznGFtP4vM38k4uGRuKrjffg==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/lezer-feel/-/lezer-feel-2.5.0.tgz",
+      "integrity": "sha512-09JlwNYeD5YYeFrl0dIFfgQKEL+NNiTyUwEtdcPhfftz1mYa7z+ylOPCv/8Z0GqG7X81uyMFvRZDFCRBFTiUPg==",
       "license": "MIT",
       "dependencies": {
         "@lezer/highlight": "^1.2.3",
-        "@lezer/lr": "^1.4.7",
+        "@lezer/lr": "^1.4.10",
         "min-dash": "^5.0.0"
       },
       "engines": {
@@ -2099,12 +2099,13 @@
       }
     },
     "node_modules/bpmnlint-plugin-camunda-compat": {
-      "version": "2.55.0",
-      "resolved": "https://registry.npmjs.org/bpmnlint-plugin-camunda-compat/-/bpmnlint-plugin-camunda-compat-2.55.0.tgz",
-      "integrity": "sha512-idG8/IG2bCB55j6mFP0HFIu5/v+0pC6MRpdFGEAqXy8bQNivIpb5gXISW37kEOEtDijgwQqDhoQ6m+nP0A9QBw==",
+      "version": "2.57.0",
+      "resolved": "https://registry.npmjs.org/bpmnlint-plugin-camunda-compat/-/bpmnlint-plugin-camunda-compat-2.57.0.tgz",
+      "integrity": "sha512-FDgCP2Y9T5WO20DoDNkP9f9klwXqIM+3vEFssnu34iEuzIEMbVysTX+zWsqCntJVJ0tOaXZSMqS/iXpn/1kNGA==",
       "license": "MIT",
       "dependencies": {
         "@bpmn-io/feel-analyzer": "^0.3.0",
+        "@bpmn-io/lezer-feel": "^2.5.0",
         "@bpmn-io/moddle-utils": "^0.3.0",
         "@bpmn-io/semver-compat": "^0.1.0",
         "@camunda/feel-builtins": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@bpmn-io/diagram-js-ui": "^0.2.4",
     "bpmn-moddle": "^10.0.0",
     "bpmnlint": "^11.12.1",
-    "bpmnlint-plugin-camunda-compat": "^2.55.0",
+    "bpmnlint-plugin-camunda-compat": "^2.57.0",
     "bpmnlint-utils": "^1.1.1",
     "camunda-bpmn-moddle": "^7.0.1",
     "clsx": "^2.0.0",

--- a/test/spec/utils/properties-panel.spec.js
+++ b/test/spec/utils/properties-panel.spec.js
@@ -3010,6 +3010,196 @@ describe('utils/properties-panel', function() {
 
       });
 
+
+      describe('agent tool contracts', function() {
+
+        function createAgenticSubProcess(flowElements) {
+          const adHocSubProcess = createElement('bpmn:AdHocSubProcess', {
+            id: 'AdHocSubProcess_1',
+            flowElements,
+            extensionElements: createElement('bpmn:ExtensionElements', {
+              values: [
+                createElement('zeebe:Properties', {
+                  properties: [
+                    createElement('zeebe:Property', {
+                      name: 'io.camunda.agenticai.toolContainer',
+                      value: 'true'
+                    })
+                  ]
+                })
+              ]
+            })
+          });
+
+          createElement('bpmn:Process', {
+            isExecutable: true,
+            flowElements: [ adHocSubProcess ]
+          });
+
+          return adHocSubProcess;
+        }
+
+
+        it('agent-fromai-contract - fromAi() in input source', async function() {
+
+          // given
+          const node = createAgenticSubProcess([
+            createElement('bpmn:ServiceTask', {
+              id: 'ServiceTask_1',
+              extensionElements: createElement('bpmn:ExtensionElements', {
+                values: [
+                  createElement('zeebe:IoMapping', {
+                    inputParameters: [
+                      createElement('zeebe:Input', { source: '=fromAi("foo")', target: 'foo' })
+                    ]
+                  })
+                ]
+              })
+            })
+          ]);
+
+          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/agent-fromai-contract');
+
+          const report = await getLintError(node, rule, { version: '8.8' });
+
+          // when
+          const entryIds = getEntryIds(report);
+
+          // then
+          expect(entryIds).to.eql([ 'ServiceTask_1-input-0-source' ]);
+        });
+
+
+        it('agent-fromai-contract - fromAi() in output source', async function() {
+
+          // given
+          const node = createAgenticSubProcess([
+            createElement('bpmn:ServiceTask', {
+              id: 'ServiceTask_1',
+              extensionElements: createElement('bpmn:ExtensionElements', {
+                values: [
+                  createElement('zeebe:IoMapping', {
+                    outputParameters: [
+                      createElement('zeebe:Output', { source: '=fromAi(toolCall.foo)', target: 'foo' })
+                    ]
+                  })
+                ]
+              })
+            })
+          ]);
+
+          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/agent-fromai-contract');
+
+          const report = await getLintError(node, rule, { version: '8.8' });
+
+          // when
+          const entryIds = getEntryIds(report);
+
+          // then
+          expect(entryIds).to.eql([ 'ServiceTask_1-output-0-source' ]);
+        });
+
+
+        it('agent-fromai-contract - duplicate fromAi() key', async function() {
+
+          // given
+          const node = createAgenticSubProcess([
+            createElement('bpmn:ServiceTask', {
+              id: 'ServiceTask_1',
+              extensionElements: createElement('bpmn:ExtensionElements', {
+                values: [
+                  createElement('zeebe:IoMapping', {
+                    inputParameters: [
+                      createElement('zeebe:Input', { source: '=fromAi(toolCall.foo)', target: 'a' }),
+                      createElement('zeebe:Input', { source: '=fromAi(toolCall.foo)', target: 'b' })
+                    ]
+                  })
+                ]
+              })
+            })
+          ]);
+
+          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/agent-fromai-contract');
+
+          const report = await getLintError(node, rule, { version: '8.8' });
+
+          // when
+          const entryIds = getEntryIds(report);
+
+          // then
+          expect(entryIds).to.eql([ 'inputs' ]);
+        });
+
+
+        it('agent-fromai-contract - fromAi() in sequence flow condition', async function() {
+
+          // given
+          const node = createAgenticSubProcess([
+            createElement('bpmn:SequenceFlow', {
+              id: 'SequenceFlow_1',
+              conditionExpression: createElement('bpmn:FormalExpression', {
+                body: '=fromAi(toolCall.foo)'
+              })
+            })
+          ]);
+
+          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/agent-fromai-contract');
+
+          const report = await getLintError(node, rule, { version: '8.8' });
+
+          // when
+          const entryIds = getEntryIds(report);
+
+          // then
+          expect(entryIds).to.eql([ 'conditionExpression' ]);
+
+          expectErrorMessage(
+            entryIds[ 0 ],
+            'fromAi() defines a tool input and cannot be used in a sequence flow condition. Define it in an input mapping on the tool\'s entry element.',
+            report
+          );
+        });
+
+
+        it('agent-tool-documentation - missing documentation', async function() {
+
+          // given
+          const node = createAgenticSubProcess([
+            createElement('bpmn:ServiceTask', { id: 'ServiceTask_1' })
+          ]);
+
+          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/agent-tool-documentation');
+
+          const report = await getLintError(node, rule, { version: '8.8' });
+
+          // when
+          const entryIds = getEntryIds(report);
+
+          // then
+          expect(entryIds).to.eql([ 'documentation' ]);
+        });
+
+
+        it('agent-tool-output-key - missing result', async function() {
+
+          // given
+          const node = createAgenticSubProcess([
+            createElement('bpmn:ServiceTask', { id: 'ServiceTask_1' })
+          ]);
+
+          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/agent-tool-output-key');
+
+          const report = await getLintError(node, rule, { version: '8.8' });
+
+          // when
+          const entryIds = getEntryIds(report);
+
+          // then
+          expect(entryIds).to.eql([ 'outputs' ]);
+        });
+
+      });
+
     });
 
 


### PR DESCRIPTION

<img width="1063" height="875" alt="image" src="https://github.com/user-attachments/assets/f25e6a70-fff2-414f-8c2f-6e12dcc91a58" />

<img width="1063" height="875" alt="image" src="https://github.com/user-attachments/assets/cad59854-1372-48f1-bf71-955d7897cf27" />

<img width="1063" height="875" alt="image" src="https://github.com/user-attachments/assets/17638def-fbb3-413d-91e4-beafa5e6a09a" />

## What's inside

Bumps `bpmnlint-plugin-camunda-compat` to `2.56.0` (regenerating `compiled-config.js`) and adds tests for the three newly integrated agentic-AI rules:

- `agent-fromai-contract` (error)
- `agent-tool-documentation` (warn)
- `agent-tool-output-key` (warn)

## Tests

Six tests added to `test/spec/utils/properties-panel.spec.js` verifying the properties-panel `entryIds` `@camunda/linting` surfaces for each distinct entry shape:

| Rule | Scenario | entryId |
|------|----------|---------|
| `agent-fromai-contract` | `fromAi()` in input source | `{taskId}-input-{n}-source` |
| `agent-fromai-contract` | `fromAi()` in output source | `{taskId}-output-{n}-source` |
| `agent-fromai-contract` | duplicate `fromAi()` key | `inputs` |
| `agent-fromai-contract` | `fromAi()` in sequence flow condition | `conditionExpression` (+ message pass-through) |
| `agent-tool-documentation` | missing documentation | `documentation` |
| `agent-tool-output-key` | missing result | `outputs` |

## Notes for reviewers

Unlike the prior two rule integrations (`no-job-priority-definition`, version-tag-as-expression), this only touches `properties-panel.spec.js` and **not** `error-messages.spec.js`. That is deliberate: these rules carry their own fully-formed, user-facing messages and their `AGENT_*` error types aren't rewritten in `error-messages.js`, so the generic pass-through test already covers messaging. The `conditionExpression` test additionally guards the non-`PROPERTY_REQUIRED` message pass-through branch fixed in 32e48bb.

🤖 Generated with [Claude Code](https://claude.com/claude-code)