### PR TITLE
fix(properties-panel): keep FEEL unsupported-function message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to [@camunda/linting](https://github.com/camunda/linting) ar
 
 ___Note:__ Yet to be released changes appear here._
 
+* `FIX`: preserve FEEL unsupported function message in properties panel ([#177](https://github.com/camunda/linting/pull/177))
+
 ## 3.54.0
 
 * `FEAT`: translate linting generated paths to entry ids ([#172](https://github.com/camunda/linting/pull/172))

--- a/lib/utils/properties-panel.js
+++ b/lib/utils/properties-panel.js
@@ -552,6 +552,13 @@ export function getErrorMessage(id, report) {
     return 'Unparsable FEEL expression.';
   }
 
+  // a FEEL function that isn't available in the target version is a value-level
+  // problem; keep the rule's message (e.g. "FEEL function <from json> requires
+  // Camunda >=8.9") instead of falling through to a generic id-based message.
+  if (type === ERROR_TYPES.FEEL_EXPRESSION_UNSUPPORTED_FUNCTION) {
+    return message;
+  }
+
   if (type === ERROR_TYPES.EXPRESSION_NOT_ALLOWED) {
     return 'Cannot be an expression.';
   }

--- a/test/spec/utils/properties-panel.spec.js
+++ b/test/spec/utils/properties-panel.spec.js
@@ -770,6 +770,34 @@ describe('utils/properties-panel', function() {
           expectErrorMessage(entryIds[ 0 ], 'Type must be defined.', report);
         });
 
+
+        it('Type (unsupported FEEL function)', async function() {
+
+          // given
+          const node = createElement('bpmn:ServiceTask', {
+            extensionElements: createElement('bpmn:ExtensionElements', {
+              values: [
+                createElement('zeebe:TaskDefinition', {
+                  type: '=from json(100)'
+                })
+              ]
+            })
+          });
+
+          const { default: rule } = await import('bpmnlint-plugin-camunda-compat/rules/camunda-cloud/feel-compatibility');
+
+          const report = await getLintError(node, rule, { version: '8.5' });
+
+          // when
+          const entryIds = getEntryIds(report);
+
+          // then
+          expect(entryIds).to.eql([ 'taskDefinitionType' ]);
+
+          expectErrorMessage(entryIds[ 0 ], report.message, report);
+          expect(report.message).to.match(/^FEEL function <.*> requires Camunda/);
+        });
+
       });
 
 


### PR DESCRIPTION
### Proposed Changes

An unavailable FEEL builtin (e.g. `from json`) used as a task definition type produced a value-level report that fell through to the generic id-based message ("Type must be defined."), contradicting the problems panel which correctly showed "FEEL function <from json> requires Camunda >=8.9".

This PR short-circuits `FEEL_EXPRESSION_UNSUPPORTED_FUNCTION` in `getErrorMessage` so the panel keeps the rule's message, matching the problems panel:

<img width="1332" height="1002" alt="image" src="https://github.com/user-attachments/assets/1304840c-5f1f-4441-8f4c-a86ce89d9b69" />

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] __Brief textual description__ of the changes present
* [x] __Visual demo__ attached
* [ ] __Steps to try out__ present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [ ] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->
